### PR TITLE
Checker improvements

### DIFF
--- a/checker/src/behavior/assignments.rs
+++ b/checker/src/behavior/assignments.rs
@@ -1,3 +1,5 @@
+use source_map::Span;
+
 use crate::{structures::operators, CheckingData, Environment, TypeId};
 
 pub enum ResultOfAssignment {
@@ -5,30 +7,26 @@ pub enum ResultOfAssignment {
 	NewValueAndAReturnValue(TypeId, TypeId),
 }
 
-pub trait AssignmentBehavior<T> {
-	/// Returns two values:
-	/// 1) the new value of the variable and returns
-	/// 2) second value returned from the expression. None = first type
-	/// TODO use [ResultOfAssignment]
-	fn get_new_value<U: crate::FSResolver>(
-		self,
-		assignee_type: TypeId,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<U>,
-		other: impl SynthesizeExpression<T>,
-	) -> ResultOfAssignment;
+pub enum Assignable {
+	Reference(Reference),
+	ObjectDestructuring(Vec<(TypeId, Reference)>),
+	ArrayDestructuring(Vec<Reference>),
+}
 
-	/// Bool whether to evaluate LHS if updating expression. e.g. `x++` or `x -= 2` are true
-	fn based_off_existing(&self) -> bool;
+pub enum Reference {
+	Variable(String),
+	Property { on: TypeId, with: TypeId },
 }
 
 // TODO
-pub trait SynthesizeExpression<T> {
+pub trait SynthesizableExpression {
 	fn synthesize_expression<U: crate::FSResolver>(
-		item: T,
+		&self,
 		environment: &mut Environment,
 		checking_data: &mut CheckingData<U>,
 	) -> TypeId;
+
+	fn get_position(&self) -> Span;
 }
 
 pub(super) struct BinaryAssignment<'a, T> {
@@ -37,123 +35,10 @@ pub(super) struct BinaryAssignment<'a, T> {
 	pub rhs: &'a mut T,
 }
 
-impl<'a, U> AssignmentBehavior<U> for BinaryAssignment<'a, U> {
-	fn get_new_value<T: crate::FSResolver>(
-		self,
-		assignee_type: TypeId,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<T>,
-		other: impl SynthesizeExpression<U>,
-	) -> ResultOfAssignment {
-		todo!()
-		// let value = synthesize_expression(self.rhs, environment, checking_data, chain);
-		// let new_value = if let Some(operator) = self.operator {
-		// 	let operator: operators::BinaryOperator = operator.into();
-		// 	let operator = super::parser_binary_operator_to_others(operator);
-		// 	let evaluate_binary_operator = evaluate_binary_operator(
-		// 		operator,
-		// 		assignee_type,
-		// 		value,
-		// 		environment,
-		// 		checking_data.settings.strict_casts,
-		// 		&mut checking_data.types,
-		// 	);
-
-		// 	if let Ok(value) = evaluate_binary_operator {
-		// 		value
-		// 	} else {
-		// 		todo!("Add error to checking_data")
-		// 	}
-		// } else {
-		// 	value
-		// };
-		// (new_value, None)
-	}
-
-	fn based_off_existing(&self) -> bool {
-		self.operator.is_some()
-	}
-}
-
 pub(crate) struct PostfixUnaryAssignment {
 	pub operator: operators::UnaryOperator,
 }
 
 pub(crate) struct PrefixUnaryAssignment {
 	pub operator: operators::UnaryOperator,
-}
-
-impl<U> AssignmentBehavior<U> for PrefixUnaryAssignment {
-	fn get_new_value<T: crate::FSResolver>(
-		self,
-		assignee_type: TypeId,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<T>,
-		other: impl SynthesizeExpression<U>,
-	) -> ResultOfAssignment {
-		todo!()
-
-		// let new_value = match self.operator {
-		// 	UnaryPrefixAssignmentOperator::Invert => evaluate_unary_operator(
-		// 		operators::UnaryOperator::LogicalNegation,
-		// 		assignee_type,
-		// 		environment,
-		// 		checking_data.settings.strict_casts,
-		// 		&mut checking_data.types,
-		// 	)
-		// 	.unwrap(),
-		// 	UnaryPrefixAssignmentOperator::IncrementOrDecrement(direction) => {
-		// 		// TODO want to down level this += or -= 1; but that function takes an expression not a type.
-		// 		// TODO error handling
-		// 		let rhs =
-		// 			checking_data.types.new_constant_type(Constant::Number(1.try_into().unwrap()));
-		// 		let operator = match direction {
-		// 			parser::operators::IncrementOrDecrement::Increment => {
-		// 				operators::BinaryOperator::Add
-		// 			}
-		// 			parser::operators::IncrementOrDecrement::Decrement => todo!(),
-		// 		};
-		// 		evaluate_binary_operator(
-		// 			operator,
-		// 			assignee_type,
-		// 			rhs,
-		// 			environment,
-		// 			checking_data.settings.strict_casts,
-		// 			&mut checking_data.types,
-		// 		)
-		// 		.unwrap()
-		// 	}
-		// };
-
-		// (new_value, Some(new_value))
-	}
-
-	fn based_off_existing(&self) -> bool {
-		true
-	}
-}
-
-impl<U> AssignmentBehavior<U> for PostfixUnaryAssignment {
-	fn get_new_value<T: crate::FSResolver>(
-		self,
-		assignee_type: TypeId,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<T>,
-		other: impl SynthesizeExpression<U>,
-	) -> ResultOfAssignment {
-		todo!()
-		// let update = AssignmentBehavior::get_new_value(
-		// 	PrefixUnaryAssignment { operator: todo!("self.operator.0,") },
-		// 	assignee_type,
-		// 	environment,
-		// 	checking_data,
-		// 	chain,
-		// );
-
-		// (update.0, Some(assignee_type))
-	}
-
-	fn based_off_existing(&self) -> bool {
-		true
-	}
 }

--- a/checker/src/behavior/functions.rs
+++ b/checker/src/behavior/functions.rs
@@ -1,18 +1,23 @@
+use source_map::Span;
+
 use crate::{
-	structures::parameters::SynthesizedParameters,
-	types::poly_types::GenericFunctionTypeParameters, CheckingData, Environment, FSResolver,
-	TypeId,
+	structures::parameters::SynthesizedParameters, types::poly_types::GenericTypeParameters,
+	CheckingData, Environment, FSResolver, TypeId,
 };
 
 pub trait SynthesizableFunction {
 	fn is_declare(&self) -> bool;
+
+	fn is_async(&self) -> bool;
+
+	fn is_generator(&self) -> bool;
 
 	/// **THIS FUNCTION IS EXPECTED TO PUT THE TYPE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESIZING THEM**
 	fn type_parameters<T: FSResolver>(
 		&self,
 		environment: &mut Environment,
 		checking_data: &mut CheckingData<T>,
-	) -> GenericFunctionTypeParameters;
+	) -> Option<GenericTypeParameters>;
 
 	/// **THIS FUNCTION IS EXPECTED TO PUT THE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESIZING THEM**
 	fn parameters<T: FSResolver>(
@@ -21,15 +26,16 @@ pub trait SynthesizableFunction {
 		checking_data: &mut CheckingData<T>,
 	) -> SynthesizedParameters;
 
+	/// Returned type is extracted from events, thus doesn't expect anything in return
 	fn body<T: FSResolver>(
 		&self,
 		environment: &mut Environment,
 		checking_data: &mut CheckingData<T>,
 	);
 
-	fn return_type<T: FSResolver>(
+	fn return_type_annotation<T: FSResolver>(
 		&self,
 		environment: &mut Environment,
 		checking_data: &mut CheckingData<T>,
-	) -> Option<TypeId>;
+	) -> Option<(TypeId, Span)>;
 }

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -14,12 +14,12 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, binary_serialize_derive::BinarySerializable)]
-pub enum Reference {
+pub enum RootReference {
 	VariableId(VariableId),
 	This,
 }
 
-impl Reference {
+impl RootReference {
 	pub fn get_name(self, environment: &Environment) -> String {
 		match self {
 			Self::VariableId(id) => environment.get_variable_name(&id),
@@ -31,13 +31,18 @@ impl Reference {
 /// Events which happen
 ///
 /// Used for getting values and states
+///
+/// `reflects_dependency` means the result goes into the type argument map. This corresponds to the
+/// type id (of constructor) it goes under
+///
+/// TODO store positions?
 #[derive(Debug, Clone, binary_serialize_derive::BinarySerializable)]
 pub enum Event {
 	/// Reads variable
 	///
 	/// Can be used for DCE reasons, or finding variables in context
 	ReadsReference {
-		reference: Reference,
+		reference: RootReference,
 		reflects_dependency: Option<TypeId>,
 	},
 	/// Also used for DCE
@@ -66,9 +71,7 @@ pub enum Event {
 	CallsType {
 		on: TypeId,
 		with: Box<[SynthesizedArgument]>,
-		/// The result of the call can go into the type argument map. This corresponds to the
-		/// key it goes under
-		return_type_matches: Option<TypeId>,
+		reflects_dependency: Option<TypeId>,
 		timing: CallingTiming,
 		called_with_new: CalledWithNew,
 	},
@@ -139,8 +142,10 @@ pub(crate) fn apply_event(
 			if let Some(id) = reflects_dependency {
 				// TODO checking constraints if inferred
 				let value = match variable {
-					Reference::VariableId(variable) => environment.get_value_of_variable(variable),
-					Reference::This => {
+					RootReference::VariableId(variable) => {
+						environment.get_value_of_variable(variable)
+					}
+					RootReference::This => {
 						this_argument.unwrap_or_else(|| environment.get_value_of_this(types))
 					}
 				};
@@ -196,7 +201,7 @@ pub(crate) fn apply_event(
 				type_arguments.set_id(id, value.into(), types);
 			}
 		}
-		Event::CallsType { on, with, return_type_matches, timing, called_with_new } => {
+		Event::CallsType { on, with, reflects_dependency, timing, called_with_new } => {
 			let on = specialize(on, type_arguments, environment, types);
 
 			let with = with
@@ -224,8 +229,8 @@ pub(crate) fn apply_event(
 					)
 					.expect("Inference and/or checking failed");
 
-					if let Some(return_type_matches) = return_type_matches {
-						type_arguments.set_id(return_type_matches, result.returned_type, types);
+					if let Some(reflects_dependency) = reflects_dependency {
+						type_arguments.set_id(reflects_dependency, result.returned_type, types);
 					}
 				}
 				// TODO different

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -31,9 +31,13 @@ use structures::functions::AutoConstructorId;
 
 use types::TypeStore;
 
-pub use behavior::{functions::SynthesizableFunction, variables::check_variable_initialization};
+pub use behavior::{
+	assignments::{Assignable, Reference, SynthesizableExpression},
+	functions::SynthesizableFunction,
+	variables::check_variable_initialization,
+};
 pub use context::{GeneralEnvironment, Root};
-pub use errors::{Diagnostic, DiagnosticsContainer, ErrorWarningInfo};
+pub use errors::{Diagnostic, DiagnosticKind, DiagnosticsContainer};
 pub use settings::TypeCheckSettings;
 pub use structures::{
 	functions::{FunctionPointer, InternalFunctionId},
@@ -42,8 +46,7 @@ pub use structures::{
 	variables::Variable,
 };
 pub use types::{
-	calling::call_type_handle_errors, operations::*, poly_types::GenericFunctionTypeParameters,
-	subtyping,
+	calling::call_type_handle_errors, operations::*, poly_types::GenericTypeParameters, subtyping,
 };
 
 pub use type_mappings::*;
@@ -165,14 +168,21 @@ impl<'a, T: crate::FSResolver> CheckingData<'a, T> {
 		// 	.unwrap();
 
 		// // module.get_exports()
-		// Ok((todo!(), &mut self.error_warning_info_handler, &mut self.type_mappings))
+		// Ok((todo!(), &mut self.diagnostics_container, &mut self.type_mappings))
 	}
 
+	/// TODO temp, needs better place
 	pub fn raise_decidable_result_error(&mut self, span: Span, value: bool) {
 		self.diagnostics_container.add_error(TypeCheckWarning::DeadBranch {
 			expression_span: span,
 			expression_value: value,
 		})
+	}
+
+	/// TODO temp, needs better place
+	pub fn raise_unimplemented_error(&mut self, item: &'static str, span: Span) {
+		self.diagnostics_container
+			.add_warning(TypeCheckWarning::Unimplemented { thing: item, at: span })
 	}
 }
 

--- a/checker/src/structures/functions.rs
+++ b/checker/src/structures/functions.rs
@@ -8,9 +8,9 @@ use source_map::Span;
 
 use crate::{
 	context::FunctionId,
-	events::{Event, Reference},
+	events::{Event, RootReference},
 	types::{
-		poly_types::{GenericFunctionTypeParameters, ResolveGenerics, TypeArguments},
+		poly_types::{GenericTypeParameters, ResolveGenerics, TypeArguments},
 		TypeId,
 	},
 	CheckingData,
@@ -75,9 +75,9 @@ pub struct SynthesizedFunction {
 	pub(crate) returned: TypeId,
 	pub(crate) events: Vec<Event>,
 	/// TODO explain
-	pub(crate) closed_over_references: HashMap<Reference, TypeId>,
+	pub(crate) closed_over_references: HashMap<RootReference, TypeId>,
 	pub(crate) synthesized_parameters: SynthesizedParameters,
-	pub(crate) type_parameters: GenericFunctionTypeParameters,
+	pub(crate) type_parameters: Option<GenericTypeParameters>,
 }
 
 /// The type of `this` that a function has ....?
@@ -99,14 +99,14 @@ impl ThisBinding {
 #[derive(Clone, Debug, binary_serialize_derive::BinarySerializable)]
 pub struct FunctionType {
 	/// TODO not sure about this field and how it tails with Pi Types
-	pub generic_type_parameters: GenericFunctionTypeParameters,
+	pub type_parameters: Option<GenericTypeParameters>,
 	pub parameters: SynthesizedParameters,
 	pub return_type: TypeId,
 	/// Side effects of the function
 	pub effects: Vec<Event>,
 
 	/// TODO type alias
-	pub closed_over_references: HashMap<Reference, TypeId>,
+	pub closed_over_references: HashMap<RootReference, TypeId>,
 
 	/// Can be called for constant result
 	pub constant_id: Option<String>,
@@ -200,15 +200,15 @@ pub enum FunctionCallingError {
 	MissingArgument {
 		parameter_pos: Span,
 	},
-	ExtraArgument {
-		idx: usize,
-		position: Span,
+	ExtraArguments {
+		count: usize,
+		// TODO position: Span,
 	},
 	NotCallable {
 		calling: TypeId,
 	},
 	ReferenceRestrictionDoesNotMatch {
-		reference: Reference,
+		reference: RootReference,
 		requirement: TypeId,
 		found: TypeId,
 	},

--- a/checker/src/structures/modules.rs
+++ b/checker/src/structures/modules.rs
@@ -28,15 +28,7 @@ pub enum ModuleFromPathError {
 
 impl From<ModuleFromPathError> for Diagnostic {
 	fn from(err: ModuleFromPathError) -> Self {
-		match err {
-			ModuleFromPathError::ParseError(parse_error) => todo!("parse_error.into()"),
-			ModuleFromPathError::PathDoesNotExist(path) => {
-				Diagnostic::Global(format!("Cannot find module '{}'", path.display()))
-			}
-			ModuleFromPathError::NoResolverForExtension(extension) => {
-				Diagnostic::Global(format!("No resolver for extension '.{}'", extension))
-			}
-		}
+		todo!()
 	}
 }
 

--- a/checker/src/structures/operators.rs
+++ b/checker/src/structures/operators.rs
@@ -4,10 +4,13 @@ pub enum BinaryOperator {
 	Add,
 	Multiply,
 	Modulo,
-	/// TODO undecided
 	Exponent,
 	BitwiseOperators(BitwiseOperators),
 	RelationOperator(RelationOperator),
+	/// TODO undecided, how to represent of as composite of others?
+	Subtract,
+	Divide,
+	LogicalOperator(LogicalOperator),
 }
 
 #[derive(Debug, Clone, Copy, binary_serialize_derive::BinarySerializable)]
@@ -36,7 +39,7 @@ pub enum LogicalOperator {
 pub enum UnaryOperator {
 	/// `-x`
 	Negation,
-	/// `1/x`
+	/// TODO non standard `1/x`
 	MultiplicativeInverse,
 	LogicalNegation,
 }

--- a/checker/src/structures/variables.rs
+++ b/checker/src/structures/variables.rs
@@ -21,7 +21,7 @@ impl Variable {
 #[derive(Copy, Clone, Debug, binary_serialize_derive::BinarySerializable)]
 pub enum VariableMutability {
 	Constant,
-	Mutable { reassignment_constraint: TypeId },
+	Mutable { reassignment_constraint: Option<TypeId> },
 }
 
 #[derive(Clone, Debug)]

--- a/checker/src/temp.rs
+++ b/checker/src/temp.rs
@@ -53,7 +53,7 @@ pub struct AssertTypeExplainer;
 // 		data.type_mappings.get_instance_for_expression(&argument.get_expression_id().unwrap());
 // 	let diagnostic = if let Some(instance) = instance {
 // 		let type_id = instance.get_type();
-// 		let r#type = data.environment.get_type_by_id(type_id);
+// 		let ty = data.environment.get_type_by_id(type_id);
 // 		let mut value_as_string =
 // 			TypeDisplay::to_string(&type_id, &data.environment.into_general_environment());
 
@@ -61,7 +61,7 @@ pub struct AssertTypeExplainer;
 // 		if let Some(specializations) = specializations {
 // 			value_as_string.push_str(" specialized with ");
 // 			for specialization in specializations.iter().copied() {
-// 				let r#type = data.environment.get_type_by_id(specialization);
+// 				let ty = data.environment.get_type_by_id(specialization);
 // 				let specializations_as_string = TypeDisplay::to_string(
 // 					&specialization,
 // 					&data.environment.into_general_environment(),
@@ -123,8 +123,8 @@ pub struct AssertTypeExplainer;
 // 			todo!()
 // 		// value_as_string.push_str(" specialized with ");
 // 		// for specialization in specializations.iter().copied() {
-// 		// 	let r#type = data.environment.get_type_by_id(specialization);
-// 		// 	let specializations_as_string = (specialization, r#type)
+// 		// 	let ty = data.environment.get_type_by_id(specialization);
+// 		// 	let specializations_as_string = (specialization, ty)
 // 		// 		.to_string(&data.environment.into_general_environment());
 
 // 		// 	value_as_string.push_str(&specializations_as_string);

--- a/checker/src/types/mod.rs
+++ b/checker/src/types/mod.rs
@@ -20,7 +20,7 @@ pub use terms::Constant;
 
 use crate::{
 	context::{get_env, GeneralEnvironment, InferenceBoundary},
-	events::Reference,
+	events::RootReference,
 	functions::FunctionType,
 	structures::{functions::SynthesizedArgument, operators::*},
 	InternalFunctionId,
@@ -135,7 +135,7 @@ pub enum PolyNature {
 	/// For functions and for loops where something in the scope can mutate (so not constant)
 	/// between runs.
 	ParentScope {
-		reference: Reference,
+		reference: RootReference,
 		based_on: PolyPointer,
 	},
 	RecursiveFunction(FunctionId, PolyPointer),
@@ -195,6 +195,7 @@ pub enum FunctionNature {
 	/// TODO needs improvement
 	Source(FunctionId, Option<GetterSetter>, Option<TypeId>),
 	Constructor(FunctionId),
+	Reference,
 }
 
 #[derive(Copy, Clone, Debug, binary_serialize_derive::BinarySerializable)]

--- a/checker/src/types/operations.rs
+++ b/checker/src/types/operations.rs
@@ -63,6 +63,9 @@ pub fn evaluate_binary_operator(
 			}
 			RelationOperator::GreaterThan => todo!(),
 		},
+		BinaryOperator::Subtract => todo!(),
+		BinaryOperator::Divide => todo!(),
+		BinaryOperator::LogicalOperator(_) => todo!(),
 	};
 	// TODO handle things and convert to bin exprs
 	super::calling::call_type(
@@ -78,17 +81,17 @@ pub fn evaluate_binary_operator(
 		types,
 		crate::events::CalledWithNew::None,
 	)
-	.map(|x| x.returned_type)
+	.map(|op| op.returned_type)
 	.map_err(|err| {
 		for error in err {
 			match error {
 				crate::structures::functions::FunctionCallingError::InvalidArgumentType { parameter_type, argument_type, argument_position, parameter_position, restriction } => {
 					crate::utils::notify!("{} {}", types.debug_type(parameter_type), types.debug_type(argument_type));
 				},
-				crate::structures::functions::FunctionCallingError::MissingArgument { parameter_pos } => todo!(),
-				crate::structures::functions::FunctionCallingError::ExtraArgument { idx, position } => todo!(),
-				crate::structures::functions::FunctionCallingError::NotCallable { calling } => todo!(),
-				crate::structures::functions::FunctionCallingError::ReferenceRestrictionDoesNotMatch { reference, requirement, found } => todo!(),
+				crate::structures::functions::FunctionCallingError::MissingArgument { .. } => unreachable!("binary operator should accept two operands"),
+				crate::structures::functions::FunctionCallingError::ExtraArguments { .. } => unreachable!("binary operator should have two operands"),
+				crate::structures::functions::FunctionCallingError::NotCallable { .. } => unreachable!("operator should be callable"),
+				crate::structures::functions::FunctionCallingError::ReferenceRestrictionDoesNotMatch { .. } => unreachable!("..."),
 			}
 		}
 		()

--- a/checker/src/types/poly_types/generics/generic_type_parameters.rs
+++ b/checker/src/types/poly_types/generics/generic_type_parameters.rs
@@ -27,12 +27,6 @@ impl From<Vec<GenericTypeParameter>> for GenericTypeParameters {
 	}
 }
 
-#[derive(Debug, Clone, binary_serialize_derive::BinarySerializable)]
-pub enum GenericFunctionTypeParameters {
-	TypedParameters(GenericTypeParameters),
-	None,
-}
-
 /// A generic type parameter. Used in verifying generic constructs.
 /// Ids used for parameter subtyping
 /// TODO could redesign later

--- a/checker/src/types/poly_types/specialization.rs
+++ b/checker/src/types/poly_types/specialization.rs
@@ -21,9 +21,9 @@ pub(crate) fn specialize(
 		return value;
 	}
 
-	let r#type = types.get_type_by_id(id);
+	let ty = types.get_type_by_id(id);
 
-	match r#type {
+	match ty {
 		Type::Constant(_) | Type::Object(..) => id,
 		// TODO temp
 		Type::Function(_, _) => id,
@@ -87,13 +87,15 @@ pub(crate) fn specialize(
 						false_res
 					}
 				} else {
+					// TODO result_union
 					let ty =
 						Constructor::ConditionalTernary { on, true_res, false_res, result_union };
+
 					types.register_type(Type::Constructor(ty))
 				}
 			}
 			Constructor::Property { .. } | Constructor::FunctionResult { .. } => {
-				unreachable!("todo this should have covered by event specialization");
+				unreachable!("this should have covered by event specialization");
 
 				// let on = specialize(on, arguments, environment);
 

--- a/checker/src/types/printing.rs
+++ b/checker/src/types/printing.rs
@@ -1,10 +1,12 @@
 use crate::{context::get_env, GeneralEnvironment};
 
-use super::{poly_types::GenericFunctionTypeParameters, PolyNature, Type, TypeId, TypeStore};
+use super::{PolyNature, Type, TypeId, TypeStore};
 
 /// TODO temp, needs recursion safe, reuse buffer
 pub fn print_type(types: &TypeStore, id: TypeId, env: &GeneralEnvironment) -> String {
-	match types.get_type_by_id(id) {
+	let ty = types.get_type_by_id(id);
+	// crate::utils::notify!("Printing {:?}", ty);
+	match ty {
 		Type::AliasTo { to, name, parameters } => name.clone(),
 		Type::And(a, b) => {
 			format!("{} & {}", print_type(types, *a, env), print_type(types, *b, env))
@@ -14,11 +16,12 @@ pub fn print_type(types: &TypeStore, id: TypeId, env: &GeneralEnvironment) -> St
 		}
 		Type::RootPolyType(nature) => match nature {
 			PolyNature::Generic { name, .. } => name.clone(),
-			PolyNature::Parameter { .. } => {
+			PolyNature::ParentScope { .. } | PolyNature::Parameter { .. } => {
 				let ty = get_env!(env.get_poly_base(id, types)).unwrap().get_type();
 				print_type(types, ty, env)
 			}
 			PolyNature::Open(to) => print_type(types, *to, env),
+
 			nature => {
 				todo!()
 				// let modified_base = match env {
@@ -51,9 +54,7 @@ pub fn print_type(types: &TypeStore, id: TypeId, env: &GeneralEnvironment) -> St
 		Type::Constant(cst) => cst.as_type_name(),
 		Type::Function(func, _) => {
 			let mut buf = String::new();
-			if let GenericFunctionTypeParameters::TypedParameters(ref parameters) =
-				func.generic_type_parameters
-			{
+			if let Some(ref parameters) = func.type_parameters {
 				buf.push('<');
 				for param in parameters.0.iter() {
 					buf.push_str(&param.name);

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -1,8 +1,11 @@
 use crate::{
 	context::{get_env, Environment, Logical, PolyBase, SetPropertyError},
 	events::Event,
+	subtyping::{type_is_subtype, SubTypeResult},
 	TypeId,
 };
+
+use source_map::{SourceId, Span};
 
 use super::{Constructor, Type, TypeStore};
 
@@ -43,196 +46,200 @@ pub(crate) fn get_property(
 		FromAObject(TypeId),
 	}
 
-	let value: GetResult =
-		if let Some(constraint) = environment.get_poly_base(on, types) {
-			match constraint {
-				PolyBase::Fixed { to, is_open_poly } => {
-					crate::utils::notify!(
-						"Get property found fixed constraint {}, is_open_poly={:?}",
-						environment.debug_type(on, types),
-						is_open_poly
-					);
+	let value: GetResult = if let Some(constraint) = environment.get_poly_base(on, types) {
+		match constraint {
+			PolyBase::Fixed { to, is_open_poly } => {
+				crate::utils::notify!(
+					"Get property found fixed constraint {}, is_open_poly={:?}",
+					environment.debug_type(on, types),
+					is_open_poly
+				);
 
-					let fact = environment.get_property_unbound(to, under, types)?;
+				let fact = environment.get_property_unbound(to, under, types)?;
 
-					match fact {
-						Logical::Pure(og) => {
-							match types.get_type_by_id(og) {
-								Type::Function(func, _) => {
-									// TODO only want to do sometimes, or even never as it can be pulled using the poly chain
-									let with_this = types.register_type(Type::Function(
-										func.clone(),
-										crate::types::FunctionNature::BehindPoly {
-											// TODO
-											function_id_if_open_poly: None,
-											this_type: Some(on),
-										},
-									));
-									crate::utils::notify!("Temp setting this on poly");
+				match fact {
+					Logical::Pure(og) => {
+						match types.get_type_by_id(og) {
+							Type::Function(func, _) => {
+								// TODO only want to do sometimes, or even never as it can be pulled using the poly chain
+								let with_this = types.register_type(Type::Function(
+									func.clone(),
+									crate::types::FunctionNature::BehindPoly {
+										// TODO
+										function_id_if_open_poly: None,
+										this_type: Some(on),
+									},
+								));
+								crate::utils::notify!("Temp setting this on poly");
 
-									GetResult::AccessIntroducesDependence(with_this)
-								}
-								Type::And(_, _) => todo!(),
-								Type::Or(_, _) => todo!(),
-								Type::RootPolyType(_) => todo!(),
-								Type::Constructor(_) => todo!(),
-								Type::AliasTo { .. } | Type::NamedRooted { .. } => {
-									if is_open_poly {
-										crate::utils::notify!("TODO evaluate getter...");
-									} else {
-										crate::utils::notify!("TODO don't evaluate getter");
-									}
-
-									// TODO don't have to recreate if don't have any events.
-									let constructor_result = types.register_type(
-										Type::Constructor(Constructor::Property { on, under }),
-									);
-
-									GetResult::AccessIntroducesDependence(constructor_result)
-								}
-								Type::Constant(_) => GetResult::FromAObject(og),
-								Type::Object(..) => todo!(),
+								GetResult::AccessIntroducesDependence(with_this)
 							}
+							Type::And(_, _) => todo!(),
+							Type::RootPolyType(_) => todo!(),
+							Type::Constructor(_) => todo!(),
+							Type::Or(_, _) | Type::AliasTo { .. } | Type::NamedRooted { .. } => {
+								if is_open_poly {
+									crate::utils::notify!("TODO evaluate getter...");
+								} else {
+									crate::utils::notify!("TODO don't evaluate getter");
+								}
+
+								// TODO don't have to recreate if don't have any events.
+								let constructor_result =
+									types.register_type(Type::Constructor(Constructor::Property {
+										on,
+										under,
+									}));
+
+								GetResult::AccessIntroducesDependence(constructor_result)
+							}
+							Type::Constant(_) => GetResult::FromAObject(og),
+							Type::Object(..) => todo!(),
 						}
-						Logical::Or(_) => todo!(),
-						Logical::Implies(_, _) => todo!(),
 					}
-				}
-				PolyBase::Dynamic { to, boundary } => {
-					crate::utils::notify!(
-						"Getting property {:?} which has a dynamic constraint {:?}",
-						on,
-						to
-					);
-					// If the property on the dynamic constraint is None
-					if environment.get_property_unbound(to, under, types).is_none() {
-						let on = if to == TypeId::ANY_TYPE {
-							let new_constraint = types.register_type(Type::Object(
-								crate::types::ObjectNature::ModifiableConstraint,
-							));
-							crate::utils::notify!("Here!!!");
-							environment.attempt_to_modify_base(on, boundary, new_constraint);
-							new_constraint
-						} else if matches!(
-							types.get_type_by_id(to),
-							Type::AliasTo { to: TypeId::OBJECT_TYPE, .. }
-						) {
-							to
-						} else {
-							todo!("new and")
-						};
-
-						environment
-							.properties
-							.entry(on)
-							.or_default()
-							.push((under, with.unwrap_or(TypeId::ANY_TYPE)));
-					} else {
-						crate::utils::notify!("Found existing property on dynamic constraint");
-					}
-
-					let constructor_result =
-						types.register_type(Type::Constructor(Constructor::Property { on, under }));
-
-					// environment
-					// 	.context_type
-					// 	.get_inferrable_constraints_mut()
-					// 	.unwrap()
-					// 	.insert(constructor_result);
-
-					GetResult::AccessIntroducesDependence(constructor_result)
+					Logical::Or(_) => todo!(),
+					Logical::Implies(_, _) => todo!(),
 				}
 			}
-		} else if let Some(_) = environment.get_poly_base(under, types) {
-			todo!()
+			PolyBase::Dynamic { to, boundary } => {
+				crate::utils::notify!(
+					"Getting property {:?} which has a dynamic constraint {:?}",
+					on,
+					to
+				);
+				// If the property on the dynamic constraint is None
+				if environment.get_property_unbound(to, under, types).is_none() {
+					let on = if to == TypeId::ANY_TYPE {
+						let new_constraint = types.register_type(Type::Object(
+							crate::types::ObjectNature::ModifiableConstraint,
+						));
+						crate::utils::notify!("Here!!!");
+						environment.attempt_to_modify_base(on, boundary, new_constraint);
+						new_constraint
+					} else if matches!(
+						types.get_type_by_id(to),
+						Type::AliasTo { to: TypeId::OBJECT_TYPE, .. }
+					) {
+						to
+					} else {
+						todo!("new and")
+					};
+
+					environment
+						.properties
+						.entry(on)
+						.or_default()
+						.push((under, with.unwrap_or(TypeId::ANY_TYPE)));
+				} else {
+					crate::utils::notify!("Found existing property on dynamic constraint");
+				}
+
+				let constructor_result =
+					types.register_type(Type::Constructor(Constructor::Property { on, under }));
+
+				// environment
+				// 	.context_type
+				// 	.get_inferrable_constraints_mut()
+				// 	.unwrap()
+				// 	.insert(constructor_result);
+
+				GetResult::AccessIntroducesDependence(constructor_result)
+			}
+		}
+	} else if let Some(_) = environment.get_poly_base(under, types) {
+		todo!()
+	} else {
+		let property = environment.get_property_unbound(on, under, types)?;
+
+		let property = if let Logical::Pure(og) = property {
+			og
 		} else {
-			let property = environment.get_property_unbound(on, under, types)?;
-
-			let property = if let Logical::Pure(og) = property {
-				og
-			} else {
-				unreachable!("TODO multiple properties");
-			};
-
-			let ty = types.get_type_by_id(property);
-			let value = match ty {
-				Type::Function(ty, nature) => {
-					// TODO getter
-					// TODO if arrow function
-					match nature {
-						super::FunctionNature::BehindPoly { .. } => todo!(),
-						super::FunctionNature::Source(id, get_set, this) => {
-							if get_set.is_some() {
-								todo!()
-							}
-							if this.is_some() {
-								panic!()
-							}
-							types.register_type(Type::Function(
-								ty.clone(),
-								super::FunctionNature::Source(id.clone(), None, Some(on)),
-							))
-						}
-						super::FunctionNature::Constructor(_) => todo!(),
-					}
-				}
-				Type::Constant(..) => property,
-				Type::NamedRooted { .. }
-				| Type::And(_, _)
-				| Type::Or(_, _)
-				| Type::Constructor(Constructor::StructureGenerics { .. }) => {
-					unreachable!("property was {:?} {:?}", property, ty)
-				}
-				Type::Constructor(constructor) => {
-					unreachable!("Interesting property was {:?}", constructor);
-				}
-				Type::Object(..) | Type::RootPolyType { .. } => {
-					property
-					// if let super::PolyNature::Open = nature {
-					// } else {
-					// 	crate::utils::notify!("Warning property has ty of nature: {:?}", nature);
-					// 	property
-					// }
-				}
-				Type::AliasTo { to, name, parameters } => {
-					todo!()
-					// if environment.is_getter(property) {
-					// 	// TODO catch unwrap as error:
-					// 	let result = call_type(
-					// 		property,
-					// 		vec![],
-					// 		Some(on),
-					// 		None,
-					// 		environment,
-					// 		checking_data,
-					// 		CalledWithNew::None,
-					// 	)
-					// 	.unwrap()
-					// 	.returned_type;
-
-					// 	return Some(PropertyResult::Getter(result));
-					// } else {
-					// 	// Bind this is this is function
-					// 	let is_function = *to == TypeId::FUNCTION_TYPE
-					// 		|| matches!(environment.get_type_by_id(*to), Type::AliasTo { to, .. } if *to == TypeId::FUNCTION_TYPE);
-
-					// 	if is_function {
-					// 		let alias = environment.new_type(Type::AliasTo {
-					// 			to: property,
-					// 			name: None,
-					// 			parameters: None,
-					// 		});
-					// 		environment.this_bindings.insert(alias, on);
-					// 		alias
-					// 	} else {
-					// 		property
-					// 	}
-					// }
-				}
-			};
-
-			GetResult::FromAObject(value)
+			unreachable!("TODO multiple properties");
 		};
+
+		let ty = types.get_type_by_id(property);
+		let value = match ty {
+			Type::Function(ty, nature) => {
+				// TODO getter
+				// TODO if arrow function
+				match nature {
+					super::FunctionNature::BehindPoly { .. } => todo!(),
+					super::FunctionNature::Source(id, get_set, this) => {
+						if get_set.is_some() {
+							todo!()
+						}
+						if this.is_some() {
+							panic!()
+						}
+						types.register_type(Type::Function(
+							ty.clone(),
+							super::FunctionNature::Source(id.clone(), None, Some(on)),
+						))
+					}
+					super::FunctionNature::Constructor(_) => todo!(),
+					super::FunctionNature::Reference => unreachable!(),
+				}
+			}
+			Type::Constant(..) => property,
+			Type::NamedRooted { .. }
+			| Type::And(_, _)
+			| Type::Or(_, _)
+			| Type::Constructor(Constructor::StructureGenerics { .. }) => {
+				unreachable!(
+					"property was {:?} {:?}, which should be able to be retutned from a function",
+					property, ty
+				)
+			}
+			Type::Constructor(constructor) => {
+				unreachable!("Interesting property was {:?}", constructor);
+			}
+			Type::Object(..) | Type::RootPolyType { .. } => {
+				property
+				// if let super::PolyNature::Open = nature {
+				// } else {
+				// 	crate::utils::notify!("Warning property has ty of nature: {:?}", nature);
+				// 	property
+				// }
+			}
+			Type::AliasTo { to, name, parameters } => {
+				todo!()
+				// if environment.is_getter(property) {
+				// 	// TODO catch unwrap as error:
+				// 	let result = call_type(
+				// 		property,
+				// 		vec![],
+				// 		Some(on),
+				// 		None,
+				// 		environment,
+				// 		checking_data,
+				// 		CalledWithNew::None,
+				// 	)
+				// 	.unwrap()
+				// 	.returned_type;
+
+				// 	return Some(PropertyResult::Getter(result));
+				// } else {
+				// 	// Bind this is this is function
+				// 	let is_function = *to == TypeId::FUNCTION_TYPE
+				// 		|| matches!(environment.get_type_by_id(*to), Type::AliasTo { to, .. } if *to == TypeId::FUNCTION_TYPE);
+
+				// 	if is_function {
+				// 		let alias = environment.new_type(Type::AliasTo {
+				// 			to: property,
+				// 			name: None,
+				// 			parameters: None,
+				// 		});
+				// 		environment.this_bindings.insert(alias, on);
+				// 		alias
+				// 	} else {
+				// 		property
+				// 	}
+				// }
+			}
+		};
+
+		GetResult::FromAObject(value)
+	};
 
 	let reflects_dependency = match value {
 		GetResult::AccessIntroducesDependence(s) => Some(s),
@@ -268,45 +275,56 @@ pub(crate) fn set_property(
 		return Err(SetPropertyError::NotWriteable);
 	}
 
-	let property_constraint = {
-		let constraint = environment
-			.parents_iter()
-			.find_map(|env| get_env!(env.object_constraints.get(&on)).cloned());
+	{
+		let property_constraint = {
+			let constraint = environment
+				.parents_iter()
+				.find_map(|env| get_env!(env.object_constraints.get(&on)).cloned());
 
-		match constraint {
-			Some(constraint) => {
-				let result = environment.get_property_unbound(constraint, under, types);
-				if result.is_none() {
-					// TODO does not exist
-					return Err(SetPropertyError::DoesNotMeetConstraint(todo!()));
+			match constraint {
+				Some(constraint) => {
+					let result = environment.get_property_unbound(constraint, under, types);
+					if result.is_none() {
+						// TODO does not exist
+						return Err(SetPropertyError::DoesNotMeetConstraint(
+							new,
+							todo!("no property"),
+						));
+					}
+					result
 				}
-				result
+				None => None,
 			}
-			None => None,
+		};
+
+		if let Some(constraint) = property_constraint {
+			let mut basic_subtyping = crate::types::subtyping::BasicEquality {
+				add_property_restrictions: true,
+				position: Span { start: 0, end: 0, source_id: SourceId::NULL },
+			};
+			let base_type = constraint.to_type();
+			if let SubTypeResult::IsNotSubType(sub_type_error) = type_is_subtype(
+				base_type,
+				new,
+				None,
+				// TODO undecided here
+				// TODO position here
+				&mut basic_subtyping,
+				environment,
+				types,
+			) {
+				// TODO don't short circuit
+				return Err(SetPropertyError::DoesNotMeetConstraint(base_type, sub_type_error));
+			}
 		}
-	};
-
-	if let Some(constraint) = property_constraint {
-		todo!();
-		// TODO maybe perform update anyway...?
-
-		// let mut basic_subtyping = crate::types::BasicEquality {
-		// 	add_property_restrictions: true,
-		// 	position: parser::Span { start: 0, end: 0, source_id: parser::SourceId::NULL },
-		// };
-		// if let SubTypeResult::IsNotSubType(sub_type_error) = type_is_subtype(
-		// 	constraint,
-		// 	new,
-		// 	None,
-		// 	// TODO undecided here
-		// 	// TODO position here
-		// 	&mut basic_subtyping,
-		// 	environment,
-		// 	&checking_data.types,
-		// ) {
-		// 	return Err(SetPropertyError::DoesNotMeetConstraint(sub_type_error));
-		// }
 	}
+
+	crate::utils::notify!(
+		"setting {:?} {:?} {:?}",
+		types.debug_type(on),
+		types.debug_type(under),
+		types.debug_type(new)
+	);
 
 	let current_property = environment.get_property_unbound(on, under, types);
 
@@ -321,13 +339,24 @@ pub(crate) fn set_property(
 						new,
 						under,
 						reflects_dependency: None,
-						initialization: true,
+						initialization: false,
 					});
 				}
 				Type::And(_, _) | Type::Or(_, _) => todo!(),
 				Type::RootPolyType(_) => todo!(),
 				Type::Constructor(_) => todo!(),
-				Type::NamedRooted { name, parameters } => todo!(),
+				Type::NamedRooted { name, parameters } => {
+					crate::utils::notify!("TODO temp, this might break things");
+					environment.properties.entry(on).or_default().push((under, new));
+					environment.context_type.events.push(Event::Setter {
+						on,
+						new,
+						under,
+						// TODO
+						reflects_dependency: None,
+						initialization: false,
+					});
+				}
 				Type::AliasTo { to, name, parameters } => {
 					todo!();
 					// if environment.is_setter(og) {

--- a/checker/src/utils.rs
+++ b/checker/src/utils.rs
@@ -71,21 +71,21 @@ pub fn shorten(s: &str) -> &str {
 macro_rules! notify {
     () => {
 		if crate::utils::is_debug_mode() {
-			#[cfg(debug_assertions)]
+			#[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
 			eprintln!("[{}:{}]", crate::utils::shorten(file!()), line!())
 		}
     };
 
     ($content:expr) => {
 		if crate::utils::is_debug_mode() {
-			#[cfg(debug_assertions)]
+			#[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
 			eprintln!("[{}:{}] {}", crate::utils::shorten(file!()), line!(), $content)
 		}
     };
 
     ($content:literal, $($es:expr),+) => {
 		if crate::utils::is_debug_mode() {
-			#[cfg(debug_assertions)]
+			#[cfg(all(debug_assertions, not(target_arch = "wasm32")))]
 			eprintln!("[{}:{}] {}", crate::utils::shorten(file!()), line!(), format_args!($content, $($es),+))
 		}
     };


### PR DESCRIPTION
Lots of things
- Basic function equality checking
- Check that body matches up with return type annotation
- Basic closed over variable in a function support
- Object constraints to catch assignments on properties
- Diagnostic is now flat structure with severity defined through `DiagnosticKind`