### PR TITLE
Updates to parser

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -34,7 +34,7 @@ iterator-endiate = "0.1.0"
 enum_variant_type = "0.3.1"
 enum-variants-strings = "0.2"
 
-source-map = { version = "0.12", features = [
+source-map = { version = "0.13", features = [
   "span-serialize",
   "self-rust-tokenize",
 ] }

--- a/parser/README.md
+++ b/parser/README.md
@@ -33,15 +33,27 @@ This is more of an exercise project in getting better at writing Rust and doesn'
 - Increase code size or decrease readability for speed improvements
 - Allow adding new syntax at runtime, that would require modifying the lexer at runtime adding new tokens
 
+### Testing
+
+> If in main root rather than this folder, add `-p ezno-parser` after `cargo run` to the following commands.
+
+For testing whether the parser can lex a file
+
+```shell
+cargo run --example lex path/to/file.js
+```
+
+and parse
+
+```shell
+cargo run --example parse path/to/file.js
+```
+
 ## Features
 
 ### Positions
 
 All syntax has reference to where it was in the source using a [Span](https://docs.rs/ezno-parser/0.0.2/ezno_parser/struct.Span.html). This uses the [source-map](https://github.com/kaleidawave/source-map) crate, so it can generate source maps.
-
-### Identifiers
-
-Most expressions, functions, blocks and some other AST has a unique identifier. This can be used to associate information with the node. For example Ezno's checker associates type information with variable reference AST for later visitors or for hover information in the LSP.
 
 ### "Cursors"
 

--- a/parser/examples/chain.rs
+++ b/parser/examples/chain.rs
@@ -11,7 +11,7 @@ struct ShowChain;
 
 impl Visitor<Expression, ()> for ShowChain {
 	fn visit(&mut self, item: &Expression, _data: &mut (), chain: &Chain) {
-		if matches!(item, Expression::VariableReference(name, _, _) if name == "chain") {
+		if matches!(item, Expression::VariableReference(name, _) if name == "chain") {
 			eprintln!("{:#?}", chain);
 		}
 	}

--- a/parser/examples/jsx.rs
+++ b/parser/examples/jsx.rs
@@ -1,4 +1,4 @@
-use ezno_parser::{ASTNode, JSXRoot, SourceId, ToStringSettings};
+use ezno_parser::{ASTNode, JSXRoot, SourceId, ToStringOptions};
 
 fn main() {
 	let source = "<MySiteLayout> <p>My page content, wrapped in a layout!</p> </MySiteLayout>";
@@ -11,5 +11,5 @@ fn main() {
 	)
 	.unwrap();
 
-	println!("{}", result.to_string(&ToStringSettings::default()));
+	println!("{}", result.to_string(&ToStringOptions::default()));
 }

--- a/parser/examples/lex.rs
+++ b/parser/examples/lex.rs
@@ -6,7 +6,7 @@ use tokenizer_lib::{ParallelTokenQueue, TokenReader};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let path = std::env::args().skip(1).next().ok_or("expected argument")?;
 	let content = std::fs::read_to_string(path)?;
-	lex_and_print_tokens(content, Some(vec![(31, EmptyCursorId::new(0))]));
+	lex_and_print_tokens(content, None);
 	Ok(())
 }
 

--- a/parser/examples/parse.rs
+++ b/parser/examples/parse.rs
@@ -1,15 +1,20 @@
-use ezno_parser::{ASTNode, FromFileError, Module, ParseSettings, ToStringSettings};
+use std::time::Instant;
+
+use ezno_parser::{ASTNode, FromFileError, Module, ParseOptions, ToStringOptions};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let path = std::env::args().skip(1).next().ok_or("expected argument")?;
+	let now = Instant::now();
 	let mut fs = source_map::MapFileStore::default();
-	match Module::from_file(&path, ParseSettings::default(), Vec::default(), &mut fs) {
+	match Module::from_file(&path, ParseOptions::default(), Vec::default(), &mut fs) {
 		Ok(module) => {
-			println!("{module:#?}");
-
-			let output = module.to_string(&ToStringSettings::default());
-			println!("In string form:");
-			println!("{output}");
+			println!("{:?}", now.elapsed());
+			if std::env::args().any(|item| item == "--ast") {
+				println!("{module:#?}");
+			} else {
+				let output = module.to_string(&ToStringOptions::default());
+				println!("{output}");
+			}
 			Ok(())
 		}
 		Err(FromFileError::FileError(_file_err)) => {
@@ -18,7 +23,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 		}
 		Err(FromFileError::ParseError(parse_err)) => {
 			println!("parse error {}", parse_err.reason);
-			println!("error on {:?}", parse_err.position.into_line_column_span(&fs));
+			println!(
+				"error on {:?}",
+				parse_err.position.into_line_column_span::<source_map::encodings::Utf8>(&fs)
+			);
 			Err(Box::<dyn std::error::Error>::from("error"))
 		}
 	}

--- a/parser/examples/type_references.rs
+++ b/parser/examples/type_references.rs
@@ -1,7 +1,7 @@
-use ezno_parser::{ASTNode, Expression, SourceId, TypeReference};
+use ezno_parser::{ASTNode, Expression, SourceId, TypeAnnotation};
 
 fn main() {
-	let reference = TypeReference::from_string(
+	let reference = TypeAnnotation::from_string(
 		"Pair<Nested<Object<2>>, Array<number>>".into(),
 		Default::default(),
 		SourceId::NULL,

--- a/parser/generator/generator.rs
+++ b/parser/generator/generator.rs
@@ -42,7 +42,7 @@ fn token_stream_to_ast_node<T: parser::ASTNode + self_rust_tokenize::SelfRustTok
 
 	let parse_result = T::from_string(
 		string,
-		parser::ParseSettings::default(),
+		parser::ParseOptions::default(),
 		parser::SourceId::NULL,
 		None,
 		cursors,

--- a/parser/src/comments.rs
+++ b/parser/src/comments.rs
@@ -1,7 +1,7 @@
 //! Contains wrappers for AST with comments
 
 use super::{ASTNode, ParseError, Span, TSXToken, TokenReader};
-use crate::ParseSettings;
+use crate::ParseOptions;
 use std::{borrow::Cow, mem};
 use tokenizer_lib::Token;
 
@@ -102,7 +102,7 @@ impl<T: ASTNode> ASTNode for WithComment<T> {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> Result<WithComment<T>, ParseError> {
 		if matches!(reader.peek(), Some(Token(TSXToken::MultiLineComment(..), _))) {
 			let comment = if let TSXToken::MultiLineComment(comment) = reader.next().unwrap().0 {
@@ -139,7 +139,7 @@ impl<T: ASTNode> ASTNode for WithComment<T> {
 	fn to_string_from_buffer<U: source_map::ToString>(
 		&self,
 		buf: &mut U,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		match self {

--- a/parser/src/declarations/classes/class_member.rs
+++ b/parser/src/declarations/classes/class_member.rs
@@ -5,9 +5,9 @@ use source_map::Span;
 use tokenizer_lib::{Token, TokenReader};
 
 use crate::{
-	functions::FunctionBased, ASTNode, Block, ChainVariable, Expression, FunctionBase,
-	GetSetGeneratorOrNone, Keyword, ParseError, ParseErrors, ParseResult, ParseSettings,
-	PropertyKey, TSXKeyword, TSXToken, TypeReference, VariableId, VisitSettings, WithComment,
+	functions::FunctionBased, ASTNode, Block, Expression, FunctionBase, GetSetGeneratorOrNone,
+	Keyword, ParseError, ParseErrors, ParseOptions, ParseResult, PropertyKey, TSXKeyword, TSXToken,
+	TypeAnnotation, VisitSettings, WithComment,
 };
 
 /// The variable id's of these is handled by their [PropertyKey]
@@ -29,7 +29,7 @@ pub type ClassFunction = FunctionBase<ClassFunctionBase>;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClassProperty {
 	pub key: WithComment<PropertyKey>,
-	pub type_reference: Option<TypeReference>,
+	pub type_annotation: Option<TypeAnnotation>,
 	pub value: Option<Box<Expression>>,
 }
 
@@ -46,7 +46,7 @@ impl ASTNode for ClassMember {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		if let Some(Token(TSXToken::Keyword(TSXKeyword::Constructor), _)) = reader.peek() {
 			let constructor = ClassConstructor::from_reader(reader, state, settings)?;
@@ -86,11 +86,11 @@ impl ASTNode for ClassMember {
 						position,
 					));
 				}
-				let member_type: Option<TypeReference> = match token {
+				let member_type: Option<TypeAnnotation> = match token {
 					TSXToken::Colon => {
 						reader.next();
-						let type_reference = TypeReference::from_reader(reader, state, settings)?;
-						Some(type_reference)
+						let type_annotation = TypeAnnotation::from_reader(reader, state, settings)?;
+						Some(type_annotation)
 					}
 					_ => None,
 				};
@@ -106,7 +106,7 @@ impl ASTNode for ClassMember {
 					is_static,
 					ClassProperty {
 						key,
-						type_reference: member_type,
+						type_annotation: member_type,
 						value: member_expression.map(Box::new),
 					},
 				))
@@ -117,18 +117,18 @@ impl ASTNode for ClassMember {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		match self {
-			Self::Property(is_static, ClassProperty { key, type_reference, value }) => {
+			Self::Property(is_static, ClassProperty { key, type_annotation, value }) => {
 				if is_static.is_some() {
 					buf.push_str("static ");
 				}
 				key.to_string_from_buffer(buf, settings, depth);
-				if let (true, Some(type_reference)) = (settings.include_types, type_reference) {
+				if let (true, Some(type_annotation)) = (settings.include_types, type_annotation) {
 					buf.push_str(": ");
-					type_reference.to_string_from_buffer(buf, settings, depth);
+					type_annotation.to_string_from_buffer(buf, settings, depth);
 				}
 				if let Some(value) = value {
 					buf.push_str(if settings.pretty { " = " } else { "=" });
@@ -166,8 +166,6 @@ impl ClassMember {
 		data: &mut TData,
 		settings: &VisitSettings,
 		chain: &mut temporary_annex::Annex<crate::visiting::Chain>,
-		// TODO VariableId and TypeId
-		class_variable_id: VariableId,
 	) {
 		match self {
 			ClassMember::Constructor(..) => {
@@ -212,8 +210,6 @@ impl ClassMember {
 		data: &mut TData,
 		settings: &VisitSettings,
 		chain: &mut temporary_annex::Annex<crate::visiting::Chain>,
-		// TODO remove
-		class_variable_id: VariableId,
 	) {
 		match self {
 			ClassMember::Constructor(..) => {
@@ -264,7 +260,7 @@ impl ClassFunction {
 	fn from_reader_with_config(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 		is_async: Option<Keyword<tsx_keywords::Async>>,
 		get_set_generator_or_none: GetSetGeneratorOrNone,
 		key: WithComment<PropertyKey>,
@@ -284,14 +280,14 @@ impl FunctionBased for ClassFunctionBase {
 	type Header = (Option<Keyword<tsx_keywords::Async>>, GetSetGeneratorOrNone);
 	type Name = WithComment<PropertyKey>;
 
-	fn get_chain_variable(this: &FunctionBase<Self>) -> ChainVariable {
-		ChainVariable::UnderClassMethod(this.body.1)
-	}
+	// fn get_chain_variable(this: &FunctionBase<Self>) -> ChainVariable {
+	// 	ChainVariable::UnderClassMethod(this.body.1)
+	// }
 
 	fn header_and_name_from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<(Self::Header, Self::Name)> {
 		let async_keyword = reader
 			.conditional_next(|tok| matches!(tok, TSXToken::Keyword(TSXKeyword::Async)))
@@ -305,7 +301,7 @@ impl FunctionBased for ClassFunctionBase {
 		buf: &mut T,
 		header: &Self::Header,
 		name: &Self::Name,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		if let Some(_header) = &header.0 {
@@ -325,14 +321,14 @@ impl FunctionBased for ClassConstructorBase {
 	type Header = Keyword<tsx_keywords::Constructor>;
 	type Name = ();
 
-	fn get_chain_variable(this: &FunctionBase<Self>) -> ChainVariable {
-		ChainVariable::UnderClassConstructor(this.body.1)
-	}
+	// fn get_chain_variable(this: &FunctionBase<Self>) -> ChainVariable {
+	// 	ChainVariable::UnderClassConstructor(this.body.1)
+	// }
 
 	fn header_and_name_from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		_state: &mut crate::ParsingState,
-		_settings: &ParseSettings,
+		_settings: &ParseOptions,
 	) -> ParseResult<(Self::Header, Self::Name)> {
 		let span = reader.expect_next(TSXToken::Keyword(TSXKeyword::Constructor))?;
 		Ok((Keyword::new(span), ()))
@@ -342,7 +338,7 @@ impl FunctionBased for ClassConstructorBase {
 		buf: &mut T,
 		_header: &Self::Header,
 		_name: &Self::Name,
-		_settings: &crate::ToStringSettings,
+		_settings: &crate::ToStringOptions,
 		_depth: u8,
 	) {
 		buf.push_str("constructor")

--- a/parser/src/declarations/export.rs
+++ b/parser/src/declarations/export.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::{
-	errors::parse_lexing_error, ASTNode, Expression, Keyword, ParseResult, ParseSettings, Span,
+	errors::parse_lexing_error, ASTNode, Expression, Keyword, ParseOptions, ParseResult, Span,
 	StatementPosition, TSXKeyword, TSXToken, Token,
 };
 
@@ -45,7 +45,7 @@ impl ASTNode for ExportDeclaration {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		let start = reader.expect_next(TSXToken::Keyword(TSXKeyword::Export))?;
 		let is_default =
@@ -111,7 +111,7 @@ impl ASTNode for ExportDeclaration {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		match self {

--- a/parser/src/declarations/mod.rs
+++ b/parser/src/declarations/mod.rs
@@ -63,7 +63,8 @@ impl Declaration {
 						| TSXKeyword::Class | TSXKeyword::Enum
 						| TSXKeyword::Type | TSXKeyword::Declare
 						| TSXKeyword::Import | TSXKeyword::Export
-						| TSXKeyword::Async | TSXKeyword::Generator
+						| TSXKeyword::Interface | TSXKeyword::Async
+						| TSXKeyword::Generator
 				) | TSXToken::At,
 				_
 			))
@@ -91,7 +92,7 @@ impl crate::ASTNode for Declaration {
 	fn from_reader(
 		reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, source_map::Span>,
 		state: &mut crate::ParsingState,
-		settings: &crate::ParseSettings,
+		settings: &crate::ParseOptions,
 	) -> crate::ParseResult<Self> {
 		// TODO assert decorators are used. If they exist but item is not `Decorated`
 		// then need to throw a parse error
@@ -208,7 +209,7 @@ impl crate::ASTNode for Declaration {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		match self {

--- a/parser/src/errors.rs
+++ b/parser/src/errors.rs
@@ -14,7 +14,6 @@ pub enum ParseErrors<'a> {
 	TypeArgumentsNotValidOnReference,
 	UnmatchedBrackets,
 	FunctionParameterOptionalAndDefaultValue,
-	NonOptionalFunctionParameterAfterOptionalFunctionParameter,
 	ExpectedIdent { found: TSXToken, at_location: &'a str },
 	ParameterCannotHaveDefaultValueHere,
 	InvalidLHSAssignment,
@@ -122,9 +121,6 @@ impl<'a> Display for ParseErrors<'a> {
 			ParseErrors::UnmatchedBrackets => f.write_str("Unmatched brackets"),
 			ParseErrors::FunctionParameterOptionalAndDefaultValue => {
 				f.write_str("Function parameter cannot be optional *and* have default expression")
-			}
-			ParseErrors::NonOptionalFunctionParameterAfterOptionalFunctionParameter => {
-				f.write_str("Function parameter cannot be non optional after optional")
 			}
 			ParseErrors::ExpectedIdent { found, at_location } => {
 				write!(f, "Expected identifier at {at_location}, found {found:?}")

--- a/parser/src/extensions/decorators.rs
+++ b/parser/src/extensions/decorators.rs
@@ -6,7 +6,7 @@ use tokenizer_lib::{Token, TokenReader};
 use visitable_derive::Visitable;
 
 use crate::{
-	tokens::token_as_identifier, ASTNode, Expression, ParseResult, ParseSettings, TSXToken,
+	tokens::token_as_identifier, ASTNode, Expression, ParseOptions, ParseResult, TSXToken,
 	Visitable,
 };
 
@@ -26,7 +26,7 @@ impl ASTNode for Decorator {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		let at_pos = reader.expect_next(TSXToken::At)?;
 		Self::from_reader_sub_at_symbol(reader, state, settings, at_pos)
@@ -35,7 +35,7 @@ impl ASTNode for Decorator {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		if settings.include_decorators {
@@ -60,7 +60,7 @@ impl Decorator {
 	pub(crate) fn from_reader_sub_at_symbol(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 		at_pos: Span,
 	) -> ParseResult<Self> {
 		let (name, name_position) = token_as_identifier(reader.next().unwrap(), "Decorator name")?;
@@ -106,7 +106,7 @@ impl<N: ASTNode> ASTNode for Decorated<N> {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		let decorators = decorators_from_reader(reader, state, settings)?;
 		N::from_reader(reader, state, settings).map(|on| Self { on, decorators })
@@ -115,7 +115,7 @@ impl<N: ASTNode> ASTNode for Decorated<N> {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		self.to_string_from_buffer_just_decorators(buf, settings, depth);
@@ -131,7 +131,7 @@ impl<U> Decorated<U> {
 	pub(crate) fn to_string_from_buffer_just_decorators<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		if settings.include_decorators {
@@ -150,7 +150,7 @@ impl<U> Decorated<U> {
 pub(crate) fn decorators_from_reader(
 	reader: &mut impl TokenReader<TSXToken, Span>,
 	state: &mut crate::ParsingState,
-	settings: &ParseSettings,
+	settings: &ParseOptions,
 ) -> ParseResult<Vec<Decorator>> {
 	let mut decorators = Vec::new();
 	while let Some(Token(TSXToken::At, _)) = reader.peek() {

--- a/parser/src/generator_helpers.rs
+++ b/parser/src/generator_helpers.rs
@@ -1,5 +1,4 @@
-use crate::expressions::ExpressionId;
-use crate::{ASTNode, Expression, PropertyReference, Statement, VariableId, VariableIdentifier};
+use crate::{ASTNode, Expression, PropertyReference, Statement, VariableIdentifier};
 
 use source_map::Span;
 
@@ -18,18 +17,13 @@ pub struct Ident<'a>(&'a str);
 
 impl<'a> IntoAST<Expression> for Ident<'a> {
 	fn into_ast(self) -> Expression {
-		Expression::VariableReference(self.0.to_owned(), Span::NULL_SPAN, ExpressionId::new())
+		Expression::VariableReference(self.0.to_owned(), Span::NULL_SPAN)
 	}
 }
 
 impl<'a> IntoAST<Expression> for &'a str {
 	fn into_ast(self) -> Expression {
-		Expression::StringLiteral(
-			self.to_owned(),
-			crate::Quoted::Double,
-			Span::NULL_SPAN,
-			ExpressionId::new(),
-		)
+		Expression::StringLiteral(self.to_owned(), crate::Quoted::Double, Span::NULL_SPAN)
 	}
 }
 
@@ -41,27 +35,19 @@ impl<'a> IntoAST<PropertyReference> for &'a str {
 
 impl<'a> IntoAST<VariableIdentifier> for &'a str {
 	fn into_ast(self) -> VariableIdentifier {
-		VariableIdentifier::Standard(self.to_owned(), VariableId::new(), Span::NULL_SPAN)
+		VariableIdentifier::Standard(self.to_owned(), Span::NULL_SPAN)
 	}
 }
 
 impl IntoAST<Expression> for usize {
 	fn into_ast(self) -> Expression {
-		Expression::NumberLiteral(
-			crate::NumberStructure::Number(self as f64),
-			Span::NULL_SPAN,
-			ExpressionId::new(),
-		)
+		Expression::NumberLiteral(crate::NumberStructure::Number(self as f64), Span::NULL_SPAN)
 	}
 }
 
 impl IntoAST<Expression> for f64 {
 	fn into_ast(self) -> Expression {
-		Expression::NumberLiteral(
-			crate::NumberStructure::Number(self),
-			Span::NULL_SPAN,
-			ExpressionId::new(),
-		)
+		Expression::NumberLiteral(crate::NumberStructure::Number(self), Span::NULL_SPAN)
 	}
 }
 

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -44,11 +44,11 @@ pub fn lex_source(
 	script: &str,
 	sender: &mut impl TokenSender<TSXToken, Span>,
 	settings: &LexSettings,
-	source_id: Option<SourceId>,
+	source: Option<SourceId>,
 	offset: Option<usize>,
 	mut cursors: Vec<(usize, EmptyCursorId)>,
 ) -> Result<(), ParseError> {
-	let source_id = source_id.unwrap_or(SourceId::NULL);
+	let source = source.unwrap_or(SourceId::NULL);
 
 	cursors.reverse();
 
@@ -118,8 +118,11 @@ pub fn lex_source(
 		// Literals:
 		Number {
 			literal_type: NumberLiteralType,
-			// For binary, hex, etc `0b0121`
+			/// For binary, hex, etc `0b0121`
 			last_character_zero: bool,
+			/// Past and `e` or `E`
+			past_exponential: bool,
+			last_was_underscore: bool,
 		},
 		String {
 			double_quoted: bool,
@@ -170,11 +173,7 @@ pub fn lex_source(
 	/// TODO not sure about this, maybe shouldn't return span
 	macro_rules! current_position {
 		() => {
-			Span {
-				start: start as u32 + offset as u32,
-				end: start as u32 + offset as u32,
-				source_id,
-			}
+			Span { start: start as u32 + offset as u32, end: start as u32 + offset as u32, source }
 		};
 	}
 
@@ -215,7 +214,7 @@ pub fn lex_source(
 					Span {
 						start: (start + offset) as u32,
 						end: (idx + offset + chr.len_utf8()) as u32,
-						source_id,
+						source,
 					},
 				));
 				if !res {
@@ -226,7 +225,7 @@ pub fn lex_source(
 			(EXCLUDING_LAST_CHAR, $t:expr $(,)?) => {{
 				let res = sender.push(Token(
 					$t,
-					Span { start: (start + offset) as u32, end: (idx + offset) as u32, source_id },
+					Span { start: (start + offset) as u32, end: (idx + offset) as u32, source },
 				));
 				if !res {
 					return Ok(());
@@ -239,7 +238,7 @@ pub fn lex_source(
 					Span {
 						start: (start + offset) as u32,
 						end: (idx + offset - $slice.len_utf8()) as u32,
-						source_id,
+						source,
 					},
 				));
 				if !res {
@@ -253,7 +252,7 @@ pub fn lex_source(
 					Span {
 						start: (idx + offset) as u32,
 						end: (idx + offset + chr.len_utf8()) as u32,
-						source_id,
+						source,
 					},
 				));
 				if !res {
@@ -263,13 +262,20 @@ pub fn lex_source(
 		}
 
 		match state {
-			LexingState::Number { ref mut literal_type, ref mut last_character_zero } => {
+			LexingState::Number {
+				ref mut literal_type,
+				ref mut last_character_zero,
+				ref mut past_exponential,
+				ref mut last_was_underscore,
+			} => {
 				match chr {
 					'0' => {
 						*last_character_zero = true;
+						*last_was_underscore = false;
 					}
 					'1'..='9' => {
 						*last_character_zero = false;
+						*last_was_underscore = false;
 					}
 					'.' => {
 						if let NumberLiteralType::Decimal { fractional } = literal_type {
@@ -306,11 +312,17 @@ pub fn lex_source(
 							}
 						}
 					}
-					'e' => {
-						unimplemented!();
+					'e' | 'E' => {
+						if *past_exponential {
+							todo!()
+						}
+						*past_exponential = true;
 					}
 					'_' => {
-						unimplemented!();
+						if *last_was_underscore {
+							todo!()
+						}
+						*last_was_underscore = true;
 					}
 					_ => {
 						push_token!(
@@ -358,7 +370,7 @@ pub fn lex_source(
 				}
 			}
 			LexingState::Identifier => match chr {
-				'A'..='Z' | 'a'..='z' | '0'..='9' | '_' => {}
+				'A'..='Z' | 'a'..='z' | '0'..='9' | '_' | '$' => {}
 				_ => {
 					let token = TSXToken::from_slice(&script[start..idx]);
 					let is_expression_prefix = token.is_expression_prefix();
@@ -466,7 +478,7 @@ pub fn lex_source(
 							Span {
 								start: (start + offset) as u32,
 								end: (idx + offset) as u32,
-								source_id,
+								source,
 							},
 						));
 					}
@@ -913,11 +925,15 @@ pub fn lex_source(
 			match chr {
 				'0' => set_state!(LexingState::Number {
 					literal_type: Default::default(),
-					last_character_zero: true
+					last_character_zero: true,
+					last_was_underscore: false,
+					past_exponential: false
 				}),
 				'1'..='9' => set_state!(LexingState::Number {
 					literal_type: Default::default(),
-					last_character_zero: false
+					last_character_zero: false,
+					last_was_underscore: false,
+					past_exponential: false
 				}),
 				'"' => set_state!(LexingState::String { double_quoted: true, escaped: false }),
 				'\'' => set_state!(LexingState::String { double_quoted: false, escaped: false }),
@@ -1042,13 +1058,13 @@ pub fn lex_source(
 		LexingState::Number { .. } => {
 			sender.push(Token(
 				TSXToken::NumberLiteral(script[start..].to_owned()),
-				Span { start: (start + offset) as u32, end: end_of_source, source_id },
+				Span { start: (start + offset) as u32, end: end_of_source, source },
 			));
 		}
 		LexingState::Identifier => {
 			sender.push(Token(
 				TSXToken::from_slice(&script[start..]),
-				Span { start: (start + offset) as u32, end: end_of_source, source_id },
+				Span { start: (start + offset) as u32, end: end_of_source, source },
 			));
 		}
 		LexingState::Symbol(symbol_state) => {
@@ -1061,7 +1077,7 @@ pub fn lex_source(
 				} => {
 					sender.push(Token(
 						result,
-						Span { start: (start + offset) as u32, end: end_of_source, source_id },
+						Span { start: (start + offset) as u32, end: end_of_source, source },
 					));
 				}
 				GetNextResult::NewState(_new_state) => unreachable!(),
@@ -1076,7 +1092,7 @@ pub fn lex_source(
 		LexingState::Comment => {
 			sender.push(Token(
 				TSXToken::Comment(script[(start + 2)..].trim_end().to_owned()),
-				Span { start: (start + offset) as u32, end: end_of_source, source_id },
+				Span { start: (start + offset) as u32, end: end_of_source, source },
 			));
 		}
 		LexingState::MultiLineComment { .. } => {

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -23,9 +23,7 @@ mod visiting;
 #[doc(hidden)]
 pub mod lexer;
 
-pub use block::{
-	Block, BlockId, BlockLike, BlockLikeMut, BlockOrSingleStatement, StatementOrDeclaration,
-};
+pub use block::{Block, BlockLike, BlockLikeMut, BlockOrSingleStatement, StatementOrDeclaration};
 pub use comments::WithComment;
 pub use cursor::{CursorId, EmptyCursorId};
 pub use declarations::Declaration;
@@ -42,20 +40,15 @@ pub use generator_helpers::IntoAST;
 use iterator_endiate::EndiateIteratorExt;
 pub use lexer::{lex_source, LexSettings};
 pub use modules::{FromFileError, Module, TypeDefinitionModule, TypeDefinitionModuleDeclaration};
-pub use parameters::{
-	FunctionParameters, OptionalOrWithDefaultValueParameter, Parameter, SpreadParameter,
-};
-pub use property_key::{PropertyId, PropertyKey};
+pub use parameters::{FunctionParameters, Parameter, SpreadParameter};
+pub use property_key::PropertyKey;
 pub use source_map::{self, SourceId, Span};
 pub use statements::Statement;
 use temporary_annex::Annex;
 pub use tokens::{tsx_keywords, TSXKeyword, TSXToken};
 pub use types::{
-	type_declarations,
-	type_declarations::{GenericTypeConstraint, TypeDeclaration},
-	type_references,
-	type_references::TypeReference,
-	TypeId,
+	type_annotations::{self, TypeAnnotation},
+	type_declarations::{self, GenericTypeConstraint, TypeDeclaration},
 };
 pub use variable_fields::*;
 pub use visiting::*;
@@ -84,7 +77,7 @@ impl Quoted {
 /// Settings to customize parsing
 #[allow(unused)]
 #[derive(Clone)]
-pub struct ParseSettings {
+pub struct ParseOptions {
 	/// Parsing of [JSX](https://facebook.github.io/jsx/) (includes some additions)
 	pub jsx: bool,
 	pub decorators: bool,
@@ -97,7 +90,7 @@ pub struct ParseSettings {
 }
 
 // TODO not sure about some of these defaults, may change in future
-impl Default for ParseSettings {
+impl Default for ParseOptions {
 	fn default() -> Self {
 		Self {
 			jsx: true,
@@ -111,7 +104,7 @@ impl Default for ParseSettings {
 }
 
 /// Settings for serializing ASTNodes
-pub struct ToStringSettings {
+pub struct ToStringOptions {
 	/// Does not include whitespace minification
 	pub pretty: bool,
 	/// Include type annotation syntax
@@ -125,9 +118,9 @@ pub struct ToStringSettings {
 	pub expect_cursors: bool,
 }
 
-impl Default for ToStringSettings {
+impl Default for ToStringOptions {
 	fn default() -> Self {
-		ToStringSettings {
+		ToStringOptions {
 			pretty: true,
 			include_types: false,
 			include_decorators: false,
@@ -139,9 +132,9 @@ impl Default for ToStringSettings {
 	}
 }
 
-impl ToStringSettings {
+impl ToStringOptions {
 	pub fn minified() -> Self {
-		ToStringSettings {
+		ToStringOptions {
 			pretty: false,
 			include_comments: false,
 			indent_with: "".to_owned(),
@@ -151,7 +144,7 @@ impl ToStringSettings {
 
 	/// With typescript type syntax
 	pub fn typescript() -> Self {
-		ToStringSettings { include_types: true, ..Default::default() }
+		ToStringOptions { include_types: true, ..Default::default() }
 	}
 
 	/// Whether to include comment in source
@@ -179,8 +172,8 @@ pub trait ASTNode: Sized + Clone + PartialEq + std::fmt::Debug + Sync + Send + '
 	#[cfg(target_arch = "wasm32")]
 	fn from_string(
 		string: String,
-		settings: ParseSettings,
-		source_id: SourceId,
+		settings: ParseOptions,
+		source: SourceId,
 		offset: Option<usize>,
 		cursors: Vec<(usize, EmptyCursorId)>,
 	) -> ParseResult<Self> {
@@ -190,7 +183,7 @@ pub trait ASTNode: Sized + Clone + PartialEq + std::fmt::Debug + Sync + Send + '
 			..Default::default()
 		};
 		let mut queue = tokenizer_lib::BufferedTokenQueue::new();
-		lexer::lex_source(&string, &mut queue, &lex_settings, Some(source_id), offset, cursors)?;
+		lexer::lex_source(&string, &mut queue, &lex_settings, Some(source), offset, cursors)?;
 
 		let mut state = ParsingState::default();
 		let res = Self::from_reader(&mut queue, &mut state, &settings);
@@ -204,11 +197,12 @@ pub trait ASTNode: Sized + Clone + PartialEq + std::fmt::Debug + Sync + Send + '
 	#[cfg(not(target_arch = "wasm32"))]
 	fn from_string(
 		source: String,
-		settings: ParseSettings,
+		settings: ParseOptions,
 		source_id: SourceId,
 		offset: Option<usize>,
 		cursors: Vec<(usize, EmptyCursorId)>,
 	) -> ParseResult<Self> {
+		use source_map::LineStarts;
 		use std::thread;
 		use tokenizer_lib::ParallelTokenQueue;
 
@@ -217,9 +211,12 @@ pub trait ASTNode: Sized + Clone + PartialEq + std::fmt::Debug + Sync + Send + '
 			lex_jsx: settings.jsx,
 			..Default::default()
 		};
+
+		let line_starts = LineStarts::new(source.as_str());
+
 		let (mut sender, mut reader) = ParallelTokenQueue::new();
 		let parsing_thread = thread::spawn(move || {
-			let mut state = ParsingState::default();
+			let mut state = ParsingState { line_starts };
 			let res = Self::from_reader(&mut reader, &mut state, &settings);
 			if res.is_ok() {
 				reader.expect_next(TSXToken::EOS)?;
@@ -239,27 +236,28 @@ pub trait ASTNode: Sized + Clone + PartialEq + std::fmt::Debug + Sync + Send + '
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self>;
 
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	);
 
 	/// Returns structure as valid string
-	fn to_string(&self, settings: &crate::ToStringSettings) -> String {
+	fn to_string(&self, settings: &crate::ToStringOptions) -> String {
 		let mut buf = String::new();
 		self.to_string_from_buffer(&mut buf, settings, 0);
 		buf
 	}
 }
 
-/// TODO local identifiers
-#[derive(Default, Debug)]
-pub struct ParsingState {}
+#[derive(Debug)]
+pub struct ParsingState {
+	pub(crate) line_starts: source_map::LineStarts,
+}
 
 /// A keyword
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -391,7 +389,7 @@ impl From<f64> for NumberStructure {
 }
 
 impl FromStr for NumberStructure {
-	type Err = ();
+	type Err = String;
 
 	// TODO separators
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -406,17 +404,57 @@ impl FromStr for NumberStructure {
 		if let Some(s) = s.strip_prefix('0') {
 			let next_char = s.chars().next();
 			match next_char {
-				Some('.') => Ok(Self::Number(sign.apply(s.parse().map_err(|_| ())?))),
-				// TODO this is broken, needs to hex decoding etc
-				Some('X' | 'x') => Ok(Self::Hex(sign, s[2..].parse().map_err(|_| ())?)),
-				Some('b' | 'B') => Ok(Self::Bin(sign, s[2..].parse().map_err(|_| ())?)),
-				Some('o' | 'O') => Ok(Self::Octal(sign, s[2..].parse().map_err(|_| ())?)),
-				Some(_) => Ok(Self::Octal(sign, s[1..].parse().map_err(|_| ())?)),
-
+				Some('.') => Ok(Self::Number(sign.apply(s.parse().map_err(|_| s.to_owned())?))),
+				Some('X' | 'x') => {
+					let mut number = 0u64;
+					for c in s[2..].as_bytes().iter().rev() {
+						number <<= 4; // 16=2^4
+						match c {
+							b'0'..=b'9' => {
+								number += (c - b'0') as u64;
+							}
+							b'a'..=b'f' => {
+								number += (c - b'a') as u64 + 10;
+							}
+							b'A'..=b'F' => {
+								number += (c - b'A') as u64 + 10;
+							}
+							_ => return Err(s.to_owned()),
+						}
+					}
+					Ok(Self::Hex(sign, number))
+				}
+				Some('b' | 'B') => {
+					let mut number = 0u64;
+					for c in s[2..].as_bytes().iter().rev() {
+						number <<= 1;
+						match c {
+							b'0' | b'1' => {
+								number += (c - b'0') as u64;
+							}
+							_ => return Err(s.to_owned()),
+						}
+					}
+					Ok(Self::Bin(sign, number))
+				}
+				// 'o' | 'O' but can also be missed
+				Some(c) => {
+					let start = if matches!(c, 'o' | 'O') { 2 } else { 1 };
+					let mut number = 0u64;
+					for c in s[start..].as_bytes().iter().rev() {
+						number <<= 3; // 8=2^3
+						if matches!(c, b'0'..=b'7') {
+							number += (c - b'0') as u64;
+						} else {
+							return Err(s.to_owned());
+						}
+					}
+					Ok(Self::Octal(sign, number))
+				}
 				None => Ok(Self::Number(0.)),
 			}
 		} else {
-			Ok(Self::Number(sign.apply(s.parse().map_err(|_| ())?)))
+			Ok(Self::Number(sign.apply(s.parse().map_err(|_| s.to_owned())?)))
 		}
 	}
 }
@@ -524,8 +562,8 @@ pub trait ExpressionOrStatementPosition:
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
-	) -> ParseResult<(Self::Name, Option<Vec<GenericTypeConstraint>>)>;
+		settings: &ParseOptions,
+	) -> ParseResult<Self::Name>;
 
 	fn as_option_str(name: &Self::Name) -> Option<&str>;
 	fn as_option_string_mut(name: &mut Self::Name) -> Option<&mut String>;
@@ -540,17 +578,9 @@ impl ExpressionOrStatementPosition for StatementPosition {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
-	) -> ParseResult<(Self::Name, Option<Vec<GenericTypeConstraint>>)> {
-		let type_declaration = TypeDeclaration::from_reader(reader, state, settings)?;
-		Ok((
-			VariableIdentifier::Standard(
-				type_declaration.name,
-				VariableId::new(),
-				type_declaration.position,
-			),
-			type_declaration.type_parameters,
-		))
+		settings: &ParseOptions,
+	) -> ParseResult<Self::Name> {
+		VariableIdentifier::from_reader(reader, state, settings)
 	}
 
 	fn as_option_str(name: &Self::Name) -> Option<&str> {
@@ -579,13 +609,12 @@ impl ExpressionOrStatementPosition for ExpressionPosition {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
-	) -> ParseResult<(Self::Name, Option<Vec<GenericTypeConstraint>>)> {
-		if let Token(TSXToken::OpenBrace, _) = reader.peek().unwrap() {
-			Ok((None, None))
+		settings: &ParseOptions,
+	) -> ParseResult<Self::Name> {
+		if let Some(Token(TSXToken::OpenBrace, _)) | None = reader.peek() {
+			Ok(None)
 		} else {
-			StatementPosition::from_reader(reader, state, settings)
-				.map(|(name, constraints)| (Some(name), constraints))
+			StatementPosition::from_reader(reader, state, settings).map(Some)
 		}
 	}
 
@@ -602,7 +631,7 @@ impl ExpressionOrStatementPosition for ExpressionPosition {
 pub(crate) fn parse_bracketed<T: ASTNode>(
 	reader: &mut impl TokenReader<TSXToken, Span>,
 	state: &mut crate::ParsingState,
-	settings: &ParseSettings,
+	settings: &ParseOptions,
 	start: Option<TSXToken>,
 	end: TSXToken,
 ) -> ParseResult<(Vec<T>, Span)> {
@@ -636,7 +665,7 @@ pub(crate) fn to_string_bracketed<T: source_map::ToString, U: ASTNode>(
 	nodes: &[U],
 	brackets: (char, char),
 	buf: &mut T,
-	settings: &crate::ToStringSettings,
+	settings: &crate::ToStringOptions,
 	depth: u8,
 ) {
 	buf.push(brackets.0);
@@ -651,20 +680,33 @@ pub(crate) fn to_string_bracketed<T: source_map::ToString, U: ASTNode>(
 }
 
 /// Part of [ASI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion)
-pub(crate) fn expect_semi_colon(reader: &mut impl TokenReader<TSXToken, Span>) -> ParseResult<()> {
-	if let Some(Token(TSXToken::CloseBrace, _)) = reader.peek() {
-		return Ok(());
+pub(crate) fn expect_semi_colon(
+	reader: &mut impl TokenReader<TSXToken, Span>,
+	line_starts: &source_map::LineStarts,
+	prev: u32,
+) -> ParseResult<()> {
+	if let Some(token) = reader.peek() {
+		let Token(kind, Span { start: next, .. }) = token;
+		// eprintln!("{:?} {:?} {:?}", prev, next, line_starts);
+		if let TSXToken::CloseBrace | TSXToken::EOS = kind {
+			Ok(())
+		} else if !matches!(kind, TSXToken::SemiColon)
+			&& line_starts.byte_indexes_on_different_lines(prev as usize, *next as usize)
+		{
+			Ok(())
+		} else {
+			reader.expect_next(TSXToken::SemiColon).map(|_| ()).map_err(Into::into)
+		}
+	} else {
+		Ok(())
 	}
-	reader.expect_next(TSXToken::SemiColon)?;
-	Ok(())
 }
 
 /// Re-exports or generator and general use
 pub mod ast {
 	pub use crate::{
 		declarations::*, expressions::*, extensions::jsx::*, statements::*, Keyword,
-		NumberStructure, StatementOrDeclaration, VariableField, VariableId, VariableIdentifier,
-		WithComment,
+		NumberStructure, StatementOrDeclaration, VariableField, VariableIdentifier, WithComment,
 	};
 
 	pub use self::assignments::{LHSOfAssignment, VariableOrPropertyAccess};

--- a/parser/src/modules.rs
+++ b/parser/src/modules.rs
@@ -1,6 +1,5 @@
 use derive_enum_from_into::EnumFrom;
 use source_map::SourceId;
-use temporary_annex::Annex;
 
 use crate::{
 	block::{parse_statements_and_declarations, statements_and_declarations_to_string},
@@ -14,8 +13,8 @@ use crate::{
 		type_alias::TypeAlias,
 		InterfaceDeclaration,
 	},
-	BlockId, BlockLike, BlockLikeMut, Chain, ChainVariable, Decorated, Decorator, ParseResult,
-	ParseSettings, ParsingState, StatementOrDeclaration, TSXKeyword, VisitSettings, Visitable,
+	BlockLike, BlockLikeMut, Decorated, Decorator, ParseOptions, ParseResult, ParsingState,
+	StatementOrDeclaration, TSXKeyword, VisitSettings,
 };
 
 use super::{lexer, ASTNode, EmptyCursorId, ParseError, Span, TSXToken, Token, TokenReader};
@@ -33,8 +32,7 @@ pub enum FromFileError {
 #[derive(Debug, Clone)]
 pub struct Module {
 	pub items: Vec<StatementOrDeclaration>,
-	pub block_id: BlockId,
-	pub source_id: SourceId,
+	pub source: SourceId,
 }
 
 impl PartialEq for Module {
@@ -47,7 +45,7 @@ impl ASTNode for Module {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		statements_and_declarations_to_string(&self.items, buf, settings, depth)
@@ -66,15 +64,13 @@ impl ASTNode for Module {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
-		parse_statements_and_declarations(reader, state, settings).map(|(statements, block_id)| {
+		parse_statements_and_declarations(reader, state, settings).map(|statements| {
 			// TODO null bad
-			let source_id = statements
-				.last()
-				.map(|stmt| stmt.get_position().source_id)
-				.unwrap_or(SourceId::NULL);
-			Module { source_id, items: statements, block_id }
+			let source =
+				statements.last().map(|stmt| stmt.get_position().source).unwrap_or(SourceId::NULL);
+			Module { source, items: statements }
 		})
 	}
 }
@@ -82,7 +78,7 @@ impl ASTNode for Module {
 impl Module {
 	pub fn to_string_with_source_map(
 		&self,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		fs: &impl source_map::FileSystem,
 	) -> (String, source_map::SourceMap) {
 		let mut buf = source_map::StringWithSourceMap::new();
@@ -90,7 +86,7 @@ impl Module {
 		buf.build(fs)
 	}
 
-	pub fn length(&self, settings: &crate::ToStringSettings) -> usize {
+	pub fn length(&self, settings: &crate::ToStringOptions) -> usize {
 		let mut buf = source_map::Counter::new();
 		self.to_string_from_buffer(&mut buf, settings, 0);
 		buf.get_count()
@@ -99,7 +95,7 @@ impl Module {
 	#[cfg(not(target_family = "wasm"))]
 	pub fn from_file(
 		path: impl AsRef<Path>,
-		settings: ParseSettings,
+		settings: ParseOptions,
 		cursors: Vec<(usize, EmptyCursorId)>,
 		fs: &mut impl source_map::FileSystem,
 	) -> Result<Self, FromFileError> {
@@ -116,18 +112,19 @@ impl Module {
 		data: &mut TData,
 		settings: &VisitSettings,
 	) {
-		let mut chain =
-			Chain::new_with_initial(ChainVariable::UnderModule(self.block_id, self.source_id));
+		use crate::visiting::Visitable;
+		let mut chain = crate::Chain::new_with_initial(crate::ChainVariable::Module(self.source));
+		let mut chain = temporary_annex::Annex::new(&mut chain);
 
-		let mut chain = Annex::new(&mut chain);
-
-		visitors.visit_block(&crate::block::BlockLike::from(self), data, &chain);
+		{
+			visitors.visit_block(&mut crate::block::BlockLike { items: &self.items }, data, &chain);
+		}
 
 		let iter = self.items.iter();
 		if settings.reverse_statements {
-			iter.rev().for_each(|item| item.visit(visitors, data, settings, &mut chain));
-		} else {
 			iter.for_each(|item| item.visit(visitors, data, settings, &mut chain));
+		} else {
+			iter.rev().for_each(|item| item.visit(visitors, data, settings, &mut chain));
 		}
 	}
 
@@ -137,14 +134,13 @@ impl Module {
 		data: &mut TData,
 		settings: &VisitSettings,
 	) {
-		let mut chain =
-			Chain::new_with_initial(ChainVariable::UnderModule(self.block_id, self.source_id));
-
-		let mut chain = Annex::new(&mut chain);
+		use crate::visiting::Visitable;
+		let mut chain = crate::Chain::new_with_initial(crate::ChainVariable::Module(self.source));
+		let mut chain = temporary_annex::Annex::new(&mut chain);
 
 		{
 			visitors.visit_block_mut(
-				&mut crate::block::BlockLikeMut { block_id: self.block_id, items: &mut self.items },
+				&mut crate::block::BlockLikeMut { items: &mut self.items },
 				data,
 				&chain,
 			);
@@ -161,13 +157,13 @@ impl Module {
 
 impl<'a> From<&'a Module> for BlockLike<'a> {
 	fn from(module: &'a Module) -> Self {
-		BlockLike { block_id: module.block_id, items: &module.items }
+		BlockLike { items: &module.items }
 	}
 }
 
 impl<'a> From<&'a mut Module> for BlockLikeMut<'a> {
 	fn from(module: &'a mut Module) -> Self {
-		BlockLikeMut { block_id: module.block_id, items: &mut module.items }
+		BlockLikeMut { items: &mut module.items }
 	}
 }
 
@@ -197,7 +193,7 @@ impl TypeDefinitionModule {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		let mut declarations = Vec::new();
 		loop {
@@ -224,8 +220,8 @@ impl TypeDefinitionModule {
 	#[cfg(target_family = "wasm")]
 	pub fn from_string(
 		source: String,
-		settings: ParseSettings,
-		source_id: SourceId,
+		settings: ParseOptions,
+		source: SourceId,
 		cursors: Vec<(usize, EmptyCursorId)>,
 	) -> ParseResult<(Self, ParsingState)> {
 		// TODO this should be covered by settings
@@ -239,7 +235,7 @@ impl TypeDefinitionModule {
 
 		// Extension which includes pulling in the string as source
 		let mut queue = tokenizer_lib::BufferedTokenQueue::new();
-		lexer::lex_source(&source, &mut queue, &lex_settings, Some(source_id), None, cursors)?;
+		lexer::lex_source(&source, &mut queue, &lex_settings, Some(source), None, cursors)?;
 
 		let mut state = ParsingState::default();
 		let res = Self::from_reader(&mut queue, &mut state, &settings);
@@ -253,17 +249,20 @@ impl TypeDefinitionModule {
 	#[cfg(not(target_family = "wasm"))]
 	pub fn from_string(
 		source: String,
-		settings: ParseSettings,
+		settings: ParseOptions,
 		source_id: SourceId,
 		cursors: Vec<(usize, EmptyCursorId)>,
 	) -> ParseResult<(Self, ParsingState)> {
+		use source_map::LineStarts;
 		use std::thread;
 		use tokenizer_lib::ParallelTokenQueue;
 
 		// Extension which includes pulling in the string as source
 		let (mut sender, mut reader) = ParallelTokenQueue::new();
+		let line_starts = LineStarts::new(source.as_str());
+
 		let parsing_thread = thread::spawn(move || {
-			let mut state = ParsingState::default();
+			let mut state = ParsingState { line_starts };
 			let res = Self::from_reader(&mut reader, &mut state, &settings);
 			match res {
 				Ok(ast) => {
@@ -289,7 +288,7 @@ impl TypeDefinitionModule {
 	#[cfg(not(target_family = "wasm"))]
 	pub fn from_file(
 		path: impl AsRef<Path>,
-		settings: ParseSettings,
+		settings: ParseOptions,
 		cursors: Vec<(usize, EmptyCursorId)>,
 		fs: &mut impl source_map::FileSystem,
 	) -> Result<(Self, ParsingState), FromFileError> {
@@ -303,7 +302,7 @@ impl ASTNode for TypeDefinitionModuleDeclaration {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		let decorators = decorators_from_reader(reader, state, settings)?;
 		match reader.peek().ok_or_else(parse_lexing_error)? {
@@ -357,7 +356,7 @@ impl ASTNode for TypeDefinitionModuleDeclaration {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		_buf: &mut T,
-		_settings: &crate::ToStringSettings,
+		_settings: &crate::ToStringOptions,
 		_depth: u8,
 	) {
 		todo!("tdms to_string_from_buffer");
@@ -371,7 +370,7 @@ impl ASTNode for TypeDefinitionModuleDeclaration {
 pub(crate) fn parse_declare_item(
 	reader: &mut impl TokenReader<TSXToken, Span>,
 	state: &mut crate::ParsingState,
-	settings: &ParseSettings,
+	settings: &ParseOptions,
 	decorators: Vec<Decorator>,
 	declare_span: Span,
 ) -> Result<TypeDefinitionModuleDeclaration, ParseError> {

--- a/parser/src/operators.rs
+++ b/parser/src/operators.rs
@@ -38,8 +38,8 @@ pub enum BinaryAssignmentOperator {
     
     AddAssign, SubtractAssign, MultiplyAssign, DivideAssign, ModuloAssign, ExponentAssign,
     LogicalAndAssign, LogicalOrAssign,
-    BitwiseShiftLeftAssign, BitwiseShiftRightAssign, BitwiseShiftRightUnsignedAssign, 
-    BitwiseAndAssign, BitwiseXOrAssign, BitOrAssign,
+    BitwiseShiftLeftAssign, BitwiseShiftRightAssign, BitwiseShiftRightUnsigned, 
+    BitwiseAndAssign, BitwiseXorAssign, BitwiseOrAssign,
 }
 
 #[rustfmt::skip]
@@ -238,10 +238,10 @@ impl Operator for BinaryAssignmentOperator {
 			BinaryAssignmentOperator::ExponentAssign => "**=",
 			BinaryAssignmentOperator::BitwiseShiftLeftAssign => "<<=",
 			BinaryAssignmentOperator::BitwiseShiftRightAssign => ">>=",
-			BinaryAssignmentOperator::BitwiseShiftRightUnsignedAssign => ">>>=",
+			BinaryAssignmentOperator::BitwiseShiftRightUnsigned => ">>>=",
 			BinaryAssignmentOperator::BitwiseAndAssign => "&=",
-			BinaryAssignmentOperator::BitwiseXOrAssign => "^=",
-			BinaryAssignmentOperator::BitOrAssign => "|=",
+			BinaryAssignmentOperator::BitwiseXorAssign => "^=",
+			BinaryAssignmentOperator::BitwiseOrAssign => "|=",
 			BinaryAssignmentOperator::LogicalAndAssign => "&&=",
 			BinaryAssignmentOperator::LogicalOrAssign => "||=",
 		}
@@ -323,12 +323,12 @@ impl From<BinaryAssignmentOperator> for BinaryOperator {
 			BinaryAssignmentOperator::LogicalOrAssign => BinaryOperator::LogicalOr,
 			BinaryAssignmentOperator::BitwiseShiftLeftAssign => BinaryOperator::BitwiseShiftLeft,
 			BinaryAssignmentOperator::BitwiseShiftRightAssign => BinaryOperator::BitwiseShiftRight,
-			BinaryAssignmentOperator::BitwiseShiftRightUnsignedAssign => {
+			BinaryAssignmentOperator::BitwiseShiftRightUnsigned => {
 				BinaryOperator::BitwiseShiftRightUnsigned
 			}
 			BinaryAssignmentOperator::BitwiseAndAssign => BinaryOperator::BitwiseAnd,
-			BinaryAssignmentOperator::BitwiseXOrAssign => BinaryOperator::BitwiseXOr,
-			BinaryAssignmentOperator::BitOrAssign => BinaryOperator::BitwiseOr,
+			BinaryAssignmentOperator::BitwiseXorAssign => BinaryOperator::BitwiseXOr,
+			BinaryAssignmentOperator::BitwiseOrAssign => BinaryOperator::BitwiseOr,
 		}
 	}
 }
@@ -345,8 +345,18 @@ impl TryFrom<&TSXToken> for BinaryAssignmentOperator {
 			TSXToken::ExponentAssign => Ok(BinaryAssignmentOperator::ExponentAssign),
 			TSXToken::LogicalAndAssign => Ok(BinaryAssignmentOperator::LogicalAndAssign),
 			TSXToken::LogicalOrAssign => Ok(BinaryAssignmentOperator::LogicalOrAssign),
-			TSXToken::BitwiseOrAssign => Ok(BinaryAssignmentOperator::BitOrAssign),
-			TSXToken::BitwiseXorAssign => Ok(BinaryAssignmentOperator::BitwiseXOrAssign),
+			TSXToken::BitwiseAndAssign => Ok(BinaryAssignmentOperator::BitwiseAndAssign),
+			TSXToken::BitwiseOrAssign => Ok(BinaryAssignmentOperator::BitwiseOrAssign),
+			TSXToken::BitwiseXorAssign => Ok(BinaryAssignmentOperator::BitwiseXorAssign),
+			TSXToken::BitwiseShiftLeftAssign => {
+				Ok(BinaryAssignmentOperator::BitwiseShiftLeftAssign)
+			}
+			TSXToken::BitwiseShiftRightAssign => {
+				Ok(BinaryAssignmentOperator::BitwiseShiftRightAssign)
+			}
+			TSXToken::BitwiseShiftRightUnsigned => {
+				Ok(BinaryAssignmentOperator::BitwiseShiftRightUnsigned)
+			}
 			TSXToken::NullishCoalescingAssign => {
 				Ok(BinaryAssignmentOperator::LogicalNullishAssignment)
 			}

--- a/parser/src/property_key.rs
+++ b/parser/src/property_key.rs
@@ -6,67 +6,27 @@ use tokenizer_lib::{Token, TokenReader};
 
 use crate::{
 	errors::parse_lexing_error, tokens::token_as_identifier, ASTNode, Expression, NumberStructure,
-	ParseResult, ParseSettings,
+	ParseOptions, ParseResult,
 };
-
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
-pub struct PropertyId(u16);
-
-impl PropertyId {
-	pub fn new() -> Self {
-		use std::sync::atomic::{AtomicU16, Ordering};
-
-		static PROPERTY_ID_COUNTER: AtomicU16 = AtomicU16::new(2000);
-		Self(PROPERTY_ID_COUNTER.fetch_add(1, Ordering::SeqCst))
-	}
-
-	pub fn new_known(id: u16) -> Self {
-		Self(id)
-	}
-
-	pub fn unwrap_counter(&self) -> u16 {
-		self.0
-	}
-}
-
-// TODO not sure
-#[cfg(feature = "self-rust-tokenize")]
-impl self_rust_tokenize::SelfRustTokenize for PropertyId {
-	fn append_to_token_stream(
-		&self,
-		token_stream: &mut self_rust_tokenize::proc_macro2::TokenStream,
-	) {
-		token_stream.extend(self_rust_tokenize::quote!(PropertyId::new()))
-	}
-}
 
 /// A key for a member in a class or object literal
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub enum PropertyKey {
-	Ident(String, PropertyId, Span),
-	StringLiteral(String, PropertyId, Span),
-	NumberLiteral(NumberStructure, PropertyId, Span),
+	Ident(String, Span),
+	StringLiteral(String, Span),
+	NumberLiteral(NumberStructure, Span),
 	/// Includes anything in the `[...]` maybe a symbol
-	Computed(Box<Expression>, PropertyId, Span),
+	Computed(Box<Expression>, Span),
 }
 
 impl PropertyKey {
-	pub fn get_property_id(&self) -> PropertyId {
-		match self {
-			PropertyKey::Ident(_, variable_id, _)
-			| PropertyKey::StringLiteral(_, variable_id, _)
-			| PropertyKey::NumberLiteral(_, variable_id, _)
-			| PropertyKey::Computed(_, variable_id, _) => *variable_id,
-		}
-	}
-
 	pub fn get_position(&self) -> Cow<Span> {
 		match self {
-			PropertyKey::Ident(_, _, pos)
-			| PropertyKey::StringLiteral(_, _, pos)
-			| PropertyKey::NumberLiteral(_, _, pos)
-			| PropertyKey::Computed(_, _, pos) => Cow::Borrowed(pos),
+			PropertyKey::Ident(_, pos)
+			| PropertyKey::StringLiteral(_, pos)
+			| PropertyKey::NumberLiteral(_, pos)
+			| PropertyKey::Computed(_, pos) => Cow::Borrowed(pos),
 		}
 	}
 }
@@ -74,10 +34,8 @@ impl PropertyKey {
 impl PartialEq<str> for PropertyKey {
 	fn eq(&self, other: &str) -> bool {
 		match self {
-			PropertyKey::Ident(name, _, _) | PropertyKey::StringLiteral(name, _, _) => {
-				name == other
-			}
-			PropertyKey::NumberLiteral(_, _, _) | PropertyKey::Computed(_, _, _) => false,
+			PropertyKey::Ident(name, _) | PropertyKey::StringLiteral(name, _) => name == other,
+			PropertyKey::NumberLiteral(_, _) | PropertyKey::Computed(_, _) => false,
 		}
 	}
 }
@@ -85,38 +43,34 @@ impl PartialEq<str> for PropertyKey {
 impl ASTNode for PropertyKey {
 	fn get_position(&self) -> Cow<Span> {
 		match self {
-			PropertyKey::Ident(_, _, pos)
-			| PropertyKey::StringLiteral(_, _, pos)
-			| PropertyKey::NumberLiteral(_, _, pos)
-			| PropertyKey::Computed(_, _, pos) => Cow::Borrowed(pos),
+			PropertyKey::Ident(_, pos)
+			| PropertyKey::StringLiteral(_, pos)
+			| PropertyKey::NumberLiteral(_, pos)
+			| PropertyKey::Computed(_, pos) => Cow::Borrowed(pos),
 		}
 	}
 
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		match reader.next().ok_or_else(parse_lexing_error)? {
 			Token(TSXToken::DoubleQuotedStringLiteral(content), position)
 			| Token(TSXToken::SingleQuotedStringLiteral(content), position) => {
-				Ok(Self::StringLiteral(content, PropertyId::new(), position))
+				Ok(Self::StringLiteral(content, position))
 			}
 			Token(TSXToken::NumberLiteral(value), position) => {
-				Ok(Self::NumberLiteral(value.parse().unwrap(), PropertyId::new(), position))
+				Ok(Self::NumberLiteral(value.parse().unwrap(), position))
 			}
 			Token(TSXToken::OpenBracket, start_pos) => {
 				let expression = Expression::from_reader(reader, state, settings)?;
 				let end_pos = reader.expect_next(TSXToken::CloseBracket)?;
-				Ok(Self::Computed(
-					Box::new(expression),
-					PropertyId::new(),
-					start_pos.union(&end_pos),
-				))
+				Ok(Self::Computed(Box::new(expression), start_pos.union(&end_pos)))
 			}
 			token => {
 				let (name, position) = token_as_identifier(token, "property key")?;
-				Ok(Self::Ident(name, PropertyId::new(), position))
+				Ok(Self::Ident(name, position))
 			}
 		}
 	}
@@ -124,18 +78,18 @@ impl ASTNode for PropertyKey {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		match self {
-			Self::Ident(ident, _, _pos) => buf.push_str(ident.as_str()),
-			Self::NumberLiteral(number, _, _) => buf.push_str(&number.to_string()),
-			Self::StringLiteral(string, _, _) => {
+			Self::Ident(ident, _pos) => buf.push_str(ident.as_str()),
+			Self::NumberLiteral(number, _) => buf.push_str(&number.to_string()),
+			Self::StringLiteral(string, _) => {
 				buf.push('"');
 				buf.push_str(string.as_str());
 				buf.push('"');
 			}
-			Self::Computed(expression, _, _) => {
+			Self::Computed(expression, _) => {
 				buf.push('[');
 				expression.to_string_from_buffer(buf, settings, depth);
 				buf.push(']');

--- a/parser/src/statements/for_statement.rs
+++ b/parser/src/statements/for_statement.rs
@@ -1,13 +1,15 @@
 use std::borrow::Cow;
 
 use crate::{
-	block::BlockOrSingleStatement,
-	declarations::variable::{VariableDeclaration, VariableDeclarationKeyword},
-	ParseSettings, TSXKeyword, VariableField, VariableFieldInSourceCode, WithComment,
+	ast::MultipleExpression, block::BlockOrSingleStatement,
+	declarations::variable::VariableDeclaration, tsx_keywords, Keyword, ParseOptions, TSXKeyword,
+	VariableField, VariableFieldInSourceCode, WithComment,
 };
 use visitable_derive::Visitable;
 
-use super::{ASTNode, Expression, ParseResult, Span, TSXToken, Token, TokenReader};
+use super::{
+	ASTNode, Expression, ParseResult, Span, TSXToken, Token, TokenReader, VarVariableStatement,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
@@ -25,7 +27,7 @@ impl ASTNode for ForLoopStatement {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		let start_pos = reader.expect_next(TSXToken::Keyword(TSXKeyword::For))?;
 		let condition = ForLoopCondition::from_reader(reader, state, settings)?;
@@ -37,7 +39,7 @@ impl ASTNode for ForLoopStatement {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		buf.push_str("for");
@@ -51,29 +53,79 @@ impl ASTNode for ForLoopStatement {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub enum ForLoopStatementInitializer {
-	Statement(VariableDeclaration),
-	Expression(Expression),
+	VariableDeclaration(VariableDeclaration),
+	VarStatement(VarVariableStatement),
+	Expression(MultipleExpression),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Visitable)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
+pub enum ForLoopVariableKeyword {
+	Const(Keyword<tsx_keywords::Const>),
+	Let(Keyword<tsx_keywords::Let>),
+	Var(Keyword<tsx_keywords::Var>),
+}
+
+impl ForLoopVariableKeyword {
+	pub fn is_token_variable_keyword(token: &TSXToken) -> bool {
+		matches!(token, TSXToken::Keyword(TSXKeyword::Const | TSXKeyword::Let | TSXKeyword::Var))
+	}
+
+	pub(crate) fn from_reader(token: Token<TSXToken, Span>) -> ParseResult<Self> {
+		match token {
+			Token(TSXToken::Keyword(TSXKeyword::Const), pos) => Ok(Self::Const(Keyword::new(pos))),
+			Token(TSXToken::Keyword(TSXKeyword::Let), pos) => Ok(Self::Let(Keyword::new(pos))),
+			Token(TSXToken::Keyword(TSXKeyword::Var), pos) => Ok(Self::Var(Keyword::new(pos))),
+			Token(token, position) => Err(crate::ParseError::new(
+				crate::ParseErrors::UnexpectedToken {
+					expected: &[
+						TSXToken::Keyword(TSXKeyword::Const),
+						TSXToken::Keyword(TSXKeyword::Let),
+						TSXToken::Keyword(TSXKeyword::Var),
+					],
+					found: token,
+				},
+				position,
+			)),
+		}
+	}
+
+	pub fn as_str(&self) -> &str {
+		match self {
+			Self::Const(_) => "const ",
+			Self::Let(_) => "let ",
+			Self::Var(_) => "var ",
+		}
+	}
+
+	pub fn get_position(&self) -> &Span {
+		match self {
+			Self::Const(kw) => kw.get_position(),
+			Self::Let(kw) => kw.get_position(),
+			Self::Var(kw) => kw.get_position(),
+		}
+	}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub enum ForLoopCondition {
 	ForOf {
-		keyword: Option<VariableDeclarationKeyword>,
+		keyword: Option<ForLoopVariableKeyword>,
 		variable: WithComment<VariableField<VariableFieldInSourceCode>>,
 		// TODO box...?
 		of: Expression,
 	},
 	ForIn {
-		keyword: Option<VariableDeclarationKeyword>,
+		keyword: Option<ForLoopVariableKeyword>,
 		variable: WithComment<VariableField<VariableFieldInSourceCode>>,
 		// TODO box...?
 		r#in: Expression,
 	},
 	Statements {
 		initializer: Option<ForLoopStatementInitializer>,
-		condition: Option<Expression>,
-		afterthought: Option<Expression>,
+		condition: Option<MultipleExpression>,
+		afterthought: Option<MultipleExpression>,
 	},
 }
 
@@ -84,7 +136,7 @@ impl ASTNode for ForLoopCondition {
 			| ForLoopCondition::ForIn { keyword, variable, r#in: rhs } => Cow::Owned(
 				keyword
 					.as_ref()
-					.map(VariableDeclarationKeyword::get_position)
+					.map(ForLoopVariableKeyword::get_position)
 					.map(Cow::Borrowed)
 					.unwrap_or_else(|| variable.get_position())
 					.union(&rhs.get_position()),
@@ -92,7 +144,8 @@ impl ASTNode for ForLoopCondition {
 			ForLoopCondition::Statements { initializer, condition: _, afterthought } => {
 				let initializer_position = match initializer.as_ref().expect("TODO what about None")
 				{
-					ForLoopStatementInitializer::Statement(stmt) => stmt.get_position(),
+					ForLoopStatementInitializer::VariableDeclaration(stmt) => stmt.get_position(),
+					ForLoopStatementInitializer::VarStatement(stmt) => stmt.get_position(),
 					ForLoopStatementInitializer::Expression(expr) => expr.get_position(),
 				};
 				Cow::Owned(
@@ -107,7 +160,7 @@ impl ASTNode for ForLoopCondition {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		reader.expect_next(TSXToken::OpenParentheses)?;
 		// Figure out if after variable declaration there exists a "=", "in" or a "of"
@@ -124,7 +177,7 @@ impl ASTNode for ForLoopCondition {
 					destructuring_depth == 0
 				} else {
 					ate_variable_specifier = true;
-					!VariableDeclarationKeyword::is_token_variable_keyword(token)
+					!ForLoopVariableKeyword::is_token_variable_keyword(token)
 				}
 			})
 			.map(|Token(tok, _)| tok);
@@ -132,9 +185,9 @@ impl ASTNode for ForLoopCondition {
 		let condition = match next {
 			Some(TSXToken::Keyword(TSXKeyword::Of)) => {
 				let keyword = if let Some(token) =
-					reader.conditional_next(VariableDeclarationKeyword::is_token_variable_keyword)
+					reader.conditional_next(ForLoopVariableKeyword::is_token_variable_keyword)
 				{
-					Some(VariableDeclarationKeyword::from_reader(token).unwrap())
+					Some(ForLoopVariableKeyword::from_reader(token).unwrap())
 				} else {
 					None
 				};
@@ -147,9 +200,9 @@ impl ASTNode for ForLoopCondition {
 			}
 			Some(TSXToken::Keyword(TSXKeyword::In)) => {
 				let keyword = if let Some(token) =
-					reader.conditional_next(VariableDeclarationKeyword::is_token_variable_keyword)
+					reader.conditional_next(ForLoopVariableKeyword::is_token_variable_keyword)
 				{
-					Some(VariableDeclarationKeyword::from_reader(token).unwrap())
+					Some(ForLoopVariableKeyword::from_reader(token).unwrap())
 				} else {
 					None
 				};
@@ -162,29 +215,33 @@ impl ASTNode for ForLoopCondition {
 			}
 			_ => {
 				let peek = reader.peek();
-				let initializer = if let Some(Token(
-					TSXToken::Keyword(TSXKeyword::Const | TSXKeyword::Let | TSXKeyword::Var),
-					_,
-				)) = peek
-				{
-					let declaration = VariableDeclaration::from_reader(reader, state, settings)?;
-					Some(ForLoopStatementInitializer::Statement(declaration))
-				} else if let Some(Token(TSXToken::SemiColon, _)) = peek {
-					None
-				} else {
-					let expr = Expression::from_reader(reader, state, settings)?;
-					Some(ForLoopStatementInitializer::Expression(expr))
-				};
+				let initializer =
+					if let Some(Token(TSXToken::Keyword(TSXKeyword::Const | TSXKeyword::Let), _)) =
+						peek
+					{
+						let declaration =
+							VariableDeclaration::from_reader(reader, state, settings)?;
+						Some(ForLoopStatementInitializer::VariableDeclaration(declaration))
+					} else if let Some(Token(TSXToken::Keyword(TSXKeyword::Var), _)) = peek {
+						let stmt = VarVariableStatement::from_reader(reader, state, settings)?;
+						Some(ForLoopStatementInitializer::VarStatement(stmt))
+					} else if let Some(Token(TSXToken::SemiColon, _)) = peek {
+						None
+					} else {
+						let expr = MultipleExpression::from_reader(reader, state, settings)?;
+						Some(ForLoopStatementInitializer::Expression(expr))
+					};
+
 				reader.expect_next(TSXToken::SemiColon)?;
 				let condition = if !matches!(reader.peek(), Some(Token(TSXToken::SemiColon, _))) {
-					Some(Expression::from_reader(reader, state, settings)?)
+					Some(MultipleExpression::from_reader(reader, state, settings)?)
 				} else {
 					None
 				};
 				reader.expect_next(TSXToken::SemiColon)?;
 				let afterthought =
 					if !matches!(reader.peek(), Some(Token(TSXToken::CloseParentheses, _))) {
-						Some(Expression::from_reader(reader, state, settings)?)
+						Some(MultipleExpression::from_reader(reader, state, settings)?)
 					} else {
 						None
 					};
@@ -198,7 +255,7 @@ impl ASTNode for ForLoopCondition {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		buf.push('(');
@@ -224,11 +281,14 @@ impl ASTNode for ForLoopCondition {
 			Self::Statements { initializer, condition, afterthought } => {
 				if let Some(initializer) = initializer {
 					match initializer {
-						ForLoopStatementInitializer::Statement(stmt) => {
+						ForLoopStatementInitializer::VariableDeclaration(stmt) => {
 							stmt.to_string_from_buffer(buf, settings, depth)
 						}
 						ForLoopStatementInitializer::Expression(expr) => {
 							expr.to_string_from_buffer(buf, settings, depth);
+						}
+						ForLoopStatementInitializer::VarStatement(stmt) => {
+							stmt.to_string_from_buffer(buf, settings, depth)
 						}
 					}
 				}

--- a/parser/src/statements/if_statement.rs
+++ b/parser/src/statements/if_statement.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
 
 use crate::{
-	block::BlockOrSingleStatement, expressions::MultipleExpression, ParseSettings, TSXKeyword,
+	block::BlockOrSingleStatement, expressions::MultipleExpression, ParseOptions, TSXKeyword,
 };
+use iterator_endiate::EndiateIteratorExt;
 use visitable_derive::Visitable;
 
 use super::{ASTNode, ParseResult, Span, TSXToken, Token, TokenReader};
@@ -39,7 +40,7 @@ impl ASTNode for IfStatement {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::If))?;
 		reader.expect_next(TSXToken::OpenParentheses)?;
@@ -80,7 +81,7 @@ impl ASTNode for IfStatement {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		buf.push_str("if");
@@ -90,9 +91,22 @@ impl ASTNode for IfStatement {
 		buf.push(')');
 		settings.add_gap(buf);
 		self.inner.to_string_from_buffer(buf, settings, depth + 1);
-		for else_statement in self.else_conditions.iter() {
+		if !settings.pretty
+			&& matches!(self.inner, BlockOrSingleStatement::SingleStatement(_))
+			&& (!self.else_conditions.is_empty() || self.trailing_else.is_some())
+		{
+			buf.push(';');
+		}
+
+		for (at_end, else_statement) in self.else_conditions.iter().endiate() {
 			settings.add_gap(buf);
 			else_statement.to_string_from_buffer(buf, settings, depth);
+			if !settings.pretty
+				&& matches!(else_statement.inner, BlockOrSingleStatement::SingleStatement(_))
+				&& at_end
+			{
+				buf.push(';');
+			}
 		}
 		if let Some(else_statement) = &self.trailing_else {
 			settings.add_gap(buf);
@@ -105,7 +119,7 @@ impl ASTNode for ConditionalElseStatement {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		let else_position = reader.expect_next(TSXToken::Keyword(TSXKeyword::Else))?;
 		Self::from_reader_sub_without_else(reader, state, settings, else_position)
@@ -118,7 +132,7 @@ impl ASTNode for ConditionalElseStatement {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		buf.push_str("else if");
@@ -135,7 +149,7 @@ impl ConditionalElseStatement {
 	fn from_reader_sub_without_else(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 		else_position: Span,
 	) -> ParseResult<Self> {
 		reader.expect_next(TSXToken::Keyword(TSXKeyword::If))?;
@@ -155,7 +169,7 @@ impl ASTNode for UnconditionalElseStatement {
 	fn from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> ParseResult<Self> {
 		let else_position = reader.expect_next(TSXToken::Keyword(TSXKeyword::Else))?;
 		Self::from_reader_sub_without_else(reader, state, settings, else_position)
@@ -168,10 +182,13 @@ impl ASTNode for UnconditionalElseStatement {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		buf.push_str("else");
+		if !settings.pretty && matches!(self.inner, BlockOrSingleStatement::SingleStatement(_)) {
+			buf.push(' ');
+		}
 		settings.add_gap(buf);
 		self.inner.to_string_from_buffer(buf, settings, depth + 1);
 	}
@@ -181,7 +198,7 @@ impl UnconditionalElseStatement {
 	fn from_reader_sub_without_else(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 		else_position: Span,
 	) -> ParseResult<Self> {
 		let statements = BlockOrSingleStatement::from_reader(reader, state, settings)?;

--- a/parser/src/statements/switch_statement.rs
+++ b/parser/src/statements/switch_statement.rs
@@ -6,7 +6,7 @@ use tokenizer_lib::Token;
 use visitable_derive::Visitable;
 
 use crate::{
-	errors::parse_lexing_error, ASTNode, Expression, ParseSettings, Statement, TSXKeyword, TSXToken,
+	errors::parse_lexing_error, ASTNode, Expression, ParseOptions, Statement, TSXKeyword, TSXToken,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
@@ -32,7 +32,7 @@ impl ASTNode for SwitchStatement {
 	fn from_reader(
 		reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &ParseSettings,
+		settings: &ParseOptions,
 	) -> Result<Self, crate::ParseError> {
 		let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::Switch))?;
 		reader.expect_next(crate::TSXToken::OpenParentheses)?;
@@ -87,7 +87,7 @@ impl ASTNode for SwitchStatement {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		buf.push_str("switch");

--- a/parser/src/statements/while_statement.rs
+++ b/parser/src/statements/while_statement.rs
@@ -21,7 +21,7 @@ impl ASTNode for WhileStatement {
 	fn from_reader(
 		reader: &mut impl tokenizer_lib::TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &crate::ParseSettings,
+		settings: &crate::ParseOptions,
 	) -> Result<Self, crate::ParseError> {
 		let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::While))?;
 		reader.expect_next(TSXToken::OpenParentheses)?;
@@ -34,7 +34,7 @@ impl ASTNode for WhileStatement {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		buf.push_str("while");
@@ -65,7 +65,7 @@ impl ASTNode for DoWhileStatement {
 	fn from_reader(
 		reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &crate::ParseSettings,
+		settings: &crate::ParseOptions,
 	) -> Result<Self, crate::ParseError> {
 		let start_span = reader.expect_next(TSXToken::Keyword(TSXKeyword::Do))?;
 		let inner = BlockOrSingleStatement::from_reader(reader, state, settings)?;
@@ -79,7 +79,7 @@ impl ASTNode for DoWhileStatement {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		buf.push_str("do");

--- a/parser/src/types/enum_declaration.rs
+++ b/parser/src/types/enum_declaration.rs
@@ -25,7 +25,7 @@ impl ASTNode for EnumDeclaration {
 	fn from_reader(
 		reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &crate::ParseSettings,
+		settings: &crate::ParseOptions,
 	) -> Result<Self, crate::ParseError> {
 		let const_pos = reader
 			.conditional_next(|tok| matches!(tok, TSXToken::Keyword(TSXKeyword::Const)))
@@ -59,7 +59,7 @@ impl ASTNode for EnumDeclaration {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		if self.is_constant {
@@ -102,7 +102,7 @@ impl ASTNode for EnumMember {
 	fn from_reader(
 		reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &crate::ParseSettings,
+		settings: &crate::ParseOptions,
 	) -> Result<Self, crate::ParseError> {
 		let (name, start_pos) =
 			token_as_identifier(reader.next().ok_or_else(parse_lexing_error)?, "Enum variant")?;
@@ -123,7 +123,7 @@ impl ASTNode for EnumMember {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		match self {

--- a/parser/src/types/namespace.rs
+++ b/parser/src/types/namespace.rs
@@ -11,7 +11,7 @@ impl crate::ASTNode for Namespace {
 	fn from_reader(
 		reader: &mut impl tokenizer_lib::TokenReader<crate::TSXToken, source_map::Span>,
 		state: &mut crate::ParsingState,
-		settings: &crate::ParseSettings,
+		settings: &crate::ParseOptions,
 	) -> crate::ParseResult<Self> {
 		reader.expect_next(crate::TSXToken::Keyword(crate::TSXKeyword::Namespace))?;
 		let (namespace_name, _) = crate::tokens::token_as_identifier(
@@ -38,7 +38,7 @@ impl crate::ASTNode for Namespace {
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		_buf: &mut T,
-		_settings: &crate::ToStringSettings,
+		_settings: &crate::ToStringOptions,
 		_depth: u8,
 	) {
 		todo!()

--- a/parser/src/types/type_alias.rs
+++ b/parser/src/types/type_alias.rs
@@ -1,14 +1,13 @@
 use source_map::Span;
 
-use crate::{ASTNode, TSXToken, TypeDeclaration, TypeId, TypeReference};
+use crate::{ASTNode, TSXToken, TypeAnnotation, TypeDeclaration};
 
 /// e.g. `type NumberArray = Array<number>`
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub struct TypeAlias {
 	pub type_name: TypeDeclaration,
-	pub type_expression: TypeReference,
-	pub type_id: TypeId,
+	pub type_expression: TypeAnnotation,
 	position: Span,
 }
 
@@ -20,20 +19,20 @@ impl ASTNode for TypeAlias {
 	fn from_reader(
 		reader: &mut impl tokenizer_lib::TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
-		settings: &crate::ParseSettings,
+		settings: &crate::ParseOptions,
 	) -> crate::ParseResult<Self> {
 		let start = reader.expect_next(TSXToken::Keyword(crate::TSXKeyword::Type))?;
 		let type_name = TypeDeclaration::from_reader(reader, state, settings)?;
 		reader.expect_next(TSXToken::Assign)?;
-		let type_expression = TypeReference::from_reader(reader, state, settings)?;
+		let type_expression = TypeAnnotation::from_reader(reader, state, settings)?;
 		let position = start.union(&type_expression.get_position());
-		Ok(Self { type_name, type_expression, type_id: TypeId::new(), position })
+		Ok(Self { type_name, type_expression, position })
 	}
 
 	fn to_string_from_buffer<T: source_map::ToString>(
 		&self,
 		buf: &mut T,
-		settings: &crate::ToStringSettings,
+		settings: &crate::ToStringOptions,
 		depth: u8,
 	) {
 		if settings.include_types {

--- a/parser/tests/cursors.rs
+++ b/parser/tests/cursors.rs
@@ -1,6 +1,5 @@
 use ezno_parser::{
-	expressions::ExpressionId, ASTNode, CursorId, Expression, SourceId, Span, Statement,
-	StatementOrDeclaration,
+	ASTNode, CursorId, Expression, SourceId, Span, Statement, StatementOrDeclaration,
 };
 
 #[test]
@@ -52,14 +51,9 @@ fn cursor_at_property_access() {
 	assert_eq!(
 		expression,
 		Expression::PropertyAccess {
-			parent: Box::new(Expression::VariableReference(
-				"x".to_owned(),
-				Span::NULL_SPAN,
-				ExpressionId::NULL
-			)),
+			parent: Box::new(Expression::VariableReference("x".to_owned(), Span::NULL_SPAN,)),
 			property: ezno_parser::PropertyReference::Cursor(CursorId(0, Default::default())),
 			position: Span::NULL_SPAN,
-			expression_id: ExpressionId::NULL,
 			is_optional: false
 		}
 	);

--- a/parser/tests/statements.rs
+++ b/parser/tests/statements.rs
@@ -1,4 +1,5 @@
-use ezno_parser::{ASTNode, Module, SourceId};
+use ezno_parser::{ASTNode, Module, SourceId, ToStringOptions};
+use pretty_assertions::assert_eq;
 
 #[test]
 fn statements() {
@@ -26,6 +27,9 @@ try {
     doThing()
 } catch (e) {
     console.error(e)
+}
+interface X {
+    a: string
 }"#
 	.trim_start();
 
@@ -33,7 +37,7 @@ try {
 		Module::from_string(input.to_owned(), Default::default(), SourceId::NULL, None, Vec::new())
 			.unwrap();
 
-	let output = module.to_string(&Default::default());
+	let output = module.to_string(&ToStringOptions::typescript());
 
 	assert_eq!(output, input);
 }

--- a/parser/tests/visiting.rs
+++ b/parser/tests/visiting.rs
@@ -1,7 +1,8 @@
 use ezno_parser::{
 	statements::UnconditionalElseStatement, ASTNode, Expression, Module, SourceId, Span, Statement,
-	ToStringSettings, VisitSettings, VisitorMut, VisitorsMut,
+	ToStringOptions, VisitSettings, VisitorMut, VisitorsMut,
 };
+use pretty_assertions::assert_eq;
 
 #[test]
 fn visiting() {
@@ -27,9 +28,9 @@ fn visiting() {
 	};
 	module.visit_mut(&mut visitors, &mut (), &VisitSettings::default());
 
-	let output = module.to_string(&ToStringSettings::minified());
+	let output = module.to_string(&ToStringOptions::minified());
 
-	let expected = r#"const x="HELLO WORLD";function y(){if(condition){do_thing("HELLO WORLD"+" TEST")}else{console.log("ELSE!")}}"#;
+	let expected = r#"const x="HELLO WORLD";function y(){if(condition){do_thing("HELLO WORLD"+" TEST")}else console.log("ELSE!")}"#;
 	assert_eq!(output, expected);
 }
 
@@ -38,7 +39,7 @@ struct MakeStringsUppercase;
 
 impl VisitorMut<Expression, ()> for MakeStringsUppercase {
 	fn visit_mut(&mut self, item: &mut Expression, _data: &mut (), _chain: &ezno_parser::Chain) {
-		if let Expression::StringLiteral(content, _quoted, _, _) = item {
+		if let Expression::StringLiteral(content, _quoted, _) = item {
 			*content = content.to_uppercase();
 		}
 	}


### PR DESCRIPTION
Updates include
- Fixes #1 via line break index recording
- Remove identifiers from `Expression` and `TypeAnnotation` (and elsewhere). Using position information suffices
- Other small fixes 
    - More support for for loops
    - hex/binary/octal number parsing
    - Interface was missing as a keyword for a declaration
    - Missing items in `From` implementations
    - Renaming items