### PR TITLE
Fixes to expression parsing

### DIFF
--- a/parser/src/declarations/classes/class_member.rs
+++ b/parser/src/declarations/classes/class_member.rs
@@ -13,6 +13,7 @@ use crate::{
 
 /// The variable id's of these is handled by their [PropertyKey]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub enum ClassMember {
 	Constructor(ClassConstructor),
 	Method(Option<Keyword<tsx_keywords::Static>>, ClassFunction),
@@ -29,6 +30,7 @@ pub struct ClassFunctionBase;
 pub type ClassFunction = FunctionBase<ClassFunctionBase>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub struct ClassProperty {
 	pub readonly_keyword: Option<Keyword<tsx_keywords::Readonly>>,
 	pub key: WithComment<PropertyKey<PublicOrPrivate>>,

--- a/parser/src/declarations/classes/mod.rs
+++ b/parser/src/declarations/classes/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 use tokenizer_lib::{Token, TokenReader};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub struct ClassDeclaration<T: ExpressionOrStatementPosition> {
 	pub class_keyword: Keyword<tsx_keywords::Class>,
 	pub name: T::Name,
@@ -23,18 +24,6 @@ pub struct ClassDeclaration<T: ExpressionOrStatementPosition> {
 	pub implements: Option<Vec<TypeAnnotation>>,
 	pub members: Vec<Decorated<ClassMember>>,
 	pub position: Span,
-}
-
-#[cfg(feature = "self-rust-tokenize")]
-impl<T: ExpressionOrStatementPosition> self_rust_tokenize::SelfRustTokenize
-	for ClassDeclaration<T>
-{
-	fn append_to_token_stream(
-		&self,
-		_token_stream: &mut self_rust_tokenize::proc_macro2::TokenStream,
-	) {
-		todo!()
-	}
 }
 
 impl<U: ExpressionOrStatementPosition + Debug + PartialEq + Eq + Clone + 'static> ASTNode

--- a/parser/src/declarations/export.rs
+++ b/parser/src/declarations/export.rs
@@ -102,7 +102,7 @@ impl ASTNode for ExportDeclaration {
 					Ok(Self::Variable { exported: Exportable::TypeAlias(type_alias), position })
 				}
 				Token(token, _) => {
-					unimplemented!("Token after export '{:?}'", token)
+					todo!("Token after export '{:?}'", token)
 				}
 			}
 		}

--- a/parser/src/declarations/mod.rs
+++ b/parser/src/declarations/mod.rs
@@ -161,24 +161,32 @@ impl crate::ASTNode for Declaration {
 					decorators,
 					declare_span,
 				)
-				.map(|ty_def_mod_stmt| match ty_def_mod_stmt {
+				.and_then(|ty_def_mod_stmt| match ty_def_mod_stmt {
 					TypeDefinitionModuleDeclaration::Variable(declare_var) => {
-						Declaration::DeclareVariable(declare_var)
+						Ok(Declaration::DeclareVariable(declare_var))
 					}
 					TypeDefinitionModuleDeclaration::Function(declare_func) => {
-						Declaration::DeclareFunction(declare_func)
+						Ok(Declaration::DeclareFunction(declare_func))
 					}
-					TypeDefinitionModuleDeclaration::Class(_) => todo!("error"),
-					TypeDefinitionModuleDeclaration::Interface(_) => {
-						todo!("error")
-					}
-					TypeDefinitionModuleDeclaration::TypeAlias(_) => todo!("error"),
-					TypeDefinitionModuleDeclaration::Namespace(_) => todo!(),
-					TypeDefinitionModuleDeclaration::Comment(_) => unreachable!(),
-					TypeDefinitionModuleDeclaration::LocalTypeAlias(_) => todo!(),
-					TypeDefinitionModuleDeclaration::LocalVariableDeclaration(_) => {
-						todo!()
-					}
+					TypeDefinitionModuleDeclaration::Class(item) => Err(ParseError::new(
+						ParseErrors::InvalidDeclareItem("class"),
+						item.get_position().into_owned(),
+					)),
+					TypeDefinitionModuleDeclaration::Interface(item) => Err(ParseError::new(
+						ParseErrors::InvalidDeclareItem("interface"),
+						item.get_position().into_owned(),
+					)),
+					TypeDefinitionModuleDeclaration::TypeAlias(item) => Err(ParseError::new(
+						ParseErrors::InvalidDeclareItem("type alias"),
+						item.get_position().into_owned(),
+					)),
+					TypeDefinitionModuleDeclaration::Namespace(item) => Err(ParseError::new(
+						ParseErrors::InvalidDeclareItem("namespace"),
+						item.get_position().into_owned(),
+					)),
+					TypeDefinitionModuleDeclaration::LocalTypeAlias(_)
+					| TypeDefinitionModuleDeclaration::LocalVariableDeclaration(_)
+					| TypeDefinitionModuleDeclaration::Comment(_) => unreachable!(),
 				})
 			}
 			_ => {

--- a/parser/src/errors.rs
+++ b/parser/src/errors.rs
@@ -19,6 +19,7 @@ pub enum ParseErrors<'a> {
 	InvalidLHSAssignment,
 	LexingFailed,
 	ExpectedCatchOrFinally,
+	InvalidDeclareItem(&'static str),
 }
 
 #[allow(missing_docs)]
@@ -145,6 +146,9 @@ impl<'a> Display for ParseErrors<'a> {
 			ParseErrors::LexingFailed => {
 				// unreachable!("This should never be written"),
 				f.write_str("Lexing issue")
+			}
+			ParseErrors::InvalidDeclareItem(item) => {
+				write!(f, "Declare item '{item}' must be in .d.ts file")
 			}
 		}
 	}

--- a/parser/src/expressions/arrow_function.rs
+++ b/parser/src/expressions/arrow_function.rs
@@ -86,7 +86,7 @@ impl FunctionBased for ArrowFunctionBase {
 		if let (true, [Parameter { name, .. }]) =
 			(parameters.rest_parameter.is_none(), parameters.parameters.as_slice())
 		{
-			if let VariableField::Name(name, ..) = name.get_ast() {
+			if let VariableField::Name(name, ..) = name.get_ast_ref() {
 				buf.push_str(name.as_str());
 			} else {
 				parameters.to_string_from_buffer(buf, settings, depth);
@@ -175,7 +175,7 @@ impl ArrowFunction {
 
 /// For [ArrowFunction] and [crate::MatchArm] bodies
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
-// #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub enum ExpressionOrBlock {
 	Expression(Box<Expression>),
 	Block(Block),

--- a/parser/src/expressions/assignments.rs
+++ b/parser/src/expressions/assignments.rs
@@ -97,9 +97,11 @@ impl TryFrom<Expression> for VariableOrPropertyAccess {
 			Expression::VariableReference(name, position) => Ok(Self::Variable(name, position)),
 			Expression::PropertyAccess { parent, position, property, is_optional } => {
 				if is_optional {
-					todo!()
+					// Still a proposal :(
+					Err(ParseError::new(crate::ParseErrors::InvalidLHSAssignment, position))
+				} else {
+					Ok(Self::PropertyAccess { parent, position, property })
 				}
-				Ok(Self::PropertyAccess { parent, position, property })
 			}
 			Expression::Index { indexer, position, indexee } => {
 				Ok(Self::Index { indexer, position, indexee })

--- a/parser/src/expressions/mod.rs
+++ b/parser/src/expressions/mod.rs
@@ -21,9 +21,9 @@ use self::{
 
 use super::{
 	operators::{
-		BinaryOperator, Operator, UnaryOperator, COMMA_PRECEDENCE, CONSTRUCTOR_PRECEDENCE,
-		CONSTRUCTOR_WITHOUT_PARENTHESIS_PRECEDENCE, INDEX_PRECEDENCE, MEMBER_ACCESS_PRECEDENCE,
-		PARENTHESIZED_EXPRESSION_AND_LITERAL_PRECEDENCE, TERNARY_PRECEDENCE,
+		BinaryOperator, Operator, UnaryOperator, COMMA_PRECEDENCE, CONDITIONAL_TERNARY_PRECEDENCE,
+		CONSTRUCTOR_PRECEDENCE, CONSTRUCTOR_WITHOUT_PARENTHESIS_PRECEDENCE, INDEX_PRECEDENCE,
+		MEMBER_ACCESS_PRECEDENCE, PARENTHESIZED_EXPRESSION_AND_LITERAL_PRECEDENCE,
 	},
 	tokens::token_as_identifier,
 	ASTNode, Block, FunctionBase, JSXRoot, ParseError, ParseOptions, Span, TSXToken, Token,
@@ -140,7 +140,7 @@ pub enum Expression {
 		position: Span,
 	},
 	/// e.g `... ? ... ? ...`
-	TernaryExpression {
+	ConditionalTernaryExpression {
 		condition: Box<Expression>,
 		truthy_result: Box<Expression>,
 		falsy_result: Box<Expression>,
@@ -206,7 +206,7 @@ impl ASTNode for Expression {
 			Self::Assignment { lhs, rhs, .. } => {
 				Cow::Owned(lhs.get_position().union(&rhs.get_position()))
 			}
-			Self::TernaryExpression { condition, falsy_result, .. } => {
+			Self::ConditionalTernaryExpression { condition, falsy_result, .. } => {
 				Cow::Owned(condition.get_position().union(&falsy_result.get_position()))
 			}
 			Self::BinaryAssignmentOperation { lhs, rhs, .. } => {
@@ -527,10 +527,10 @@ impl Expression {
 				Expression::JSXRoot(root)
 			}
 			Token(TSXToken::TemplateLiteralStart, start_pos) => {
-				return TemplateLiteral::from_reader_sub_start_with_tag(
+				let template_literal = TemplateLiteral::from_reader_sub_start_with_tag(
 					reader, state, settings, None, start_pos,
-				)
-				.map(Expression::TemplateLiteral);
+				)?;
+				Expression::TemplateLiteral(template_literal)
 			}
 			Token(TSXToken::Keyword(TSXKeyword::Function), span) => {
 				let header = FunctionHeader::VirginFunctionHeader {
@@ -704,7 +704,7 @@ impl Expression {
 				}
 				TSXToken::QuestionMark => {
 					if AssociativityDirection::RightToLeft
-						.should_return(parent_precedence, TERNARY_PRECEDENCE)
+						.should_return(parent_precedence, CONDITIONAL_TERNARY_PRECEDENCE)
 					{
 						return Ok(top);
 					}
@@ -712,7 +712,7 @@ impl Expression {
 					let lhs = Self::from_reader(reader, state, settings)?;
 					reader.expect_next(TSXToken::Colon)?;
 					let rhs = Self::from_reader(reader, state, settings)?;
-					top = Expression::TernaryExpression {
+					top = Expression::ConditionalTernaryExpression {
 						condition: Box::new(top),
 						truthy_result: Box::new(lhs),
 						falsy_result: Box::new(rhs),
@@ -912,7 +912,7 @@ impl Expression {
 							reader,
 							state,
 							settings,
-							parent_precedence,
+							operator.precedence(),
 						)?;
 
 						top = Expression::BinaryOperation {
@@ -932,7 +932,7 @@ impl Expression {
 							reader,
 							state,
 							settings,
-							parent_precedence,
+							operator.precedence(),
 						)?;
 						top = Expression::BinaryAssignmentOperation {
 							lhs: top.try_into()?,
@@ -995,7 +995,7 @@ impl Expression {
                 CONSTRUCTOR_WITHOUT_PARENTHESIS_PRECEDENCE
             }
             Self::Index { .. } => INDEX_PRECEDENCE,
-            Self::TernaryExpression { .. } => TERNARY_PRECEDENCE,
+            Self::ConditionalTernaryExpression { .. } => CONDITIONAL_TERNARY_PRECEDENCE,
             Self::PrefixComment(_, expression, _) | Self::PostfixComment(expression, _, _) => {
                 expression.get_precedence()
             }
@@ -1203,12 +1203,29 @@ impl Expression {
 			Self::TemplateLiteral(template_literal) => {
 				template_literal.to_string_from_buffer(buf, settings, depth)
 			}
-			Self::TernaryExpression { condition, truthy_result, falsy_result, .. } => {
-				condition.to_string_using_precedence(buf, settings, depth, TERNARY_PRECEDENCE);
+			Self::ConditionalTernaryExpression {
+				condition, truthy_result, falsy_result, ..
+			} => {
+				condition.to_string_using_precedence(
+					buf,
+					settings,
+					depth,
+					CONDITIONAL_TERNARY_PRECEDENCE,
+				);
 				buf.push_str(if settings.pretty { " ? " } else { "?" });
-				truthy_result.to_string_using_precedence(buf, settings, depth, TERNARY_PRECEDENCE);
+				truthy_result.to_string_using_precedence(
+					buf,
+					settings,
+					depth,
+					CONDITIONAL_TERNARY_PRECEDENCE,
+				);
 				buf.push_str(if settings.pretty { " : " } else { ":" });
-				falsy_result.to_string_using_precedence(buf, settings, depth, TERNARY_PRECEDENCE);
+				falsy_result.to_string_using_precedence(
+					buf,
+					settings,
+					depth,
+					CONDITIONAL_TERNARY_PRECEDENCE,
+				);
 			}
 			Self::Null(..) => buf.push_str("null"),
 			Self::IsExpression(is_expr) => is_expr.to_string_from_buffer(buf, settings, depth),
@@ -1383,7 +1400,7 @@ impl ASTNode for SpreadExpression {
 		match self {
 			SpreadExpression::Spread(_, pos) => Cow::Borrowed(pos),
 			SpreadExpression::NonSpread(ast) => ast.get_position(),
-			SpreadExpression::Empty => todo!(),
+			SpreadExpression::Empty => Cow::Owned(Span::NULL_SPAN),
 		}
 	}
 
@@ -1400,9 +1417,7 @@ impl ASTNode for SpreadExpression {
 				let position = start_pos.union(&expression.get_position());
 				Ok(Self::Spread(expression, position))
 			}
-			TSXToken::Comma => {
-				todo!("EMpty?");
-			}
+			TSXToken::Comma => Ok(Self::Empty),
 			_ => Ok(Self::NonSpread(Expression::from_reader(reader, state, settings)?)),
 		}
 	}

--- a/parser/src/expressions/object_literal.rs
+++ b/parser/src/expressions/object_literal.rs
@@ -228,10 +228,14 @@ impl ASTNode for ObjectLiteralMember {
 				}
 				if matches!(reader.peek(), Some(Token(TSXToken::Comma | TSXToken::CloseBrace, _))) {
 					// TODO fix
-					if let PropertyKey::Ident(name, position, _) = key.unwrap_ast() {
+					if let PropertyKey::Ident(name, position, _) = key.get_ast() {
 						Ok(Self::Shorthand(name, position))
 					} else {
-						todo!()
+						let Token(found, position) = reader.next().unwrap();
+						Err(ParseError::new(
+							ParseErrors::UnexpectedToken { expected: &[TSXToken::Colon], found },
+							position,
+						))
 					}
 				} else {
 					reader.expect_next(TSXToken::Colon)?;
@@ -271,7 +275,7 @@ impl ASTNode for ObjectLiteralMember {
 
 	fn get_position(&self) -> Cow<Span> {
 		match self {
-			Self::Method(..) => todo!(),
+			Self::Method(method) => method.get_position(),
 			Self::Shorthand(_, pos)
 			| Self::Property(_, _, pos)
 			| Self::SpreadExpression(_, pos) => Cow::Borrowed(pos),

--- a/parser/src/functions.rs
+++ b/parser/src/functions.rs
@@ -87,6 +87,7 @@ pub trait FunctionBased: Debug + Clone + PartialEq + Eq + Send + Sync {
 ///
 /// Note: the [PartialEq] implementation is based on syntactical representation rather than [FunctionId] equality
 #[derive(Debug, Clone, PartialEqExtras)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub struct FunctionBase<T: FunctionBased> {
 	pub header: T::Header,
 	pub name: T::Name,
@@ -95,16 +96,6 @@ pub struct FunctionBase<T: FunctionBased> {
 	pub return_type: Option<TypeAnnotation>,
 	pub body: T::Body,
 	pub position: Span,
-}
-
-#[cfg(feature = "self-rust-tokenize")]
-impl<T: FunctionBased> self_rust_tokenize::SelfRustTokenize for FunctionBase<T> {
-	fn append_to_token_stream(
-		&self,
-		_token_stream: &mut self_rust_tokenize::proc_macro2::TokenStream,
-	) {
-		todo!("fb to tokens")
-	}
 }
 
 impl<T: FunctionBased> Eq for FunctionBase<T> {}
@@ -224,11 +215,6 @@ impl<T: ExpressionOrStatementPosition> FunctionBased for GeneralFunctionBase<T> 
 	type Header = FunctionHeader;
 	type Name = T::Name;
 
-	// fn get_chain_variable(_this: &FunctionBase<Self>) -> crate::ChainVariable {
-	// 	todo!()
-	// 	// crate::ChainVariable::UnderExpressionFunctionBlock(self.base.body.1, self.expression_id)
-	// }
-
 	fn header_and_name_from_reader(
 		reader: &mut impl TokenReader<TSXToken, Span>,
 		state: &mut crate::ParsingState,
@@ -258,6 +244,7 @@ impl<T: ExpressionOrStatementPosition> FunctionBased for GeneralFunctionBase<T> 
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub enum FunctionHeader {
 	VirginFunctionHeader {
 		async_keyword: Option<Keyword<tsx_keywords::Async>>,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -522,6 +522,7 @@ impl NumberStructure {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, Default)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub enum GetSetGeneratorOrNone {
 	Get(Keyword<tsx_keywords::Get>),
 	Set(Keyword<tsx_keywords::Set>),

--- a/parser/src/operators.rs
+++ b/parser/src/operators.rs
@@ -12,16 +12,18 @@ use crate::{TSXKeyword, TSXToken};
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub enum BinaryOperator {
-    StrictEqual, StrictNotEqual, Equal, NotEqual,
-    Add, Subtract, Multiply, Divide, Modulo, Exponent,
-    GreaterThan, LessThan, LessThanEqual, GreaterThanEqual,
-
-    InstanceOf, In,
+	Add, Subtract, Multiply, Divide, Modulo, Exponent,
 
     BitwiseShiftLeft, BitwiseShiftRight, BitwiseShiftRightUnsigned,
     BitwiseAnd, BitwiseXOr, BitwiseOr,
+
+    StrictEqual, StrictNotEqual, Equal, NotEqual,
+    GreaterThan, LessThan, LessThanEqual, GreaterThanEqual,
+
     LogicalAnd, LogicalOr,
     NullCoalescing, 
+
+    InstanceOf, In,
 
     /// Non standard
     Divides,
@@ -39,7 +41,7 @@ pub enum BinaryAssignmentOperator {
     AddAssign, SubtractAssign, MultiplyAssign, DivideAssign, ModuloAssign, ExponentAssign,
     LogicalAndAssign, LogicalOrAssign,
     BitwiseShiftLeftAssign, BitwiseShiftRightAssign, BitwiseShiftRightUnsigned, 
-    BitwiseAndAssign, BitwiseXorAssign, BitwiseOrAssign,
+    BitwiseAndAssign, BitwiseXOrAssign, BitwiseOrAssign,
 }
 
 #[rustfmt::skip]
@@ -240,7 +242,7 @@ impl Operator for BinaryAssignmentOperator {
 			BinaryAssignmentOperator::BitwiseShiftRightAssign => ">>=",
 			BinaryAssignmentOperator::BitwiseShiftRightUnsigned => ">>>=",
 			BinaryAssignmentOperator::BitwiseAndAssign => "&=",
-			BinaryAssignmentOperator::BitwiseXorAssign => "^=",
+			BinaryAssignmentOperator::BitwiseXOrAssign => "^=",
 			BinaryAssignmentOperator::BitwiseOrAssign => "|=",
 			BinaryAssignmentOperator::LogicalAndAssign => "&&=",
 			BinaryAssignmentOperator::LogicalOrAssign => "||=",
@@ -327,7 +329,7 @@ impl From<BinaryAssignmentOperator> for BinaryOperator {
 				BinaryOperator::BitwiseShiftRightUnsigned
 			}
 			BinaryAssignmentOperator::BitwiseAndAssign => BinaryOperator::BitwiseAnd,
-			BinaryAssignmentOperator::BitwiseXorAssign => BinaryOperator::BitwiseXOr,
+			BinaryAssignmentOperator::BitwiseXOrAssign => BinaryOperator::BitwiseXOr,
 			BinaryAssignmentOperator::BitwiseOrAssign => BinaryOperator::BitwiseOr,
 		}
 	}
@@ -347,7 +349,7 @@ impl TryFrom<&TSXToken> for BinaryAssignmentOperator {
 			TSXToken::LogicalOrAssign => Ok(BinaryAssignmentOperator::LogicalOrAssign),
 			TSXToken::BitwiseAndAssign => Ok(BinaryAssignmentOperator::BitwiseAndAssign),
 			TSXToken::BitwiseOrAssign => Ok(BinaryAssignmentOperator::BitwiseOrAssign),
-			TSXToken::BitwiseXorAssign => Ok(BinaryAssignmentOperator::BitwiseXorAssign),
+			TSXToken::BitwiseXorAssign => Ok(BinaryAssignmentOperator::BitwiseXOrAssign),
 			TSXToken::BitwiseShiftLeftAssign => {
 				Ok(BinaryAssignmentOperator::BitwiseShiftLeftAssign)
 			}
@@ -469,7 +471,7 @@ pub(crate) const COMMA_PRECEDENCE: u8 = 1;
 pub(crate) const MEMBER_ACCESS_PRECEDENCE: u8 = 18;
 pub(crate) const OPTIONAL_CHAINING_PRECEDENCE: u8 = 18;
 pub(crate) const INDEX_PRECEDENCE: u8 = 18;
-pub(crate) const TERNARY_PRECEDENCE: u8 = 4;
+pub(crate) const CONDITIONAL_TERNARY_PRECEDENCE: u8 = 2;
 pub(crate) const FUNCTION_CALL_PRECEDENCE: u8 = 18;
 pub(crate) const CONSTRUCTOR_PRECEDENCE: u8 = 18;
 pub(crate) const CONSTRUCTOR_WITHOUT_PARENTHESIS_PRECEDENCE: u8 = 17;

--- a/parser/src/parameters.rs
+++ b/parser/src/parameters.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub struct Parameter {
 	pub name: WithComment<VariableField<VariableFieldInSourceCode>>,
 	pub type_annotation: Option<TypeAnnotation>,
@@ -33,12 +34,14 @@ impl Parameter {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub enum ParameterData {
 	Optional,
 	WithDefaultValue(Box<Expression>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub struct SpreadParameter {
 	pub name: VariableIdentifier,
 	pub type_annotation: Option<TypeAnnotation>,
@@ -47,6 +50,7 @@ pub struct SpreadParameter {
 /// TODO need to something special to not enable `OptionalFunctionParameter::WithValue` in interfaces and other
 /// type structure
 #[derive(Debug, Clone, PartialEqExtras, Visitable)]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub struct FunctionParameters {
 	pub parameters: Vec<Parameter>,
 	pub rest_parameter: Option<Box<SpreadParameter>>,

--- a/parser/src/types/namespace.rs
+++ b/parser/src/types/namespace.rs
@@ -5,7 +5,7 @@ pub struct Namespace(String, Vec<crate::TypeDefinitionModuleDeclaration>);
 
 impl crate::ASTNode for Namespace {
 	fn get_position(&self) -> Cow<source_map::Span> {
-		unimplemented!()
+		todo!()
 	}
 
 	fn from_reader(

--- a/parser/src/types/type_annotations.rs
+++ b/parser/src/types/type_annotations.rs
@@ -248,7 +248,7 @@ impl ASTNode for TypeAnnotation {
 					}
 				}
 			}
-			Self::NamespacedName(..) => unimplemented!(),
+			Self::NamespacedName(..) => todo!(),
 			Self::ObjectLiteral(members, _) => {
 				buf.push('{');
 				for (at_end, member) in members.iter().endiate() {
@@ -282,8 +282,8 @@ impl ASTNode for TypeAnnotation {
 				buf.push(']');
 			}
 
-			Self::Index(..) => unimplemented!(),
-			Self::KeyOf(..) => unimplemented!(),
+			Self::Index(..) => todo!(),
+			Self::KeyOf(..) => todo!(),
 			Self::Conditional { condition, resolve_true, resolve_false, .. } => {
 				condition.to_string_from_buffer(buf, settings, depth);
 				buf.push_str(" ? ");

--- a/parser/src/visiting.rs
+++ b/parser/src/visiting.rs
@@ -258,6 +258,8 @@ mod structures {
 	#[derive(Debug, Clone)]
 	pub enum ChainVariable {
 		Module(SourceId),
+		Function(Span),
+		Block(Span),
 	}
 
 	/// The current location in the AST
@@ -289,12 +291,11 @@ mod structures {
 		}
 
 		pub fn get_module(&self) -> SourceId {
-			todo!()
-			// if let ChainVariable::UnderModule(_, source) = self.0.first().unwrap() {
-			// 	*source
-			// } else {
-			// 	panic!()
-			// }
+			if let ChainVariable::Module(source) = self.0.first().unwrap() {
+				source.to_owned()
+			} else {
+				SourceId::NULL
+			}
 		}
 
 		// TODO get function root. Aka last thing before in top level scope or
@@ -356,7 +357,7 @@ mod structures {
 				| ImmutableVariableOrPropertyPart::ObjectDestructuringMember(_) => None,
 				ImmutableVariableOrPropertyPart::ClassName(name, _) => *name,
 				ImmutableVariableOrPropertyPart::ObjectPropertyKey(property) => {
-					match property.get_ast() {
+					match property.get_ast_ref() {
 						PropertyKey::Ident(ident, _, _) | PropertyKey::StringLiteral(ident, _) => {
 							Some(ident.as_str())
 						}
@@ -364,7 +365,7 @@ mod structures {
 					}
 				}
 				ImmutableVariableOrPropertyPart::ClassPropertyKey(property) => {
-					match property.get_ast() {
+					match property.get_ast_ref() {
 						PropertyKey::Ident(ident, _, _) | PropertyKey::StringLiteral(ident, _) => {
 							Some(ident.as_str())
 						}


### PR DESCRIPTION
Fixes: to
- Conditional ternary parsing issue
- Template literals should eagerily return
- FunctionBase gets SelfTokenize
- ast-explorer should create files 
- Less `todo!()`s in the parser