### PR TITLE
Add basic comments as types for variables

### DIFF
--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -226,12 +226,13 @@ pub(super) fn synthesize_variable_declaration_item<
 ) where
 	for<'a> Option<&'a parser::Expression>: From<&'a U>,
 {
-	let var_ty_and_pos = variable_declaration.type_annotation.as_ref().map(|reference| {
-		(
-			synthesize_type_annotation(reference, environment, checking_data),
-			reference.get_position().into_owned(),
-		)
-	});
+	// This is only added if there is an annotation, so can be None
+	let get_position = variable_declaration.get_position();
+	let var_ty_and_pos = checking_data
+		.type_mappings
+		.variable_restrictions
+		.get(&(get_position.source, get_position.start))
+		.map(|(ty, pos)| (*ty, pos.clone()));
 
 	let value_ty = if let Some(value) =
 		Option::<&parser::Expression>::from(&variable_declaration.expression)

--- a/checker/src/type_mappings.rs
+++ b/checker/src/type_mappings.rs
@@ -3,6 +3,8 @@ use std::{
 	path::PathBuf,
 };
 
+use source_map::{SourceId, Span};
+
 use super::range_map::RangeMap;
 
 use crate::{
@@ -27,6 +29,9 @@ pub struct TypeMappings {
 	pub import_statements_to_pointing_path: RangeMap<PathBuf>,
 	/// can be used for tree shaking
 	pub called_functions: HashSet<FunctionId>,
+
+	/// Variable restriction. Cached after hoisting pass. TODO temp needs tidy
+	pub variable_restrictions: HashMap<(SourceId, u32), (TypeId, Span)>,
 }
 
 #[derive(Default, Debug)]

--- a/parser/src/comments.rs
+++ b/parser/src/comments.rs
@@ -2,14 +2,14 @@
 
 use super::{ASTNode, ParseError, Span, TSXToken, TokenReader};
 use crate::{ParseOptions, Visitable};
-use std::{borrow::Cow, mem};
+use std::borrow::Cow;
 use tokenizer_lib::Token;
 
 #[derive(Debug, Clone, Eq)]
 pub enum WithComment<T> {
 	None(T),
-	PrefixComment(String, T),
-	PostfixComment(T, String),
+	PrefixComment(String, T, Span),
+	PostfixComment(T, String, Span),
 }
 
 // Ignore comments for now
@@ -24,8 +24,8 @@ where
 	) {
 		match self {
 			WithComment::None(item)
-			| WithComment::PrefixComment(_, item)
-			| WithComment::PostfixComment(item, _) => {
+			| WithComment::PrefixComment(_, item, _)
+			| WithComment::PostfixComment(item, _, _) => {
 				let inner = self_rust_tokenize::SelfRustTokenize::to_tokens(item);
 				token_stream.extend(self_rust_tokenize::quote!(WithComment::None(#inner)))
 			}
@@ -70,31 +70,24 @@ impl<T> From<T> for WithComment<T> {
 impl<T> WithComment<T> {
 	pub fn get_ast(self) -> T {
 		match self {
-			Self::None(ast) | Self::PrefixComment(_, ast) | Self::PostfixComment(ast, _) => ast,
+			Self::None(ast) | Self::PrefixComment(_, ast, _) | Self::PostfixComment(ast, _, _) => {
+				ast
+			}
 		}
 	}
 
 	pub fn get_ast_ref(&self) -> &T {
 		match self {
-			Self::None(ast) | Self::PrefixComment(_, ast) | Self::PostfixComment(ast, _) => ast,
+			Self::None(ast) | Self::PrefixComment(_, ast, _) | Self::PostfixComment(ast, _, _) => {
+				ast
+			}
 		}
 	}
 
 	pub fn get_ast_mut(&mut self) -> &mut T {
 		match self {
-			Self::None(ast) | Self::PrefixComment(_, ast) | Self::PostfixComment(ast, _) => ast,
-		}
-	}
-
-	// TODO not sure about location of this
-	pub fn add_comment(&mut self, comment: &str) {
-		match self {
-			Self::None(t) => {
-				let t = mem::replace(t, unsafe { mem::zeroed() });
-				*self = Self::PrefixComment(comment.to_owned(), t);
-			}
-			Self::PrefixComment(prev_comment, _) | Self::PostfixComment(_, prev_comment) => {
-				prev_comment.push_str(comment)
+			Self::None(ast) | Self::PrefixComment(_, ast, _) | Self::PostfixComment(ast, _, _) => {
+				ast
 			}
 		}
 	}
@@ -102,8 +95,12 @@ impl<T> WithComment<T> {
 	pub fn map<U>(self, cb: impl FnOnce(T) -> U) -> WithComment<U> {
 		match self {
 			Self::None(item) => WithComment::None(cb(item)),
-			Self::PrefixComment(comment, item) => WithComment::PrefixComment(comment, cb(item)),
-			Self::PostfixComment(item, comment) => WithComment::PostfixComment(cb(item), comment),
+			Self::PrefixComment(comment, item, position) => {
+				WithComment::PrefixComment(comment, cb(item), position)
+			}
+			Self::PostfixComment(item, comment, position) => {
+				WithComment::PostfixComment(cb(item), comment, position)
+			}
 		}
 	}
 }
@@ -114,35 +111,37 @@ impl<T: ASTNode> ASTNode for WithComment<T> {
 		state: &mut crate::ParsingState,
 		settings: &ParseOptions,
 	) -> Result<WithComment<T>, ParseError> {
-		if matches!(reader.peek(), Some(Token(TSXToken::MultiLineComment(..), _))) {
-			let comment = if let TSXToken::MultiLineComment(comment) = reader.next().unwrap().0 {
-				comment
-			} else {
+		if let Some(token) =
+			reader.conditional_next(|t| matches!(t, TSXToken::MultiLineComment(..)))
+		{
+			let Token(TSXToken::MultiLineComment(comment), position) = token else {
 				unreachable!();
 			};
-			Ok(Self::PrefixComment(comment, T::from_reader(reader, state, settings)?))
+			let item = T::from_reader(reader, state, settings)?;
+			let position = position.union(&item.get_position());
+			Ok(Self::PrefixComment(comment, item, position))
 		} else {
-			let key = T::from_reader(reader, state, settings)?;
-			if matches!(reader.peek(), Some(Token(TSXToken::MultiLineComment(..), _))) {
-				let comment = if let TSXToken::MultiLineComment(comment) = reader.next().unwrap().0
-				{
-					comment
-				} else {
+			let item = T::from_reader(reader, state, settings)?;
+			if let Some(token) =
+				reader.conditional_next(|t| matches!(t, TSXToken::MultiLineComment(..)))
+			{
+				let Token(TSXToken::MultiLineComment(comment), position) = token else {
 					unreachable!();
 				};
-				Ok(Self::PostfixComment(key, comment))
+				let position = item.get_position().union(&position);
+				Ok(Self::PostfixComment(item, comment, position))
 			} else {
-				Ok(Self::None(key))
+				Ok(Self::None(item))
 			}
 		}
 	}
 
-	// TODO doesn't include comment space might be fine
 	fn get_position(&self) -> Cow<Span> {
 		match self {
 			Self::None(ast) => ast.get_position(),
-			Self::PrefixComment(_, ast) => ast.get_position(),
-			Self::PostfixComment(ast, _) => ast.get_position(),
+			Self::PostfixComment(_, _, position) | Self::PrefixComment(_, _, position) => {
+				Cow::Borrowed(position)
+			}
 		}
 	}
 
@@ -154,7 +153,7 @@ impl<T: ASTNode> ASTNode for WithComment<T> {
 	) {
 		match self {
 			Self::None(ast) => ast.to_string_from_buffer(buf, settings, depth),
-			Self::PrefixComment(comment, ast) => {
+			Self::PrefixComment(comment, ast, _) => {
 				if settings.should_add_comment() {
 					buf.push_str("/*");
 					buf.push_str_contains_new_line(comment.as_str());
@@ -162,7 +161,7 @@ impl<T: ASTNode> ASTNode for WithComment<T> {
 				}
 				ast.to_string_from_buffer(buf, settings, depth);
 			}
-			Self::PostfixComment(ast, comment) => {
+			Self::PostfixComment(ast, comment, _) => {
 				ast.to_string_from_buffer(buf, settings, depth);
 				if settings.should_add_comment() {
 					buf.push_str(" /*");

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -189,7 +189,7 @@ pub trait ASTNode: Sized + Clone + PartialEq + std::fmt::Debug + Sync + Send + '
 		source: String,
 		settings: ParseOptions,
 		source_id: SourceId,
-		offset: Option<usize>,
+		offset: Option<u32>,
 		cursors: Vec<(usize, EmptyCursorId)>,
 	) -> ParseResult<Self> {
 		use source_map::LineStarts;
@@ -230,7 +230,7 @@ fn lex_and_parse_script<T: ASTNode>(
 	options: ParseOptions,
 	script: String,
 	source: SourceId,
-	offset: Option<usize>,
+	offset: Option<u32>,
 	cursors: Vec<(usize, CursorId<()>)>,
 ) -> Result<T, ParseError> {
 	let (mut sender, mut reader) = tokenizer_lib::ParallelTokenQueue::new();

--- a/parser/src/variable_fields.rs
+++ b/parser/src/variable_fields.rs
@@ -72,8 +72,10 @@ pub enum VariableField<T: VariableFieldKind> {
 	/// `x`
 	Name(VariableIdentifier),
 	/// `[x, y, z]`
+	/// TODO spread last
 	Array(Vec<ArrayDestructuringField<T>>, Span),
 	/// `{ x, y: z }`.
+	/// TODO spread last
 	Object(Vec<WithComment<ObjectDestructuringField<T>>>, Span),
 }
 


### PR DESCRIPTION
Treat postfix comments on variable identifiers and function parameters as a type annotation

```js
error:
  ┌─ .\private\test-files\demo.ts:1:24
  │
1 │ const x /* string */ = 4;
  │            ------      ^ Type 4 is not assignable to type string
  │            │
  │            Variable declared with type string
```

*this PR also adds a few changes to the parser to make this work*