### PR TITLE
Add call checking behavior

### DIFF
--- a/checker/definitions/internal.d.ts
+++ b/checker/definitions/internal.d.ts
@@ -2,6 +2,7 @@ declare function debug_context(): void performs const debug_context;
 declare function print_type(): void performs const print_type;
 declare function debug_type(): void performs const debug_type;
 declare function debug_effects(): void performs const debug_effects;
+declare function is_dependent(): void performs const is_dependent;
 
 interface Array<T> {
     length: number;

--- a/checker/specification/specification.md
+++ b/checker/specification/specification.md
@@ -481,7 +481,7 @@ isNegative(4) satisfies boolean
 - Expected number, found "negative"
 - Expected boolean, found "positive"
 
-#### Conditional update
+#### *Conclusive* conditional update
 
 ```ts
 let a: number = 0
@@ -498,6 +498,46 @@ a satisfies 3
 
 - Expected 2, found 0
 - Expected 3, found 1
+
+#### *Inconclusive* conditional update
+
+```ts
+declare var value: string;
+let a: string | number = 0
+function conditional(v: string) {
+	if (v === "value") {
+		a = "hi"
+	}
+}
+conditional(value);
+a satisfies string
+```
+
+- Expected string, found "hi" | 0
+
+#### If else if nesting
+
+```ts
+function print_number(value: number) {
+    if (value === 0) {
+        return "zero"
+    } else if (value === 1) {
+        return "one"
+    } else {
+        return "some number"
+    }
+}
+
+print_number(0) satisfies "some number"
+print_number(1) satisfies "ONE"
+print_number(100) satisfies "100"
+print_number(-1) satisfies "TWO"
+```
+
+- Expected "some number", found "zero"
+- Expected "ONE", found "one"
+- Expected "100", found "some number"
+- Expected "TWO", found "some number"
 
 #### Operator short circuiting
 

--- a/checker/src/behavior/constant_functions.rs
+++ b/checker/src/behavior/constant_functions.rs
@@ -16,7 +16,7 @@ pub(crate) fn call_constant_function(
 	this_arg: Option<TypeId>,
 	arguments: &[SynthesizedArgument],
 	types: &mut TypeStore,
-	context: &mut Environment,
+	environment: &Environment,
 ) -> Result<ConstantResult, ()> {
 	// crate::utils::notify!("Calling constant function {} with {:?}", name, arguments);
 	// TODO as parameter
@@ -80,7 +80,7 @@ pub(crate) fn call_constant_function(
 		"print_type" | "debug_type" => {
 			let debug = id == "debug_type";
 			let ty = arguments.first().unwrap().into_type().unwrap();
-			let ty_as_string = print_type(ty, types, &context.into_general_context(), debug);
+			let ty_as_string = print_type(ty, types, &environment.into_general_context(), debug);
 			Ok(ConstantResult::Diagnostic(format!("Type is: {ty_as_string}")))
 		}
 		"debug_effects" => {
@@ -92,7 +92,11 @@ pub(crate) fn call_constant_function(
 				Ok(ConstantResult::Diagnostic("not a function".to_owned()))
 			}
 		}
-		"debug_context" => Ok(ConstantResult::Diagnostic(context.debug())),
+		"debug_context" => Ok(ConstantResult::Diagnostic(environment.debug())),
+		"is_dependent" => Ok(ConstantResult::Diagnostic(format!(
+			"is dependent {:?}",
+			types.get_type_by_id(arguments.first().unwrap().into_type().unwrap()).is_dependent()
+		))),
 		func => panic!("Unknown/unimplemented const function {func}"),
 	}
 }

--- a/checker/src/behavior/functions.rs
+++ b/checker/src/behavior/functions.rs
@@ -76,7 +76,7 @@ impl RegisterBehavior for RegisterOnExisting {
 		));
 		let variable_id = environment.variables.get(&self.0).unwrap().declared_at.clone();
 		let variable_id = VariableId(variable_id.source, variable_id.start);
-		environment.variable_current_value.insert(variable_id, ty);
+		environment.facts.variable_current_value.insert(variable_id, ty);
 	}
 }
 

--- a/checker/src/behavior/objects.rs
+++ b/checker/src/behavior/objects.rs
@@ -1,5 +1,5 @@
 use crate::{
-	context::Environment,
+	context::{facts::Facts, Environment},
 	types::{properties::Property, TypeStore},
 	TypeId,
 };
@@ -10,17 +10,13 @@ pub struct ObjectBuilder {
 }
 
 impl ObjectBuilder {
-	pub fn new(
-		prototype: Option<TypeId>,
-		types: &mut TypeStore,
-		environment: &mut Environment,
-	) -> Self {
-		let object = environment.new_object(types, prototype);
-		Self { object }
+	pub fn new(prototype: Option<TypeId>, types: &mut TypeStore, facts: &mut Facts) -> Self {
+		let is_under_dyn = false;
+		Self { object: facts.new_object(prototype, types, is_under_dyn) }
 	}
 
 	pub fn append(&mut self, environment: &mut Environment, under: TypeId, value: Property) {
-		environment.register_property(self.object, under, value, true)
+		environment.facts.register_property(self.object, under, value, true)
 	}
 
 	pub fn build_object(self) -> TypeId {

--- a/checker/src/behavior/template_literal.rs
+++ b/checker/src/behavior/template_literal.rs
@@ -48,8 +48,11 @@ pub fn synthesize_template_literal<
 	}
 
 	if let Some(tag) = tag {
-		let mut static_parts =
-			ObjectBuilder::new(Some(TypeId::ARRAY_TYPE), &mut checking_data.types, environment);
+		let mut static_parts = ObjectBuilder::new(
+			Some(TypeId::ARRAY_TYPE),
+			&mut checking_data.types,
+			&mut environment.facts,
+		);
 
 		// TODO position
 		let mut arguments = Vec::<SynthesizedArgument>::new();

--- a/checker/src/context/calling.rs
+++ b/checker/src/context/calling.rs
@@ -1,0 +1,45 @@
+use std::cell::RefCell;
+
+use crate::Environment;
+use super::facts::Facts;
+
+
+
+pub struct CheckThings;
+
+impl CallCheckingBehavior for CheckThings {
+	const CHECK_TYPES: bool = true;
+
+	fn get_top_level_facts<'a>(&'a mut self, environment: &'a mut Environment) -> &'a mut Facts {
+		&mut environment.facts
+	}
+}
+
+/// For anything that might involve a call, including gets, sets and actual calls
+pub(crate) trait CallCheckingBehavior {
+	// TODO
+	const CHECK_TYPES: bool;
+
+	fn get_top_level_facts<'a>(&'a mut self, environment: &'a mut Environment) -> &'a mut Facts;
+}
+
+pub(crate) enum TargetType {
+	/// TODO currently refcell to
+	Conditional(RefCell<Facts>),
+	/// TODO function id for recursion
+	Function(()),
+}
+
+pub(crate) struct Target {
+	// pub(crate) based_on: &'a mut Environment<'a>,
+	// pub(crate) chain: Annex<'a, Vec<TargetType>>,
+	pub(crate) facts: Option<Facts>,
+}
+
+impl CallCheckingBehavior for Target {
+	const CHECK_TYPES: bool = false;
+
+	fn get_top_level_facts<'a>(&'a mut self, environment: &'a mut Environment) -> &'a mut Facts {
+		self.facts.as_mut().unwrap_or(&mut environment.facts)
+	}
+}

--- a/checker/src/context/facts.rs
+++ b/checker/src/context/facts.rs
@@ -1,0 +1,70 @@
+use std::collections::HashMap;
+
+use crate::{events::Event, Property, Type, TypeId, VariableId};
+
+/// Things that are currently true or have happened
+#[derive(Debug, Default)]
+pub struct Facts {
+	pub(crate) events: Vec<Event>,
+	/// TODO think about tasks. These are things that may happen at next stop point
+	pub(crate) queued_events: Vec<Event>,
+
+	/// This can be not have a value if not defined
+	pub(crate) variable_current_value: HashMap<VariableId, TypeId>,
+	pub(crate) current_properties: HashMap<TypeId, Vec<(TypeId, Property)>>,
+	pub(crate) prototypes: HashMap<TypeId, TypeId>,
+
+	pub(crate) configurable: HashMap<(TypeId, TypeId), TypeId>,
+	pub(crate) enumerable: HashMap<(TypeId, TypeId), TypeId>,
+	pub(crate) writable: HashMap<(TypeId, TypeId), TypeId>,
+	pub(crate) frozen: HashMap<TypeId, TypeId>,
+}
+
+impl Facts {
+	/// TODO temp
+	pub fn register_property(
+		&mut self,
+		on: TypeId,
+		under: TypeId,
+		to: Property,
+		register_setter_event: bool,
+	) {
+		// crate::utils::notify!("Registering {:?} {:?} {:?}", on, under, to);
+		self.current_properties.entry(on).or_default().push((under, to.clone()));
+		if register_setter_event {
+			self.events.push(Event::Setter {
+				on,
+				under,
+				new: to,
+				reflects_dependency: None,
+				initialization: true,
+			});
+		}
+	}
+
+	pub(crate) fn throw_value(&mut self, value: TypeId) {
+		self.events.push(Event::Throw(value));
+	}
+
+	pub(crate) fn new_object(
+		&mut self,
+		prototype: Option<TypeId>,
+		types: &mut crate::types::TypeStore,
+		is_under_dyn: bool,
+	) -> TypeId {
+		let ty = types.register_type(Type::Object(crate::types::ObjectNature::RealDeal));
+
+		if let Some(prototype) = prototype {
+			self.prototypes.insert(ty, prototype);
+		}
+
+		if is_under_dyn {
+			// TODO maybe register the environment if function ...
+			// TODO register properties
+			let value = Event::CreateObject { referenced_in_scope_as: ty, prototype };
+			self.events.push(value);
+		}
+
+		ty
+	}
+}

--- a/checker/src/context/root.rs
+++ b/checker/src/context/root.rs
@@ -20,10 +20,6 @@ impl ContextType for RootContext {
 	fn is_dynamic_boundary(&self) -> bool {
 		false
 	}
-
-	fn get_events(&mut self) -> Option<&mut Vec<crate::events::Event>> {
-		None
-	}
 }
 
 const HEADER: &[u8] = b"EZNO\0CONTEXT\0FILE";
@@ -60,20 +56,12 @@ impl Root {
 			named_types,
 			variables: Default::default(),
 			variable_names: Default::default(),
-			variable_current_value: Default::default(),
 			deferred_function_constraints: Default::default(),
 			bases: Default::default(),
-			tasks_to_run: Default::default(),
-			properties: Default::default(),
 			object_constraints: Default::default(),
-			reverse_properties: Default::default(),
-			configurable: Default::default(),
-			enumerable: Default::default(),
-			writable: Default::default(),
-			frozen: Default::default(),
 			// TODO
 			can_use_this: crate::context::CanUseThis::Yeah { this_ty: TypeId::ERROR_TYPE },
-			prototypes: Default::default(),
+			facts: Default::default(),
 		}
 	}
 

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -353,11 +353,6 @@ mod defined_errors_and_warnings {
 							kind: super::DiagnosticKind::Error,
 						}
 					}
-					//  Diagnostic::Position {
-					// 	reason: format!("Cannot call {}", calling),
-					// 	position: at,
-					// 	kind: super::DiagnosticKind::Error,
-					// },
 					FunctionCallingError::ReferenceRestrictionDoesNotMatch {
 						reference,
 						requirement,
@@ -371,6 +366,11 @@ mod defined_errors_and_warnings {
 					// 	position: call_site,
 					// 	kind: super::DiagnosticKind::Error,
 					// },
+					FunctionCallingError::Recursed(_, call_site) => Diagnostic::Position {
+						reason: "Encountered recursion".into(),
+						position: call_site,
+						kind: crate::DiagnosticKind::Error,
+					},
 				},
 				//  => ,
 				TypeCheckError::AssignmentError(error) => match error {

--- a/checker/src/events/function_calling.rs
+++ b/checker/src/events/function_calling.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use source_map::{SourceId, Span};
 
 use crate::{
+	context::{calling::Target, get_value_of_variable, CallCheckingBehavior},
 	diagnostics::TypeStringRepresentation,
 	types::functions::SynthesizedArgument,
 	types::{
@@ -18,7 +19,7 @@ use crate::{
 		subtyping::{type_is_subtype, BasicEquality, NonEqualityReason, SubTypeResult},
 		Constructor, FunctionKind, FunctionType, PolyNature, PolyPointer, Type, TypeId,
 	},
-	FunctionId,
+	Environment, FunctionId,
 };
 
 use map_vec::Map as SmallMap;
@@ -79,7 +80,7 @@ impl FunctionType {
 	/// Calls the function
 	///
 	/// Returns warnings and errors
-	pub(crate) fn call(
+	pub(crate) fn call<'a, E: CallCheckingBehavior>(
 		&self,
 		called_with_new: CalledWithNew,
 		mut this_argument: Option<TypeId>,
@@ -87,61 +88,22 @@ impl FunctionType {
 		parent_type_arguments: &Option<CurriedFunctionTypeArguments>,
 		arguments: &[SynthesizedArgument],
 		call_site: Span,
+		environment: &mut Environment,
+		behavior: &E,
 		types: &mut crate::TypeStore,
-		environment: &mut crate::context::Environment,
 	) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
 		let (mut errors, mut warnings) = (Vec::new(), Vec::<()>::new());
 
 		// Type arguments of the function
 		let local_arguments: map_vec::Map<TypeId, FunctionTypeArgument> =
-			if let Some(call_site_type_arguments) = call_site_type_arguments {
-				if let Some(ref typed_parameters) = self.type_parameters {
-					typed_parameters
-						.0
-						.iter()
-						.zip(call_site_type_arguments.into_iter())
-						.map(|(param, (pos, ty))| {
-							if let Type::RootPolyType(PolyNature::Generic {
-								eager_fixed: PolyPointer::Fixed(gen_ty),
-								..
-							}) = types.get_type_by_id(param.id)
-							{
-								let mut basic_subtyping = BasicEquality {
-									add_property_restrictions: false,
-									position: pos.clone(),
-								};
-								let type_is_subtype = type_is_subtype(
-									*gen_ty,
-									ty,
-									None,
-									&mut basic_subtyping,
-									environment,
-									types,
-								);
-
-								match type_is_subtype {
-									SubTypeResult::IsSubType => {}
-									SubTypeResult::IsNotSubType(_) => {
-										todo!("generic argument does not match restriction")
-									}
-								}
-							} else {
-								todo!();
-								// crate::utils::notify!("Generic parameter with no aliasing restriction, I think this fine on internals");
-							};
-
-							(
-								param.id,
-								FunctionTypeArgument { value: None, restriction: Some((pos, ty)) },
-							)
-						})
-						.collect()
-				} else {
-					crate::utils::notify!(
-						"Call site arguments on function without typed parameters..."
-					);
-					SmallMap::new()
-				}
+			if let (Some(call_site_type_arguments), true) =
+				(call_site_type_arguments, E::CHECK_TYPES)
+			{
+				self.synthesize_call_site_type_arguments(
+					call_site_type_arguments,
+					types,
+					environment,
+				)
 			} else {
 				SmallMap::new()
 			};
@@ -234,52 +196,61 @@ impl FunctionType {
 					// 	types.debug_type(*argument_type)
 					// );
 
-					let result = type_is_subtype(
-						parameter.ty,
-						*argument_type,
-						None,
-						&mut seeding_context,
-						environment,
-						&types,
-					);
-					if let SubTypeResult::IsNotSubType(reasons) = result {
-						let restriction = if let NonEqualityReason::GenericRestrictionMismatch {
-							restriction,
-							reason,
-							pos,
-						} = reasons
-						{
-							Some((
-								pos,
-								crate::diagnostics::TypeStringRepresentation::from_type_id(
+					if E::CHECK_TYPES {
+						// crate::utils::notify!("Param {:?} :> {:?}", parameter.ty, *argument_type);
+						let result = type_is_subtype(
+							parameter.ty,
+							*argument_type,
+							None,
+							&mut seeding_context,
+							environment,
+							&types,
+						);
+						// crate::utils::notify!("Aftermath {:?}", seeding_context.type_arguments);
+						if let SubTypeResult::IsNotSubType(reasons) = result {
+							let restriction =
+								if let NonEqualityReason::GenericRestrictionMismatch {
 									restriction,
-									&environment.into_general_context(),
-									types,
-									false,
-								),
-							))
-						} else {
-							None
-						};
-						errors.push(FunctionCallingError::InvalidArgumentType {
-							parameter_type:
-								crate::diagnostics::TypeStringRepresentation::from_type_id(
-									parameter.ty,
-									&environment.into_general_context(),
-									types,
-									false,
-								),
-							argument_type:
-								crate::diagnostics::TypeStringRepresentation::from_type_id(
-									*argument_type,
-									&environment.into_general_context(),
-									types,
-									false,
-								),
-							parameter_position: parameter.position.clone(),
-							argument_position: argument_position.clone(),
-							restriction,
-						})
+									reason,
+									pos,
+								} = reasons
+								{
+									Some((
+										pos,
+										crate::diagnostics::TypeStringRepresentation::from_type_id(
+											restriction,
+											&environment.into_general_context(),
+											types,
+											false,
+										),
+									))
+								} else {
+									None
+								};
+
+							errors.push(FunctionCallingError::InvalidArgumentType {
+								parameter_type:
+									crate::diagnostics::TypeStringRepresentation::from_type_id(
+										parameter.ty,
+										&environment.into_general_context(),
+										types,
+										false,
+									),
+								argument_type:
+									crate::diagnostics::TypeStringRepresentation::from_type_id(
+										*argument_type,
+										&environment.into_general_context(),
+										types,
+										false,
+									),
+								parameter_position: parameter.position.clone(),
+								argument_position: argument_position.clone(),
+								restriction,
+							})
+						}
+					} else {
+						// Already checked so can set. TODO destructuring etc
+						seeding_context.type_arguments.set_id(parameter.ty, *argument_type, &types);
 					}
 				} else if let Some(value) = parameter.missing_value {
 					// TODO evaluate effects
@@ -334,24 +305,25 @@ impl FunctionType {
 								unreachable!()
 							};
 
-						let result = type_is_subtype(
-							item_type,
-							*argument_type,
-							None,
-							&mut seeding_context,
-							environment,
-							&types,
-						);
+						if E::CHECK_TYPES {
+							let result = type_is_subtype(
+								item_type,
+								*argument_type,
+								None,
+								&mut seeding_context,
+								environment,
+								&types,
+							);
 
-						if let SubTypeResult::IsNotSubType(reasons) = result {
-							let restriction =
-								if let NonEqualityReason::GenericRestrictionMismatch {
-									restriction,
-									reason,
-									pos,
-								} = reasons
-								{
-									Some((
+							if let SubTypeResult::IsNotSubType(reasons) = result {
+								let restriction =
+									if let NonEqualityReason::GenericRestrictionMismatch {
+										restriction,
+										reason,
+										pos,
+									} = reasons
+									{
+										Some((
 										pos,
 										crate::diagnostics::TypeStringRepresentation::from_type_id(
 											restriction,
@@ -360,28 +332,31 @@ impl FunctionType {
 											false,
 										),
 									))
-								} else {
-									None
-								};
-							errors.push(FunctionCallingError::InvalidArgumentType {
-								parameter_type:
-									crate::diagnostics::TypeStringRepresentation::from_type_id(
-										rest_parameter.item_type,
-										&environment.into_general_context(),
-										types,
-										false,
-									),
-								argument_type:
-									crate::diagnostics::TypeStringRepresentation::from_type_id(
-										*argument_type,
-										&environment.into_general_context(),
-										types,
-										false,
-									),
-								argument_position: argument_pos.clone(),
-								parameter_position: rest_parameter.position.clone(),
-								restriction,
-							})
+									} else {
+										None
+									};
+								errors.push(FunctionCallingError::InvalidArgumentType {
+									parameter_type:
+										crate::diagnostics::TypeStringRepresentation::from_type_id(
+											rest_parameter.item_type,
+											&environment.into_general_context(),
+											types,
+											false,
+										),
+									argument_type:
+										crate::diagnostics::TypeStringRepresentation::from_type_id(
+											*argument_type,
+											&environment.into_general_context(),
+											types,
+											false,
+										),
+									argument_position: argument_pos.clone(),
+									parameter_position: rest_parameter.position.clone(),
+									restriction,
+								})
+							}
+						} else {
+							todo!("specialize")
 						}
 					}
 				} else {
@@ -440,76 +415,80 @@ impl FunctionType {
 			}
 		}
 
-		for (reference, restriction) in self.closed_over_references.clone().into_iter() {
-			match reference {
-				RootReference::VariableId(ref variable) => {
-					let current_value = environment
-						.get_value_of_variable(variable.clone())
-						.expect("closed over reference not assigned");
+		if E::CHECK_TYPES {
+			for (reference, restriction) in self.closed_over_references.clone().into_iter() {
+				match reference {
+					RootReference::VariableId(ref variable) => {
+						let current_value =
+							get_value_of_variable(environment.facts_chain(), variable.clone())
+								.expect("closed over reference not assigned");
 
-					let mut basic_subtyping = BasicEquality {
-						add_property_restrictions: false,
-						position: Span { start: 0, end: 0, source: SourceId::NULL },
-					};
-					if let SubTypeResult::IsNotSubType(reasons) = type_is_subtype(
-						restriction,
-						current_value,
-						None,
-						// TODO temp position
-						&mut basic_subtyping,
-						environment,
-						&types,
-					) {
-						errors.push(FunctionCallingError::ReferenceRestrictionDoesNotMatch {
-							reference,
-							requirement: crate::diagnostics::TypeStringRepresentation::from_type_id(
-								restriction,
-								&environment.into_general_context(),
-								&types,
-								false,
-							),
-							found: crate::diagnostics::TypeStringRepresentation::from_type_id(
-								current_value,
-								&environment.into_general_context(),
-								types,
-								false,
-							),
-						});
+						let mut basic_subtyping = BasicEquality {
+							add_property_restrictions: false,
+							position: Span { start: 0, end: 0, source: SourceId::NULL },
+						};
+						if let SubTypeResult::IsNotSubType(reasons) = type_is_subtype(
+							restriction,
+							current_value,
+							None,
+							// TODO temp position
+							&mut basic_subtyping,
+							environment,
+							&types,
+						) {
+							errors.push(FunctionCallingError::ReferenceRestrictionDoesNotMatch {
+								reference,
+								requirement:
+									crate::diagnostics::TypeStringRepresentation::from_type_id(
+										restriction,
+										&environment.into_general_context(),
+										&types,
+										false,
+									),
+								found: crate::diagnostics::TypeStringRepresentation::from_type_id(
+									current_value,
+									&environment.into_general_context(),
+									types,
+									false,
+								),
+							});
+						}
 					}
-				}
-				RootReference::This if matches!(called_with_new, CalledWithNew::None) => {}
-				RootReference::This => {
-					let value_of_this =
-						this_argument.unwrap_or_else(|| environment.get_value_of_this(types));
+					RootReference::This if matches!(called_with_new, CalledWithNew::None) => {}
+					RootReference::This => {
+						let value_of_this =
+							this_argument.unwrap_or_else(|| environment.get_value_of_this(types));
 
-					let mut basic_subtyping = BasicEquality {
-						add_property_restrictions: false,
-						position: Span { start: 0, end: 0, source: SourceId::NULL },
-					};
-					if let SubTypeResult::IsNotSubType(reasons) = type_is_subtype(
-						restriction,
-						value_of_this,
-						None,
-						// TODO temp position
-						&mut basic_subtyping,
-						environment,
-						&types,
-					) {
-						errors.push(FunctionCallingError::ReferenceRestrictionDoesNotMatch {
-							reference,
-							requirement: crate::diagnostics::TypeStringRepresentation::from_type_id(
-								restriction,
-								&environment.into_general_context(),
-								types,
-								false,
-							),
-							found: crate::diagnostics::TypeStringRepresentation::from_type_id(
-								value_of_this,
-								&environment.into_general_context(),
-								types,
-								false,
-							),
-						});
+						let mut basic_subtyping = BasicEquality {
+							add_property_restrictions: false,
+							position: Span { start: 0, end: 0, source: SourceId::NULL },
+						};
+						if let SubTypeResult::IsNotSubType(reasons) = type_is_subtype(
+							restriction,
+							value_of_this,
+							None,
+							// TODO temp position
+							&mut basic_subtyping,
+							environment,
+							&types,
+						) {
+							errors.push(FunctionCallingError::ReferenceRestrictionDoesNotMatch {
+								reference,
+								requirement:
+									crate::diagnostics::TypeStringRepresentation::from_type_id(
+										restriction,
+										&environment.into_general_context(),
+										types,
+										false,
+									),
+								found: crate::diagnostics::TypeStringRepresentation::from_type_id(
+									value_of_this,
+									&environment.into_general_context(),
+									types,
+									false,
+								),
+							});
+						}
 					}
 				}
 			}
@@ -520,13 +499,25 @@ impl FunctionType {
 		}
 
 		// Evaluate effects directly into environment
+		// let mut chain = Vec::new();
+		// chain: Annex::new(&mut chain),
+		let mut target = Target { facts: None };
 		for event in self.effects.clone().into_iter() {
-			// TODO skip returns if new, need a warning or something.
+			// TODO extract
+			// let mut target = environment.new_function_target();
+			// TODO
+			let apply_event = apply_event(
+				event,
+				this_argument,
+				&mut type_arguments,
+				environment,
+				&mut target,
+				types,
+			);
 
-			let apply_event =
-				apply_event(event, environment, this_argument, &mut type_arguments, types);
 			if let EarlyReturn::Some(returned_type) = apply_event {
 				if let CalledWithNew::New { .. } = called_with_new {
+					// TODO skip returns if new, need a warning or something.
 					crate::utils::notify!("Returned despite being called with new...");
 					// todo!("warning")
 				}
@@ -553,12 +544,67 @@ impl FunctionType {
 		// } else {
 		// };
 
-		let returned_type = specialize(self.return_type, &mut type_arguments, environment, types);
+		let returned_type = specialize(
+			self.return_type,
+			&mut type_arguments,
+			&environment.into_general_context(),
+			types,
+		);
 
 		Ok(FunctionCallResult {
 			returned_type,
 			warnings: Default::default(),
 			called: Some(self.id.clone()),
 		})
+	}
+
+	fn synthesize_call_site_type_arguments(
+		&self,
+		call_site_type_arguments: Vec<(Span, TypeId)>,
+		types: &mut crate::types::TypeStore,
+		environment: &mut Environment,
+	) -> SmallMap<TypeId, FunctionTypeArgument> {
+		if let Some(ref typed_parameters) = self.type_parameters {
+			typed_parameters
+				.0
+				.iter()
+				.zip(call_site_type_arguments.into_iter())
+				.map(|(param, (pos, ty))| {
+					if let Type::RootPolyType(PolyNature::Generic {
+						eager_fixed: PolyPointer::Fixed(gen_ty),
+						..
+					}) = types.get_type_by_id(param.id)
+					{
+						let mut basic_subtyping = BasicEquality {
+							add_property_restrictions: false,
+							position: pos.clone(),
+						};
+						let type_is_subtype = type_is_subtype(
+							*gen_ty,
+							ty,
+							None,
+							&mut basic_subtyping,
+							environment,
+							types,
+						);
+
+						match type_is_subtype {
+							SubTypeResult::IsSubType => {}
+							SubTypeResult::IsNotSubType(_) => {
+								todo!("generic argument does not match restriction")
+							}
+						}
+					} else {
+						todo!();
+						// crate::utils::notify!("Generic parameter with no aliasing restriction, I think this fine on internals");
+					};
+
+					(param.id, FunctionTypeArgument { value: None, restriction: Some((pos, ty)) })
+				})
+				.collect()
+		} else {
+			crate::utils::notify!("Call site arguments on function without typed parameters...");
+			SmallMap::new()
+		}
 	}
 }

--- a/checker/src/events/helpers.rs
+++ b/checker/src/events/helpers.rs
@@ -19,7 +19,8 @@ pub(crate) fn get_return_from_events<'a>(
 	while let Some(event) = iter.next() {
 		if let Event::Return { returned } = event {
 			return ReturnedTypeFromBlock::Returned(*returned);
-		} else if let Event::Conditionally { on, events_if_truthy, else_events } = event {
+		} else if let Event::Conditionally { condition: on, events_if_truthy, else_events } = event
+		{
 			let return_if_truthy = get_return_from_events(&mut events_if_truthy.iter(), types);
 			let else_return = get_return_from_events(&mut else_events.iter(), types);
 

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -3,7 +3,7 @@
 //! Events is the general name for the IR. Effect = Events of a function
 
 use crate::{
-	context::{calling::Target, facts::Facts, get_value_of_variable, CallCheckingBehavior},
+	context::{calling::Target, get_value_of_variable, CallCheckingBehavior},
 	types::{
 		is_type_truthy_falsy,
 		printing::print_type,
@@ -146,7 +146,6 @@ pub(crate) type EarlyReturn = Option<TypeId>;
 
 pub(crate) fn apply_event(
 	event: Event,
-	// target: EventTarget,
 	this_argument: Option<TypeId>,
 	type_arguments: &mut TypeArguments,
 	environment: &mut Environment,
@@ -319,48 +318,36 @@ pub(crate) fn apply_event(
 					apply_event(event, this_argument, type_arguments, environment, target, types);
 				}
 			} else {
-				// TODO could inject proofs
-				let truthy_facts = {
-					// let chain = if target.facts target.chain.push_annex(item);
-					let mut new_target = Target {
-						// TODO chain
-						// chain: target.chain,
-						facts: Some(Facts::default()),
-					};
+				// TODO early returns
+
+				// TODO could inject proofs but probably already worked out
+				let truthy_facts = target.new_conditional_target(|target: &mut Target| {
 					for event in events_if_truthy.into_vec() {
 						apply_event(
 							event,
 							this_argument,
 							type_arguments,
 							environment,
-							&mut new_target,
+							target,
 							types,
 						);
 					}
-					new_target.facts.unwrap()
-				};
+				});
 
-				let mut else_facts = {
-					// let chain = if target.facts target.chain.push_annex(item);
-					let mut new_target = Target {
-						// TODO chain
-						// chain: target.chain,
-						facts: Some(Facts::default()),
-					};
+				let mut else_facts = target.new_conditional_target(|target: &mut Target| {
 					for event in else_events.into_vec() {
 						apply_event(
 							event,
 							this_argument,
 							type_arguments,
 							environment,
-							&mut new_target,
+							target,
 							types,
 						);
 					}
-					new_target.facts.unwrap()
-				};
+				});
 
-				crate::utils::notify!("TF {:?}\n EF {:?}", truthy_facts, else_facts);
+				// crate::utils::notify!("TF {:?}\n EF {:?}", truthy_facts, else_facts);
 
 				// TODO all things that are
 				// - variable and property values (these aren't read from events)

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -3,8 +3,14 @@
 //! Events is the general name for the IR. Effect = Events of a function
 
 use crate::{
-	types::{properties::Property, TypeStore},
-	VariableId,
+	context::{calling::Target, facts::Facts, get_value_of_variable, CallCheckingBehavior},
+	types::{
+		is_type_truthy_falsy,
+		printing::print_type,
+		properties::{get_property, set_property, Property},
+		TypeStore,
+	},
+	TruthyFalsy, VariableId,
 };
 
 mod function_calling;
@@ -52,6 +58,13 @@ pub enum Event {
 	/// Also used for DCE
 	SetsVariable(VariableId, TypeId),
 
+	/// Mostly trivial, sometimes can call a function :(
+	Getter {
+		on: TypeId,
+		under: TypeId,
+		reflects_dependency: Option<TypeId>,
+	},
+
 	/// All changes to the value of a property
 	Setter {
 		on: TypeId,
@@ -63,13 +76,6 @@ pub enum Event {
 		/// TODO this is [define] property
 		/// see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields
 		initialization: bool,
-	},
-
-	// TODO
-	Getter {
-		on: TypeId,
-		under: TypeId,
-		reflects_dependency: Option<TypeId>,
 	},
 
 	/// This includes closed over variables, anything dependent
@@ -85,7 +91,7 @@ pub enum Event {
 	Throw(TypeId),
 
 	Conditionally {
-		on: TypeId,
+		condition: TypeId,
 		events_if_truthy: Box<[Event]>,
 		else_events: Box<[Event]>,
 	},
@@ -138,101 +144,105 @@ pub enum CallingTiming {
 
 pub(crate) type EarlyReturn = Option<TypeId>;
 
-trait EventPool {}
-
 pub(crate) fn apply_event(
 	event: Event,
-	//
-	environment: &mut Environment,
+	// target: EventTarget,
 	this_argument: Option<TypeId>,
 	type_arguments: &mut TypeArguments,
+	environment: &mut Environment,
+	target: &mut Target,
 	types: &mut TypeStore,
 ) -> EarlyReturn {
 	match event {
 		Event::ReadsReference { reference, reflects_dependency } => {
 			if let Some(id) = reflects_dependency {
-				// TODO checking constraints if inferred
 				let value = match reference {
-					RootReference::VariableId(variable) => environment
-						.get_value_of_variable(variable)
-						.expect("closed over reference not assigned"),
+					RootReference::VariableId(id) => {
+						get_value_of_variable(environment.facts_chain(), id)
+							.expect("variable has no value")
+					}
 					RootReference::This => {
 						this_argument.unwrap_or_else(|| environment.get_value_of_this(types))
 					}
 				};
-
 				type_arguments.set_id(id, value, types);
 			}
 		}
 		Event::SetsVariable(variable, value) => {
-			let new_value = specialize(value, type_arguments, environment, types);
+			let new_value =
+				specialize(value, type_arguments, &environment.into_general_context(), types);
 
-			// TODO re-push event
-			environment.context_type.events.push(Event::SetsVariable(variable.clone(), new_value));
-			environment.variable_current_value.insert(variable, new_value);
+			{
+				let facts = target.get_top_level_facts(environment);
+				facts.events.push(Event::SetsVariable(variable.clone(), new_value));
+				facts.variable_current_value.insert(variable, new_value);
+			}
+		}
+		Event::Getter { on, under, reflects_dependency } => {
+			let gc = environment.into_general_context();
+
+			let on = specialize(on, type_arguments, &gc, types);
+			let property = specialize(under, type_arguments, &gc, types);
+
+			let value = get_property(on, under, None, environment, target, types)
+				.expect("Inferred constraints and checking failed");
+
+			if let Some(id) = reflects_dependency {
+				type_arguments.set_id(id, value.into(), types);
+			}
 		}
 		Event::Setter { on, under, new, reflects_dependency, initialization } => {
-			let on = specialize(on, type_arguments, environment, types);
-			let under = specialize(under, type_arguments, environment, types);
+			let gc = environment.into_general_context();
+			let on = specialize(on, type_arguments, &gc, types);
+			let under = specialize(under, type_arguments, &gc, types);
 
 			let new = match new {
 				Property::Value(new) => {
-					Property::Value(specialize(new, type_arguments, environment, types))
+					Property::Value(specialize(new, type_arguments, &gc, types))
 				}
+				// For declare property
 				Property::Getter(_) => todo!(),
 				Property::Setter(_) => todo!(),
 				Property::GetterAndSetter(_, _) => todo!(),
 			};
 
-			// crate::utils::notify!(
-			// 	"[Event::Setter] {}[{}] = {}",
-			// 	environment.debug_type(under),
-			// 	environment.debug_type(on),
-			// 	environment.debug_type(new)
-			// );
+			let gc = environment.into_general_context();
+
+			crate::utils::notify!(
+				"[Event::Setter] {}[{}] = {}",
+				print_type(on, types, &gc, true),
+				print_type(under, types, &gc, true),
+				if let Property::Value(new) = new {
+					print_type(new, types, &gc, true)
+				} else {
+					format!("{:?}", new)
+				}
+			);
 
 			if initialization {
-				environment.register_property(on, under, new, true);
+				target.get_top_level_facts(environment).register_property(on, under, new, true);
 			} else {
-				match new {
-					Property::Value(new) => {
-						let returned = environment.set_property(on, under, new, types).unwrap();
+				let returned = set_property(on, under, new, environment, target, types).unwrap();
 
-						if let Some(id) = reflects_dependency {
-							type_arguments.set_id(
-								id,
-								returned.unwrap_or(TypeId::UNDEFINED_TYPE),
-								types,
-							);
-						}
-					}
-					Property::Getter(_) => todo!(),
-					Property::Setter(_) => todo!(),
-					Property::GetterAndSetter(_, _) => todo!(),
+				if let Some(id) = reflects_dependency {
+					type_arguments.set_id(id, returned.unwrap_or(TypeId::UNDEFINED_TYPE), types);
 				}
 			}
 		}
-		Event::Getter { on, under: property, reflects_dependency } => {
-			if let Some(id) = reflects_dependency {
-				let on = specialize(on, type_arguments, environment, types);
-				let property = specialize(property, type_arguments, environment, types);
-
-				let value = environment
-					.get_property(on, property, types, None)
-					.expect("Inferred constraints and checking failed");
-
-				type_arguments.set_id(id, value.into(), types);
-			}
-		}
 		Event::CallsType { on, with, reflects_dependency, timing, called_with_new } => {
-			let on = specialize(on, type_arguments, environment, types);
+			let on = specialize(on, type_arguments, &environment.into_general_context(), types);
 
 			let with = with
 				.into_iter()
 				.map(|argument| match argument {
 					SynthesizedArgument::NonSpread { ty, position: pos } => {
 						SynthesizedArgument::NonSpread {
-							ty: specialize(*ty, type_arguments, environment, types),
+							ty: specialize(
+								*ty,
+								type_arguments,
+								&environment.into_general_context(),
+								types,
+							),
 							position: pos.clone(),
 						}
 					}
@@ -250,6 +260,7 @@ pub(crate) fn apply_event(
 						// TODO
 						source_map::Span::NULL_SPAN,
 						environment,
+						target,
 						types,
 					);
 					match result {
@@ -288,32 +299,95 @@ pub(crate) fn apply_event(
 			}
 		}
 		Event::Throw(thrown) => {
-			let specialized_thrown = specialize(thrown, type_arguments, environment, types);
-			environment.throw_value(specialized_thrown);
+			let specialized_thrown =
+				specialize(thrown, type_arguments, &environment.into_general_context(), types);
+
+			target.get_top_level_facts(environment).throw_value(specialized_thrown);
 
 			if specialized_thrown != TypeId::ERROR_TYPE {
 				return None;
 			}
 		}
 		// TODO extract
-		Event::Conditionally { on, events_if_truthy, else_events } => {
-			let on = specialize(on, type_arguments, environment, types);
+		Event::Conditionally { condition, events_if_truthy, else_events } => {
+			let condition =
+				specialize(condition, type_arguments, &environment.into_general_context(), types);
 
-			match environment.is_type_truthy_falsy(on, types) {
-				crate::TruthyFalsy::Decidable(value) => {
-					let to_evaluate = if value { events_if_truthy } else { else_events };
-					for event in to_evaluate.iter().cloned() {
-						apply_event(event, environment, this_argument, type_arguments, types);
+			if let TruthyFalsy::Decidable(result) = is_type_truthy_falsy(condition, types) {
+				let to_evaluate = if result { events_if_truthy } else { else_events };
+				for event in to_evaluate.iter().cloned() {
+					apply_event(event, this_argument, type_arguments, environment, target, types);
+				}
+			} else {
+				// TODO could inject proofs
+				let truthy_facts = {
+					// let chain = if target.facts target.chain.push_annex(item);
+					let mut new_target = Target {
+						// TODO chain
+						// chain: target.chain,
+						facts: Some(Facts::default()),
+					};
+					for event in events_if_truthy.into_vec() {
+						apply_event(
+							event,
+							this_argument,
+							type_arguments,
+							environment,
+							&mut new_target,
+							types,
+						);
 					}
+					new_target.facts.unwrap()
+				};
+
+				let mut else_facts = {
+					// let chain = if target.facts target.chain.push_annex(item);
+					let mut new_target = Target {
+						// TODO chain
+						// chain: target.chain,
+						facts: Some(Facts::default()),
+					};
+					for event in else_events.into_vec() {
+						apply_event(
+							event,
+							this_argument,
+							type_arguments,
+							environment,
+							&mut new_target,
+							types,
+						);
+					}
+					new_target.facts.unwrap()
+				};
+
+				crate::utils::notify!("TF {:?}\n EF {:?}", truthy_facts, else_facts);
+
+				// TODO all things that are
+				// - variable and property values (these aren't read from events)
+				// - immutable, mutable, prototypes etc
+				// }
+				let facts = target.get_top_level_facts(environment);
+				for (var, truth) in truthy_facts.variable_current_value {
+					let entry = facts.variable_current_value.entry(var);
+					entry.and_modify(|existing| {
+						*existing = types.new_conditional_type(
+							condition,
+							truth,
+							else_facts.variable_current_value.remove(&var).unwrap_or(*existing),
+						)
+					});
 				}
-				crate::TruthyFalsy::Unknown => {
-					todo!()
-					// environment.new_lexical_environment_fold_into_parent(environment_type, checking_data, cb);
-				}
+
+				target.get_top_level_facts(environment).events.push(Event::Conditionally {
+					condition,
+					events_if_truthy: truthy_facts.events.into_boxed_slice(),
+					else_events: else_facts.events.into_boxed_slice(),
+				});
 			}
 		}
 		Event::Return { returned } => {
-			let specialized_returned = specialize(returned, type_arguments, environment, types);
+			let specialized_returned =
+				specialize(returned, type_arguments, &environment.into_general_context(), types);
 
 			if specialized_returned != TypeId::ERROR_TYPE {
 				return Some(specialized_returned);
@@ -324,11 +398,18 @@ pub(crate) fn apply_event(
 		Event::CreateObject { referenced_in_scope_as, prototype } => {
 			// TODO only if exposed via set
 
+			let prototype = prototype.map(|prototype| {
+				specialize(prototype, type_arguments, &environment.into_general_context(), types)
+			});
+
 			crate::utils::notify!(
 				"Event::CreateObject: Check whether creating a function for closed over variables"
 			);
 
-			let new_id = environment.new_object(types, prototype);
+			// TODO
+			let is_under_dyn = true;
+			let new_id =
+				target.get_top_level_facts(environment).new_object(prototype, types, is_under_dyn);
 			type_arguments.set_id(referenced_in_scope_as, new_id, types);
 		}
 		Event::Repeatedly { n, with } => {

--- a/checker/src/synthesis/block.rs
+++ b/checker/src/synthesis/block.rs
@@ -66,10 +66,16 @@ pub(super) fn synthesize_block<T: crate::FSResolver>(
 		}
 	}
 
-	if let Some(statements) = unreachable_at_idx.map(|idx| &statements[idx..]) {
-		crate::utils::notify!("Statements not run, only run for expressions and such");
-		// if statements.iter().all(|stmt|)
-		// let span = statements.first().unwrap().get_position().union(&statements.last().unwrap().get_position());
-		// checking_data.diagnostics_container.add_error(TypeCheckError::StatementsNotRun { between: span });
+	if let Some(idx) = unreachable_at_idx {
+		let statements_not_run = &statements[idx..];
+		if !statements_not_run.is_empty() {
+			crate::utils::notify!(
+				"Statements not run, only run for expressions and such {:?}",
+				statements_not_run
+			);
+			// if statements.iter().all(|stmt|)
+			// let span = statements.first().unwrap().get_position().union(&statements.last().unwrap().get_position());
+			// checking_data.diagnostics_container.add_error(TypeCheckError::StatementsNotRun { between: span });
+		}
 	}
 }

--- a/checker/src/synthesis/classes.rs
+++ b/checker/src/synthesis/classes.rs
@@ -127,7 +127,7 @@ pub(super) fn synthesize_class_declaration<
 						if static_kw.is_some() {
 							static_properties.push((key, property));
 						} else {
-							environment.register_property(class_type, key, property, true);
+							environment.facts.register_property(class_type, key, property, true);
 							// TODO check not already exists
 
 							// if let Some(existing_property) = existing_property {

--- a/checker/src/synthesis/expressions.rs
+++ b/checker/src/synthesis/expressions.rs
@@ -15,8 +15,9 @@ use crate::{
 		functions::{RegisterAsType, RegisterOnExistingObject},
 		objects::ObjectBuilder,
 		operations::{
-			evaluate_logical_operation, evaluate_pure_binary_operation_handle_errors,
-			evaluate_pure_unary_operator, EqualityAndInequality, MathematicalAndBitwise, PureUnary,
+			evaluate_logical_operation_with_expression,
+			evaluate_pure_binary_operation_handle_errors, evaluate_pure_unary_operator,
+			EqualityAndInequality, MathematicalAndBitwise, PureUnary,
 		},
 		template_literal::synthesize_template_literal,
 	},
@@ -112,8 +113,11 @@ pub(super) fn synthesize_expression<T: crate::FSResolver>(
 				}
 			}
 
-			let mut basis =
-				ObjectBuilder::new(Some(TypeId::ARRAY_TYPE), &mut checking_data.types, environment);
+			let mut basis = ObjectBuilder::new(
+				Some(TypeId::ARRAY_TYPE),
+				&mut checking_data.types,
+				&mut environment.facts,
+			);
 
 			for (idx, value) in elements.iter().enumerate() {
 				let (key, value) = synthesize_array_item(idx, value, environment, checking_data);
@@ -159,7 +163,7 @@ pub(super) fn synthesize_expression<T: crate::FSResolver>(
 			| BinaryOperator::LogicalOr
 			| BinaryOperator::NullCoalescing = operator
 			{
-				return evaluate_logical_operation(
+				return evaluate_logical_operation_with_expression(
 					lhs_ty,
 					match operator {
 						BinaryOperator::LogicalAnd => crate::behavior::operations::Logical::And,
@@ -248,7 +252,6 @@ pub(super) fn synthesize_expression<T: crate::FSResolver>(
 							operator,
 							operand_type,
 							&mut checking_data.types,
-							environment,
 						)
 						.unwrap(),
 					)
@@ -780,7 +783,7 @@ pub(super) fn synthesize_class_fields<T: crate::FSResolver>(
 	let this = environment.get_value_of_this(&mut checking_data.types);
 	for (under, mut expression) in fields {
 		let new = synthesize_expression(&expression, environment, checking_data);
-		environment.context_type.events.push(Event::Setter {
+		environment.facts.events.push(Event::Setter {
 			on: this,
 			new: crate::types::properties::Property::Value(new),
 			under,
@@ -827,7 +830,8 @@ pub(super) fn synthesize_object_literal<T: crate::FSResolver>(
 	checking_data: &mut CheckingData<T>,
 	environment: &mut Environment,
 ) -> TypeId {
-	let mut object_builder = ObjectBuilder::new(None, &mut checking_data.types, environment);
+	let mut object_builder =
+		ObjectBuilder::new(None, &mut checking_data.types, &mut environment.facts);
 
 	for member in members.iter() {
 		match member {

--- a/checker/src/synthesis/extensions/jsx.rs
+++ b/checker/src/synthesis/extensions/jsx.rs
@@ -33,8 +33,11 @@ pub(crate) fn synthesize_jsx_element<T: crate::FSResolver>(
 		checking_data.types.new_constant_type(Constant::String(element.tag_name.clone()));
 
 	if let Some(element_type) = environment.get_tag_name(tag_name_as_cst_ty, &checking_data.types) {
-		let mut new_element_object =
-			ObjectBuilder::new(Some(element_type), &mut checking_data.types, environment);
+		let mut new_element_object = ObjectBuilder::new(
+			Some(element_type),
+			&mut checking_data.types,
+			&mut environment.facts,
+		);
 
 		for attribute in element.attributes.iter() {
 			let (name, attr_value) = synthesize_attribute(attribute, environment, checking_data);

--- a/checker/src/synthesis/functions.rs
+++ b/checker/src/synthesis/functions.rs
@@ -619,7 +619,7 @@ pub(super) fn type_function_reference<T: crate::FSResolver, S: ContextType>(
 						environment.can_use_this =
 							CanUseThis::Yeah { this_ty: on_interface.unwrap() };
 						synthesize_block(&block.0, environment, checking_data);
-						(mem::take(&mut environment.context_type.events), None)
+						(mem::take(&mut environment.facts.events), None)
 					}
 					Performs::Const(id) => (Default::default(), Some(id)),
 					Performs::None => (Default::default(), Default::default()),

--- a/checker/src/synthesis/interfaces.rs
+++ b/checker/src/synthesis/interfaces.rs
@@ -152,7 +152,7 @@ impl SynthesizeInterfaceBehavior for OnToType {
 			}
 			InterfaceValue::Value(value) => value,
 		};
-		environment.register_property(self.0, under, Property::Value(ty), false)
+		environment.facts.register_property(self.0, under, Property::Value(ty), false)
 	}
 
 	fn interface_type(&self) -> Option<TypeId> {

--- a/checker/src/synthesis/type_annotations.rs
+++ b/checker/src/synthesis/type_annotations.rs
@@ -61,7 +61,7 @@ pub(super) fn synthesize_type_annotation<S: ContextType, T: crate::FSResolver>(
 		}
 		TypeAnnotation::Name(name, _) => match name.as_str() {
 			"any" => checking_data.types.new_any_parameter(environment),
-			"this" => environment.get_value_of_this(&mut checking_data.types),
+			"this" => todo!(), // environment.get_value_of_this(&mut checking_data.types),
 			"self" => TypeId::THIS_ARG,
 			name => {
 				match environment.get_type_from_name(name) {
@@ -219,7 +219,8 @@ pub(super) fn synthesize_type_annotation<S: ContextType, T: crate::FSResolver>(
 
 						keys.insert(idx_ty);
 						environment
-							.properties
+							.facts
+							.current_properties
 							.entry(obj)
 							.or_default()
 							.push((idx_ty, Property::Value(item_ty)));
@@ -234,7 +235,8 @@ pub(super) fn synthesize_type_annotation<S: ContextType, T: crate::FSResolver>(
 			let length_value = checking_data.types.new_constant_type(constant);
 
 			environment
-				.properties
+				.facts
+				.current_properties
 				.entry(obj)
 				.or_default()
 				.push((TypeId::LENGTH_AS_STRING, Property::Value(length_value)));

--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -19,7 +19,7 @@ use crate::{
 /// TODO shouldn't return type, for performs...
 pub(crate) fn register_variable<T: crate::FSResolver, U: parser::VariableFieldKind>(
 	name: &parser::VariableField<U>,
-	environment: &mut crate::context::Context<crate::context::Syntax<'_>>,
+	environment: &mut Environment,
 	checking_data: &mut CheckingData<'_, T>,
 	behavior: crate::context::VariableRegisterBehavior,
 	constraint: Option<TypeId>,

--- a/checker/src/types/calling.rs
+++ b/checker/src/types/calling.rs
@@ -1,13 +1,12 @@
 use source_map::Span;
 
 use crate::{
-	context::{Environment, PolyBase},
+	context::{calling::CheckThings, CallCheckingBehavior, Environment, PolyBase},
 	diagnostics::TypeCheckError,
 	events::{CalledWithNew, Event, FunctionCallResult, FunctionCallingError},
 	types::functions::SynthesizedArgument,
-	types::functions::{SynthesizedParameter, SynthesizedParameters},
 	types::{FunctionType, Type},
-	FunctionId, TypeId,
+	TypeId,
 };
 
 use super::{Constructor, FunctionNature, TypeStore};
@@ -31,6 +30,7 @@ pub fn call_type_handle_errors<T: crate::FSResolver>(
 		arguments,
 		call_site.clone(),
 		environment,
+		&mut CheckThings,
 		&mut checking_data.types,
 	);
 	match result {
@@ -64,15 +64,16 @@ pub fn call_type_handle_errors<T: crate::FSResolver>(
 }
 
 /// TODO this and aliases kindof broken
-pub fn call_type(
+pub(crate) fn call_type(
 	on: TypeId,
 	called_with_new: CalledWithNew,
+	// Overwritten by .call, else look at binding
 	this_argument: Option<TypeId>,
 	call_site_type_arguments: Option<Vec<(Span, TypeId)>>,
 	arguments: Vec<SynthesizedArgument>,
 	call_site: Span,
-	// Overwritten by .call, else look at binding
 	environment: &mut Environment,
+	behavior: &mut impl CallCheckingBehavior,
 	types: &mut TypeStore,
 ) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
 	if on == TypeId::ERROR_TYPE
@@ -88,179 +89,31 @@ pub fn call_type(
 
 	if let Type::Function(function_type, variant) = types.get_type_by_id(on) {
 		// TODO as Rc to avoid expensive clone
-		let function_type = function_type.clone();
-
-		let this_argument =
-			if let FunctionNature::Source(this_arg) = variant { this_arg.clone() } else { None };
-
-		// TODO should be done after call to check that arguments are correct
-		if let Some(const_fn_ident) = function_type.constant_id.as_deref() {
-			let this_argument = this_argument.or(this_argument);
-			let has_dependent_argument = arguments.iter().any(|arg| {
-				types
-					.get_type_by_id(arg.into_type().expect("dependent spread types"))
-					.is_dependent()
-			});
-
-			// TODO temp, need a better solution
-			let call_anyway =
-				matches!(const_fn_ident, "debug_type" | "print_type" | "call" | "bind");
-
-			if !call_anyway && has_dependent_argument {
-				let with = arguments.to_vec().into_boxed_slice();
-				// TODO with cloned!!
-				let result = function_type
-					.clone()
-					.call(
-						called_with_new,
-						this_argument,
-						call_site_type_arguments,
-						// TODO
-						&None,
-						&arguments,
-						call_site,
-						types,
-						environment,
-					)?
-					.returned_type;
-
-				let new_type = Type::Constructor(Constructor::FunctionResult {
-					on,
-					with: with.clone(),
-					result: super::PolyPointer::Fixed(result),
-				});
-
-				let ty = types.register_type(new_type);
-
-				environment.context_type.events.push(Event::CallsType {
-					on,
-					with: arguments.clone().into_boxed_slice(),
-					reflects_dependency: Some(ty),
-					timing: crate::events::CallingTiming::Synchronous,
-					called_with_new,
-				});
-
-				return Ok(FunctionCallResult {
-					returned_type: ty,
-					warnings: Default::default(),
-					called: None,
-				});
-			}
-		}
-
-		function_type.call(
+		call_using_function_type(
+			function_type.clone(),
+			variant.clone(),
+			&arguments,
+			called_with_new,
+			call_site_type_arguments,
+			call_site,
+			on,
+			environment,
+			behavior,
+			types,
+		)
+	} else if let Some(constraint) = environment.get_poly_base(on, &types) {
+		create_generic_function_call(
+			constraint,
 			called_with_new,
 			this_argument,
 			call_site_type_arguments,
-			// TODO
-			&None,
-			&arguments,
+			arguments,
 			call_site,
-			types,
+			on,
 			environment,
+			behavior,
+			types,
 		)
-	} else if let Some(constraint) = environment.get_poly_base(on, &types) {
-		match constraint {
-			PolyBase::Fixed { to, is_open_poly } => {
-				let result = call_type(
-					to,
-					called_with_new,
-					this_argument,
-					call_site_type_arguments,
-					// TODO clone
-					arguments.clone(),
-					call_site,
-					environment,
-					types,
-				)?;
-
-				let with = arguments.into_boxed_slice();
-
-				let reflects_dependency = if !is_open_poly {
-					// TODO check trivial result
-					let constructor_return =
-						types.register_type(Type::Constructor(Constructor::FunctionResult {
-							// TODO on or to
-							on,
-							with: with.clone(),
-							// TODO unwrap
-							result: super::PolyPointer::Fixed(result.returned_type),
-						}));
-
-					Some(constructor_return)
-				} else {
-					None
-				};
-
-				environment.context_type.events.push(Event::CallsType {
-					on,
-					with,
-					timing: crate::events::CallingTiming::Synchronous,
-					called_with_new,
-					reflects_dependency,
-				});
-
-				// TODO should wrap result in open poly
-				Ok(FunctionCallResult {
-					called: result.called,
-					returned_type: reflects_dependency.unwrap_or(result.returned_type),
-					warnings: result.warnings,
-				})
-			}
-			PolyBase::Dynamic { to, boundary } => {
-				if to == TypeId::ANY_TYPE {
-					let parameters = arguments
-						.iter()
-						.cloned()
-						.enumerate()
-						.map(|(idx, argument)| match argument {
-							SynthesizedArgument::NonSpread { ty, position } => {
-								SynthesizedParameter {
-									name: format!("i{}", idx),
-									ty,
-									// TODO
-									position,
-									// TODO
-									missing_value: None,
-								}
-							}
-						})
-						.collect();
-
-					// Inferred function type
-
-					let function_type = FunctionType {
-						// TODO explain
-						type_parameters: None,
-						parameters: SynthesizedParameters {
-							parameters,
-							// TODO I think this is okay
-							rest_parameter: Default::default(),
-						},
-						return_type: TypeId::ANY_TYPE,
-						// This is where it would be good for a smaller type reference based function type
-						effects: Default::default(),
-						closed_over_references: Default::default(),
-						// TODO
-						kind: crate::types::FunctionKind::Arrow,
-						constant_id: None,
-						id: FunctionId::NULL,
-					};
-
-					let new_constraint = types.register_type(Type::Function(
-						function_type,
-						crate::types::FunctionNature::BehindPoly {
-							function_id_if_open_poly: None,
-							this_type: None,
-						},
-					));
-					environment.attempt_to_modify_base(on, boundary, new_constraint);
-					todo!()
-				} else {
-					todo!();
-				}
-			}
-		}
 	} else {
 		return Err(vec![FunctionCallingError::NotCallable {
 			calling: crate::diagnostics::TypeStringRepresentation::from_type_id(
@@ -272,4 +125,206 @@ pub fn call_type(
 			call_site,
 		}]);
 	}
+}
+
+fn create_generic_function_call(
+	constraint: PolyBase,
+	called_with_new: CalledWithNew,
+	this_argument: Option<TypeId>,
+	call_site_type_arguments: Option<Vec<(Span, TypeId)>>,
+	arguments: Vec<SynthesizedArgument>,
+	call_site: Span,
+	on: TypeId,
+	environment: &mut Environment,
+	behavior: &mut impl CallCheckingBehavior,
+	types: &mut TypeStore,
+) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
+	match constraint {
+		PolyBase::Fixed { to, is_open_poly } => {
+			let result = call_type(
+				to,
+				called_with_new,
+				this_argument,
+				call_site_type_arguments,
+				// TODO clone
+				arguments.clone(),
+				call_site,
+				environment,
+				behavior,
+				types,
+			)?;
+
+			let with = arguments.into_boxed_slice();
+
+			let reflects_dependency = if !is_open_poly {
+				// TODO check trivial result
+				let constructor_return =
+					types.register_type(Type::Constructor(Constructor::FunctionResult {
+						// TODO on or to
+						on,
+						with: with.clone(),
+						// TODO unwrap
+						result: super::PolyPointer::Fixed(result.returned_type),
+					}));
+
+				Some(constructor_return)
+			} else {
+				None
+			};
+
+			// TODO nearest fact
+			environment.facts.events.push(Event::CallsType {
+				on,
+				with,
+				timing: crate::events::CallingTiming::Synchronous,
+				called_with_new,
+				reflects_dependency,
+			});
+
+			// TODO should wrap result in open poly
+			Ok(FunctionCallResult {
+				called: result.called,
+				returned_type: reflects_dependency.unwrap_or(result.returned_type),
+				warnings: result.warnings,
+			})
+		}
+		PolyBase::Dynamic { to, boundary } => {
+			// if to == TypeId::ANY_TYPE {
+			// 	let parameters = arguments
+			// 		.iter()
+			// 		.cloned()
+			// 		.enumerate()
+			// 		.map(|(idx, argument)| match argument {
+			// 			SynthesizedArgument::NonSpread { ty, position } => {
+			// 				SynthesizedParameter {
+			// 					name: format!("i{}", idx),
+			// 					ty,
+			// 					// TODO
+			// 					position,
+			// 					// TODO
+			// 					missing_value: None,
+			// 				}
+			// 			}
+			// 		})
+			// 		.collect();
+
+			// 	// Inferred function type
+
+			// 	let function_type = FunctionType {
+			// 		// TODO explain
+			// 		type_parameters: None,
+			// 		parameters: SynthesizedParameters {
+			// 			parameters,
+			// 			// TODO I think this is okay
+			// 			rest_parameter: Default::default(),
+			// 		},
+			// 		return_type: TypeId::ANY_TYPE,
+			// 		// This is where it would be good for a smaller type reference based function type
+			// 		effects: Default::default(),
+			// 		closed_over_references: Default::default(),
+			// 		// TODO
+			// 		kind: crate::types::FunctionKind::Arrow,
+			// 		constant_id: None,
+			// 		id: FunctionId::NULL,
+			// 	};
+
+			// 	let new_constraint = types.register_type(Type::Function(
+			// 		function_type,
+			// 		crate::types::FunctionNature::BehindPoly {
+			// 			function_id_if_open_poly: None,
+			// 			this_type: None,
+			// 		},
+			// 	));
+			// 	environment.attempt_to_modify_base(on, boundary, new_constraint);
+			// 	todo!()
+			// } else {
+			// }
+			todo!();
+		}
+	}
+}
+
+fn call_using_function_type(
+	function_type: FunctionType,
+	variant: FunctionNature,
+	arguments: &Vec<SynthesizedArgument>,
+	called_with_new: CalledWithNew,
+	call_site_type_arguments: Option<Vec<(Span, TypeId)>>,
+	call_site: Span,
+	on: TypeId,
+	environment: &mut Environment,
+	behavior: &mut impl CallCheckingBehavior,
+	types: &mut TypeStore,
+) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
+	let this_argument =
+		if let FunctionNature::Source(this_arg) = variant { this_arg.clone() } else { None };
+
+	// TODO should be done after call to check that arguments are correct
+	if let Some(const_fn_ident) = function_type.constant_id.as_deref() {
+		let this_argument = this_argument.or(this_argument);
+		let has_dependent_argument = arguments.iter().any(|arg| {
+			types.get_type_by_id(arg.into_type().expect("dependent spread types")).is_dependent()
+		});
+
+		// TODO temp, need a better solution
+		let call_anyway = matches!(
+			const_fn_ident,
+			"debug_type" | "print_type" | "is_dependent" | "call" | "bind"
+		);
+
+		if !call_anyway && has_dependent_argument {
+			let with = arguments.to_vec().into_boxed_slice();
+			// TODO with cloned!!
+			let result = function_type
+				.clone()
+				.call(
+					called_with_new,
+					this_argument,
+					call_site_type_arguments,
+					// TODO
+					&None,
+					arguments,
+					call_site,
+					environment,
+					behavior,
+					types,
+				)?
+				.returned_type;
+
+			let new_type = Type::Constructor(Constructor::FunctionResult {
+				on,
+				with: with.clone(),
+				result: super::PolyPointer::Fixed(result),
+			});
+
+			let ty = types.register_type(new_type);
+
+			behavior.get_top_level_facts(environment).events.push(Event::CallsType {
+				on,
+				with: arguments.clone().into_boxed_slice(),
+				reflects_dependency: Some(ty),
+				timing: crate::events::CallingTiming::Synchronous,
+				called_with_new,
+			});
+
+			return Ok(FunctionCallResult {
+				returned_type: ty,
+				warnings: Default::default(),
+				called: None,
+			});
+		}
+	}
+
+	function_type.call(
+		called_with_new,
+		this_argument,
+		call_site_type_arguments,
+		// TODO
+		&None,
+		arguments,
+		call_site,
+		environment,
+		behavior,
+		types,
+	)
 }

--- a/checker/src/types/calling.rs
+++ b/checker/src/types/calling.rs
@@ -64,7 +64,7 @@ pub fn call_type_handle_errors<T: crate::FSResolver>(
 }
 
 /// TODO this and aliases kindof broken
-pub(crate) fn call_type(
+pub(crate) fn call_type<'a, E: CallCheckingBehavior>(
 	on: TypeId,
 	called_with_new: CalledWithNew,
 	// Overwritten by .call, else look at binding
@@ -73,7 +73,7 @@ pub(crate) fn call_type(
 	arguments: Vec<SynthesizedArgument>,
 	call_site: Span,
 	environment: &mut Environment,
-	behavior: &mut impl CallCheckingBehavior,
+	behavior: &mut E,
 	types: &mut TypeStore,
 ) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
 	if on == TypeId::ERROR_TYPE
@@ -127,7 +127,7 @@ pub(crate) fn call_type(
 	}
 }
 
-fn create_generic_function_call(
+fn create_generic_function_call<'a, E: CallCheckingBehavior>(
 	constraint: PolyBase,
 	called_with_new: CalledWithNew,
 	this_argument: Option<TypeId>,
@@ -136,7 +136,7 @@ fn create_generic_function_call(
 	call_site: Span,
 	on: TypeId,
 	environment: &mut Environment,
-	behavior: &mut impl CallCheckingBehavior,
+	behavior: &mut E,
 	types: &mut TypeStore,
 ) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
 	match constraint {
@@ -244,7 +244,7 @@ fn create_generic_function_call(
 	}
 }
 
-fn call_using_function_type(
+fn call_using_function_type<'a, E: CallCheckingBehavior>(
 	function_type: FunctionType,
 	variant: FunctionNature,
 	arguments: &Vec<SynthesizedArgument>,
@@ -253,7 +253,7 @@ fn call_using_function_type(
 	call_site: Span,
 	on: TypeId,
 	environment: &mut Environment,
-	behavior: &mut impl CallCheckingBehavior,
+	behavior: &mut E,
 	types: &mut TypeStore,
 ) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
 	let this_argument =

--- a/checker/src/types/functions.rs
+++ b/checker/src/types/functions.rs
@@ -56,6 +56,7 @@ pub enum FunctionNature {
 #[derive(Clone, Debug, binary_serialize_derive::BinarySerializable)]
 pub struct SynthesizedParameter {
 	pub name: String,
+	/// This is the generic parameter type, not the restriction
 	pub ty: TypeId,
 	pub position: Span,
 	/// For optional parameters this is [TypeId::UNDEFINED_TYPE] else some type

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -1,9 +1,9 @@
 use crate::{
-	context::{get_on_ctx, Environment, Logical, PolyBase, SetPropertyError},
+	context::{CallCheckingBehavior, Logical, PolyBase, SetPropertyError},
 	events::Event,
 	subtyping::{type_is_subtype, SubTypeResult},
 	types::FunctionType,
-	TypeId,
+	Environment, TypeId,
 };
 
 use source_map::{SourceId, Span};
@@ -50,12 +50,13 @@ impl Property {
 ///
 /// *be aware this creates a new type every time, bc of this binding. could cache this bound
 /// types at some point*
-pub(crate) fn get_property(
-	environment: &mut Environment,
+pub(crate) fn get_property<'a, E: CallCheckingBehavior>(
 	on: TypeId,
 	under: TypeId,
-	types: &mut TypeStore,
 	with: Option<TypeId>,
+	environment: &mut Environment,
+	behavior: &mut E,
+	types: &mut TypeStore,
 ) -> Option<PropertyResult> {
 	if on == TypeId::ERROR_TYPE || under == TypeId::ERROR_TYPE {
 		return Some(PropertyResult::Direct(TypeId::ERROR_TYPE));
@@ -68,224 +69,20 @@ pub(crate) fn get_property(
 	}
 
 	let value: GetResult = if let Some(constraint) = environment.get_poly_base(on, types) {
-		match constraint {
-			PolyBase::Fixed { to, is_open_poly } => {
-				// crate::utils::notify!(
-				// 	"Get property found fixed constraint {}, is_open_poly={:?}",
-				// 	environment.debug_type(on, types),
-				// 	is_open_poly
-				// );
-
-				let fact = environment.get_property_unbound(to, under, types)?;
-
-				match fact {
-					Logical::Pure(og) => {
-						match og {
-							Property::Value(og) => {
-								match types.get_type_by_id(og) {
-									Type::Function(func, _) => {
-										// TODO only want to do sometimes, or even never as it can be pulled using the poly chain
-										let with_this = types.register_type(Type::Function(
-											func.clone(),
-											crate::types::FunctionNature::BehindPoly {
-												// TODO
-												function_id_if_open_poly: None,
-												this_type: Some(on),
-											},
-										));
-										crate::utils::notify!("Temp setting this on poly");
-
-										GetResult::AccessIntroducesDependence(with_this)
-									}
-									Type::And(_, _) => todo!(),
-									Type::RootPolyType(_) => todo!(),
-									Type::Constructor(_) => todo!(),
-									Type::Or(_, _)
-									| Type::AliasTo { .. }
-									| Type::NamedRooted { .. } => {
-										if is_open_poly {
-											crate::utils::notify!("TODO evaluate getter...");
-										} else {
-											crate::utils::notify!("TODO don't evaluate getter");
-										}
-
-										// TODO don't have to recreate if don't have any events.
-										let constructor_result = types.register_type(
-											Type::Constructor(Constructor::Property { on, under }),
-										);
-
-										GetResult::AccessIntroducesDependence(constructor_result)
-									}
-									Type::Constant(_) => GetResult::FromAObject(og),
-									Type::Object(..) => todo!(),
-								}
-							}
-							Property::Getter(_) => todo!(),
-							Property::Setter(_) => todo!(),
-							Property::GetterAndSetter(_, _) => todo!(),
-						}
-					}
-					Logical::Or(_) => todo!(),
-					Logical::Implies(_, _) => todo!(),
-				}
-			}
-			PolyBase::Dynamic { to, boundary } => {
-				crate::utils::notify!(
-					"Getting property {:?} which has a dynamic constraint {:?}",
-					on,
-					to
-				);
-				// If the property on the dynamic constraint is None
-				if environment.get_property_unbound(to, under, types).is_none() {
-					let on = if to == TypeId::ANY_TYPE {
-						let new_constraint = types.register_type(Type::Object(
-							crate::types::ObjectNature::ModifiableConstraint,
-						));
-						crate::utils::notify!("Here!!!");
-						environment.attempt_to_modify_base(on, boundary, new_constraint);
-						new_constraint
-					} else if matches!(
-						types.get_type_by_id(to),
-						Type::AliasTo { to: TypeId::OBJECT_TYPE, .. }
-					) {
-						to
-					} else {
-						todo!("new and")
-					};
-
-					environment
-						.properties
-						.entry(on)
-						.or_default()
-						.push((under, Property::Value(with.unwrap_or(TypeId::ANY_TYPE))));
-				} else {
-					crate::utils::notify!("Found existing property on dynamic constraint");
-				}
-
-				let constructor_result =
-					types.register_type(Type::Constructor(Constructor::Property { on, under }));
-
-				// environment
-				// 	.context_type
-				// 	.get_inferrable_constraints_mut()
-				// 	.unwrap()
-				// 	.insert(constructor_result);
-
-				GetResult::AccessIntroducesDependence(constructor_result)
-			}
-		}
+		GetResult::AccessIntroducesDependence(getter_on_type(
+			constraint,
+			under,
+			on,
+			with,
+			environment,
+			behavior,
+			types,
+		)?)
 	} else if let Some(_) = environment.get_poly_base(under, types) {
 		todo!()
 	} else {
-		let value = environment.get_property_unbound(on, under, types)?;
-
-		let value = match value {
-			Logical::Pure(property) => {
-				match property {
-					Property::Value(value) => {
-						let ty = types.get_type_by_id(value);
-						match ty {
-							Type::Function(func, nature) => match nature {
-								super::FunctionNature::BehindPoly { .. } => todo!(),
-								super::FunctionNature::Source(this) => {
-									if this.is_some() {
-										panic!()
-									}
-									types.register_type(Type::Function(
-										func.clone(),
-										super::FunctionNature::Source(Some(on)),
-									))
-								}
-								super::FunctionNature::Constructor => todo!(),
-								super::FunctionNature::Reference => {
-									crate::utils::notify!("TODO temp reference function business");
-									types.register_type(Type::Function(
-										func.clone(),
-										super::FunctionNature::Source(Some(on)),
-									))
-								}
-							},
-							Type::Object(..) | Type::RootPolyType { .. } | Type::Constant(..) => {
-								value
-							}
-							Type::NamedRooted { .. }
-							| Type::And(_, _)
-							| Type::Or(_, _)
-							| Type::Constructor(Constructor::StructureGenerics { .. }) => {
-								crate::utils::notify!(
-									"property was {:?} {:?}, which should be NOT be able to be returned from a function",
-									property, ty
-								);
-								types.register_type(Type::RootPolyType(
-									crate::types::PolyNature::Open(value),
-								))
-							}
-							Type::Constructor(constructor) => {
-								unreachable!("Interesting property was {:?}", constructor);
-							}
-							Type::AliasTo { to, name, parameters } => {
-								todo!()
-								// if environment.is_getter(property) {
-								// 	// TODO catch unwrap as error:
-								// 	let result = call_type(
-								// 		property,
-								// 		vec![],
-								// 		Some(on),
-								// 		None,
-								// 		environment,
-								// 		checking_data,
-								// 		CalledWithNew::None,
-								// 	)
-								// 	.unwrap()
-								// 	.returned_type;
-
-								// 	return Some(PropertyResult::Getter(result));
-								// } else {
-								// 	// Bind this is this is function
-								// 	let is_function = *to == TypeId::FUNCTION_TYPE
-								// 		|| matches!(environment.get_type_by_id(*to), Type::AliasTo { to, .. } if *to == TypeId::FUNCTION_TYPE);
-
-								// 	if is_function {
-								// 		let alias = environment.new_type(Type::AliasTo {
-								// 			to: property,
-								// 			name: None,
-								// 			parameters: None,
-								// 		});
-								// 		environment.this_bindings.insert(alias, on);
-								// 		alias
-								// 	} else {
-								// 		property
-								// 	}
-								// }
-							}
-						}
-					}
-					Property::Getter(func) => {
-						return match func.call(
-							crate::events::CalledWithNew::None,
-							Some(on),
-							None,
-							&None,
-							&[],
-							Span::NULL_SPAN,
-							types,
-							environment,
-						) {
-							Ok(res) => Some(PropertyResult::Getter(res.returned_type)),
-							Err(_) => {
-								todo!()
-							}
-						}
-					}
-					Property::Setter(_) => todo!(),
-					Property::GetterAndSetter(_, _) => todo!(),
-				}
-			}
-			Logical::Or(_) => todo!(),
-			Logical::Implies(_, _) => todo!(),
-		};
-
-		GetResult::FromAObject(value)
+		// TODO
+		return get_from_an_object(on, under, environment, behavior, types);
 	};
 
 	let reflects_dependency = match value {
@@ -293,40 +90,279 @@ pub(crate) fn get_property(
 		GetResult::FromAObject(_) => None,
 	};
 
-	environment.context_type.events.push(Event::Getter { on, under, reflects_dependency });
+	behavior.get_top_level_facts(environment).events.push(Event::Getter {
+		on,
+		under,
+		reflects_dependency,
+	});
 
 	let (GetResult::AccessIntroducesDependence(value) | GetResult::FromAObject(value)) = value else { unreachable!() };
 
 	// Carry the frozen part
-	if let Some(frozen) = environment.is_frozen(on) {
-		environment.frozen.insert(value, frozen);
-	}
+	// if let Some(frozen) = environment.is_frozen(on) {
+	// 	environment.facts.frozen.insert(value, frozen);
+	// }
 
 	// TODO generic
 	Some(PropertyResult::Direct(value))
 }
 
+fn get_from_an_object(
+	on: TypeId,
+	under: TypeId,
+	environment: &mut Environment,
+	behavior: &mut impl CallCheckingBehavior,
+	types: &mut TypeStore,
+) -> Option<PropertyResult> {
+	match environment.get_property_unbound(on, under, types)? {
+		Logical::Pure(property) => {
+			match property {
+				Property::Value(value) => {
+					let ty = types.get_type_by_id(value);
+					match ty {
+						Type::Function(func, nature) => match nature {
+							super::FunctionNature::BehindPoly { .. } => todo!(),
+							super::FunctionNature::Source(this) => {
+								if this.is_some() {
+									panic!()
+								}
+								todo!()
+								// Some(GetResult::AccessIntroducesDependence(types.register_type(Type::Function(
+								// 	func.clone(),
+								// 	super::FunctionNature::Source(Some(on)),
+								// ))
+							}
+							super::FunctionNature::Constructor => todo!(),
+							super::FunctionNature::Reference => {
+								crate::utils::notify!("TODO temp reference function business");
+								let func = types.register_type(Type::Function(
+									func.clone(),
+									super::FunctionNature::Source(Some(on)),
+								));
+								Some(PropertyResult::Direct(func))
+							}
+						},
+						Type::Object(..) | Type::RootPolyType { .. } | Type::Constant(..) => {
+							Some(PropertyResult::Direct(value))
+						}
+						Type::NamedRooted { .. }
+						| Type::And(_, _)
+						| Type::Or(_, _)
+						| Type::Constructor(Constructor::StructureGenerics { .. }) => {
+							crate::utils::notify!(
+								"property was {:?} {:?}, which should be NOT be able to be returned from a function",
+								property, ty
+							);
+							let value = types.register_type(Type::RootPolyType(
+								crate::types::PolyNature::Open(value),
+							));
+							Some(PropertyResult::Direct(value))
+						}
+						Type::Constructor(constructor) => {
+							unreachable!("Interesting property was {:?}", constructor);
+						}
+						Type::AliasTo { to, name, parameters } => {
+							todo!()
+							// if environment.is_getter(property) {
+							// 	// TODO catch unwrap as error:
+							// 	let result = call_type(
+							// 		property,
+							// 		vec![],
+							// 		Some(on),
+							// 		None,
+							// 		environment,
+							// 		checking_data,
+							// 		CalledWithNew::None,
+							// 	)
+							// 	.unwrap()
+							// 	.returned_type;
+
+							// 	return Some(PropertyResult::Getter(result));
+							// } else {
+							// 	// Bind this is this is function
+							// 	let is_function = *to == TypeId::FUNCTION_TYPE
+							// 		|| matches!(environment.get_type_by_id(*to), Type::AliasTo { to, .. } if *to == TypeId::FUNCTION_TYPE);
+
+							// 	if is_function {
+							// 		let alias = environment.new_type(Type::AliasTo {
+							// 			to: property,
+							// 			name: None,
+							// 			parameters: None,
+							// 		});
+							// 		environment.this_bindings.insert(alias, on);
+							// 		alias
+							// 	} else {
+							// 		property
+							// 	}
+							// }
+						}
+					}
+				}
+				Property::GetterAndSetter(func, _) | Property::Getter(func) => {
+					let call = func.call(
+						crate::events::CalledWithNew::None,
+						Some(on),
+						None,
+						&None,
+						&[],
+						Span::NULL_SPAN,
+						environment,
+						behavior,
+						types,
+					);
+					return match call {
+						Ok(res) => Some(PropertyResult::Getter(res.returned_type)),
+						Err(_) => {
+							todo!()
+						}
+					};
+				}
+				Property::Setter(_) => todo!(),
+			}
+		}
+		Logical::Or(_) => todo!(),
+		Logical::Implies(_, _) => todo!(),
+	}
+}
+
+fn getter_on_type(
+	constraint: PolyBase,
+	under: TypeId,
+	on: TypeId,
+	with: Option<TypeId>,
+	environment: &mut Environment,
+	behavior: &mut impl CallCheckingBehavior,
+	types: &mut TypeStore,
+) -> Option<TypeId> {
+	match constraint {
+		PolyBase::Fixed { to, is_open_poly } => {
+			// crate::utils::notify!(
+			// 	"Get property found fixed constraint {}, is_open_poly={:?}",
+			// 	environment.debug_type(on, types),
+			// 	is_open_poly
+			// );
+
+			let fact = environment.get_property_unbound(to, under, types)?;
+
+			match fact {
+				Logical::Pure(og) => {
+					match og {
+						Property::Value(og) => {
+							match types.get_type_by_id(og) {
+								Type::Function(func, _) => {
+									// TODO only want to do sometimes, or even never as it can be pulled using the poly chain
+									let with_this = types.register_type(Type::Function(
+										func.clone(),
+										crate::types::FunctionNature::BehindPoly {
+											// TODO
+											function_id_if_open_poly: None,
+											this_type: Some(on),
+										},
+									));
+									crate::utils::notify!("Temp setting this on poly");
+
+									Some(with_this)
+								}
+								Type::And(_, _)
+								| Type::Object(..)
+								| Type::RootPolyType(_)
+								| Type::Constructor(_)
+								| Type::Or(_, _)
+								| Type::AliasTo { .. }
+								| Type::NamedRooted { .. } => {
+									// TODO this isn't necessary sometimes
+									let constructor_result = types.register_type(
+										Type::Constructor(Constructor::Property { on, under }),
+									);
+
+									Some(constructor_result)
+								}
+								Type::Constant(_) => Some(og),
+							}
+						}
+						Property::GetterAndSetter(_getter, _) | Property::Getter(_getter) => {
+							if is_open_poly {
+								crate::utils::notify!("TODO evaluate getter...");
+							} else {
+								crate::utils::notify!("TODO don't evaluate getter");
+							}
+							todo!()
+						}
+						Property::Setter(_) => todo!("error"),
+					}
+				}
+				Logical::Or(_) => todo!(),
+				Logical::Implies(_, _) => todo!(),
+			}
+		}
+		PolyBase::Dynamic { to, boundary } => {
+			todo!("this is likely changing")
+			// crate::utils::notify!(
+			// 	"Getting property {:?} which has a dynamic constraint {:?}",
+			// 	on,
+			// 	to
+			// );
+			// // If the property on the dynamic constraint is None
+			// if environment.get_property_unbound(to, under, types).is_none() {
+			// 	let on = if to == TypeId::ANY_TYPE {
+			// 		let new_constraint = types.register_type(Type::Object(
+			// 			crate::types::ObjectNature::ModifiableConstraint,
+			// 		));
+			// 		crate::utils::notify!("Here!!!");
+			// 		environment.attempt_to_modify_base(on, boundary, new_constraint);
+			// 		new_constraint
+			// 	} else if matches!(
+			// 		types.get_type_by_id(to),
+			// 		Type::AliasTo { to: TypeId::OBJECT_TYPE, .. }
+			// 	) {
+			// 		to
+			// 	} else {
+			// 		todo!("new and")
+			// 	};
+
+			// 	environment
+			// 		.facts
+			// 		.current_properties
+			// 		.entry(on)
+			// 		.or_default()
+			// 		.push((under, Property::Value(with.unwrap_or(TypeId::ANY_TYPE))));
+			// } else {
+			// 	crate::utils::notify!("Found existing property on dynamic constraint");
+			// }
+
+			// let constructor_result =
+			// 	types.register_type(Type::Constructor(Constructor::Property { on, under }));
+
+			// // environment
+			// // 	.context_type
+			// // 	.get_inferrable_constraints_mut()
+			// // 	.unwrap()
+			// // 	.insert(constructor_result);
+
+			// Some(GetResult::AccessIntroducesDependence(constructor_result))
+		}
+	}
+}
+
 /// Aka a assignment to a property, **INCLUDING initialization of a new one**
 ///
 /// Evaluates setters
-pub(crate) fn set_property(
-	environment: &mut Environment,
+pub(crate) fn set_property<E: CallCheckingBehavior>(
 	on: TypeId,
 	under: TypeId,
 	new: Property,
+	environment: &mut Environment,
+	behavior: &mut E,
 	types: &mut TypeStore,
 ) -> Result<Option<TypeId>, SetPropertyError> {
-	let pair = (on, under);
+	// TODO
+	// if environment.is_not_writeable(on, under) {
+	// 	return Err(SetPropertyError::NotWriteable);
+	// }
 
-	if environment.parents_iter().any(|env| get_on_ctx!(env.writable.get(&pair)).is_some()) {
-		return Err(SetPropertyError::NotWriteable);
-	}
-
-	{
+	if E::CHECK_TYPES {
 		let property_constraint = {
-			let constraint = environment
-				.parents_iter()
-				.find_map(|env| get_on_ctx!(env.object_constraints.get(&on)).cloned());
+			let constraint = environment.get_object_constraint(on);
 
 			match constraint {
 				Some(constraint) => {
@@ -386,8 +422,9 @@ pub(crate) fn set_property(
 		match fact {
 			Logical::Pure(og) => match og {
 				Property::Value(og) => {
-					environment.properties.entry(on).or_default().push((under, new.clone()));
-					environment.context_type.events.push(Event::Setter {
+					let facts = behavior.get_top_level_facts(environment);
+					facts.current_properties.entry(on).or_default().push((under, new.clone()));
+					facts.events.push(Event::Setter {
 						on,
 						new,
 						under,
@@ -397,22 +434,14 @@ pub(crate) fn set_property(
 					});
 				}
 				Property::Getter(_) => todo!(),
-				Property::Setter(_) => todo!(),
-				Property::GetterAndSetter(_, _) => todo!(),
+				Property::GetterAndSetter(_, _setter) | Property::Setter(_setter) => todo!(),
 			},
 			Logical::Or(_) => todo!(),
 			Logical::Implies(_, _) => todo!(),
 		}
 	} else {
 		// TODO abstract
-		environment.properties.entry(on).or_default().push((under, new.clone()));
-		environment.context_type.events.push(Event::Setter {
-			on,
-			new,
-			under,
-			reflects_dependency: None,
-			initialization: true,
-		});
+		behavior.get_top_level_facts(environment).register_property(on, under, new, false);
 	}
 	Ok(None)
 }

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -107,11 +107,11 @@ pub(crate) fn get_property<'a, E: CallCheckingBehavior>(
 	Some(PropertyResult::Direct(value))
 }
 
-fn get_from_an_object(
+fn get_from_an_object<'a, E: CallCheckingBehavior>(
 	on: TypeId,
 	under: TypeId,
 	environment: &mut Environment,
-	behavior: &mut impl CallCheckingBehavior,
+	behavior: &mut E,
 	types: &mut TypeStore,
 ) -> Option<PropertyResult> {
 	match environment.get_property_unbound(on, under, types)? {
@@ -225,13 +225,13 @@ fn get_from_an_object(
 	}
 }
 
-fn getter_on_type(
+fn getter_on_type<'a, E: CallCheckingBehavior>(
 	constraint: PolyBase,
 	under: TypeId,
 	on: TypeId,
 	with: Option<TypeId>,
 	environment: &mut Environment,
-	behavior: &mut impl CallCheckingBehavior,
+	behavior: &mut E,
 	types: &mut TypeStore,
 ) -> Option<TypeId> {
 	match constraint {
@@ -347,7 +347,7 @@ fn getter_on_type(
 /// Aka a assignment to a property, **INCLUDING initialization of a new one**
 ///
 /// Evaluates setters
-pub(crate) fn set_property<E: CallCheckingBehavior>(
+pub(crate) fn set_property<'a, E: CallCheckingBehavior>(
 	on: TypeId,
 	under: TypeId,
 	new: Property,
@@ -360,7 +360,7 @@ pub(crate) fn set_property<E: CallCheckingBehavior>(
 	// 	return Err(SetPropertyError::NotWriteable);
 	// }
 
-	if E::CHECK_TYPES {
+	if E::CHECK_PARAMETERS {
 		let property_constraint = {
 			let constraint = environment.get_object_constraint(on);
 


### PR DESCRIPTION
Currently when applying events (after calling a function) the parameter checking (and others) was repeated. This PR adds a new `CallCheckingBehavior` trait that flows between things that can call (getting and setting properties as well as the obvious function calling). While still having access to root environment, it skips checking.

The additional `Target` struct which implements  `CallCheckingBehavior` is used whem applying events (and thus does not check). It fixes applying undecidable conditional events (check specification a example).

Still some work to do.