### PR TITLE
Add positions to events (issue #37)

### DIFF
--- a/checker/specification/specification.md
+++ b/checker/specification/specification.md
@@ -123,7 +123,7 @@ function func(): string {
 }
 ```
 
-- Function is expected to return string but returned 2
+- Cannot return 2 because the function is expected to return string
 
 #### *Inferred* return type
 
@@ -201,7 +201,7 @@ function getSecond2<T, U>(p1: T, p2: U): U {
 }
 ```
 
-- Function is expected to return U but returned T
+- Cannot return T because the function is expected to return U
 
 #### Use of generics in function body
 
@@ -229,7 +229,7 @@ function createObject2<T, U>(a: T, b: U): { a: U, b: U } {
 }
 ```
 
-- Function is expected to return {"a": U, "b": U, } but returned {"a": T, "b": U, }
+- Cannot return {"a": T, "b": U, } because the function is expected to return {"a": U, "b": U, }
 
 ### Function calling
 

--- a/checker/src/behavior/functions.rs
+++ b/checker/src/behavior/functions.rs
@@ -58,9 +58,13 @@ impl<M: crate::ASTImplementation> FunctionRegisterBehavior<M> for RegisterAsType
 		let id = func_ty.id;
 		types.functions.insert(id, func_ty);
 		let ty = types.register_type(crate::Type::Function(id, ThisValue::UseParent));
+
+		// TODO: Needs a way to get position (perhaps from a method in `SynthesisableFunction`).
+		// Can `return_type_annotation` be used to get the position?
 		environment.facts.events.push(Event::CreateObject {
 			prototype: crate::events::PrototypeArgument::Function(id),
 			referenced_in_scope_as: ty,
+			position: None,
 		});
 		ty
 	}
@@ -83,9 +87,11 @@ impl<M: crate::ASTImplementation> FunctionRegisterBehavior<M> for RegisterOnExis
 		types.functions.insert(id, func_ty);
 		let ty = types.register_type(crate::Type::Function(id, Default::default()));
 		context.facts.variable_current_value.insert(self.0, ty);
+		// TODO Needs a position
 		context.facts.events.push(Event::CreateObject {
 			prototype: crate::events::PrototypeArgument::Function(id),
 			referenced_in_scope_as: ty,
+			position: None,
 		});
 	}
 }
@@ -111,9 +117,12 @@ impl<M: crate::ASTImplementation> FunctionRegisterBehavior<M> for RegisterOnExis
 				let id = func_ty.id;
 				types.functions.insert(id, func_ty);
 				let ty = types.register_type(Type::Function(id, Default::default()));
+
+				// TODO Needs a position
 				environment.facts.events.push(Event::CreateObject {
 					prototype: crate::events::PrototypeArgument::Function(id),
 					referenced_in_scope_as: ty,
+					position: None,
 				});
 				Property::Value(ty)
 			}

--- a/checker/src/behavior/functions.rs
+++ b/checker/src/behavior/functions.rs
@@ -199,10 +199,15 @@ pub enum ThisValue {
 }
 
 impl ThisValue {
-	pub(crate) fn get(&self, environment: &mut Environment, types: &mut TypeStore) -> TypeId {
+	pub(crate) fn get(
+		&self,
+		environment: &mut Environment,
+		types: &mut TypeStore,
+		position: SpanWithSource,
+	) -> TypeId {
 		match self {
 			ThisValue::Passed(value) => *value,
-			ThisValue::UseParent => environment.get_value_of_this(types),
+			ThisValue::UseParent => environment.get_value_of_this(types, position),
 		}
 	}
 

--- a/checker/src/behavior/objects.rs
+++ b/checker/src/behavior/objects.rs
@@ -1,3 +1,5 @@
+use source_map::SpanWithSource;
+
 use crate::{
 	context::{
 		facts::{Facts, PublicityKind},
@@ -25,8 +27,9 @@ impl ObjectBuilder {
 		under: TypeId,
 		value: Property,
 		property: PublicityKind,
+		position: Option<SpanWithSource>,
 	) {
-		environment.facts.register_property(self.object, under, value, true, property)
+		environment.facts.register_property(self.object, under, value, true, property, position)
 	}
 
 	pub fn build_object(self) -> TypeId {

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -758,8 +758,8 @@ impl<'a> Environment<'a> {
 		}
 	}
 
-	pub fn throw_value(&mut self, value: TypeId) {
-		self.facts.events.push(Event::Throw(value));
+	pub fn throw_value(&mut self, value: TypeId, position: SpanWithSource) {
+		self.facts.events.push(Event::Throw(value, position));
 	}
 
 	pub fn return_value(&mut self, returned: TypeId, returned_position: SpanWithSource) {

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -733,11 +733,12 @@ impl<'a> Environment<'a> {
 				&mut checking_data.types,
 			);
 			let falsy_events = falsy_environment.facts.events;
-			// TODO
+			// TODO It might be possible to get position from one of the SynthesisableConditional but its `get_position` is not implemented yet
 			self.facts.events.push(Event::Conditionally {
 				condition,
 				events_if_truthy: truthy_events.into_boxed_slice(),
 				else_events: falsy_events.into_boxed_slice(),
+				position: None,
 			});
 
 			// TODO all things that are
@@ -750,6 +751,7 @@ impl<'a> Environment<'a> {
 				condition,
 				events_if_truthy: truthy_events.into_boxed_slice(),
 				else_events: Default::default(),
+				position: None,
 			});
 
 			// TODO above
@@ -805,6 +807,7 @@ impl<'a> Environment<'a> {
 		));
 
 		let prototype = crate::events::PrototypeArgument::Yeah(over);
+		// TODO Unknown position
 		let event = Event::Conditionally {
 			condition,
 			events_if_truthy: Box::new([Event::CreateObject {
@@ -812,6 +815,7 @@ impl<'a> Environment<'a> {
 				prototype,
 			}]),
 			else_events: Box::new([]),
+			position: None,
 		};
 
 		self.facts.events.push(event);

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -813,6 +813,7 @@ impl<'a> Environment<'a> {
 			events_if_truthy: Box::new([Event::CreateObject {
 				referenced_in_scope_as: ty,
 				prototype,
+				position: None,
 			}]),
 			else_events: Box::new([]),
 			position: None,

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -172,7 +172,14 @@ impl<'a> Environment<'a> {
 								checking_data,
 							)),
 						Reference::Property { on, with, publicity, span } => Ok(env
-							.set_property(on, with, publicity, new, &mut checking_data.types)?
+							.set_property(
+								on,
+								with,
+								publicity,
+								new,
+								&mut checking_data.types,
+								Some(span),
+							)?
 							.unwrap_or(new)),
 					}
 				}
@@ -769,6 +776,7 @@ impl<'a> Environment<'a> {
 		kind: PublicityKind,
 		new: TypeId,
 		types: &mut TypeStore,
+		setter_position: Option<SpanWithSource>,
 	) -> Result<Option<TypeId>, SetPropertyError> {
 		crate::types::properties::set_property(
 			on,
@@ -778,6 +786,7 @@ impl<'a> Environment<'a> {
 			self,
 			&mut CheckThings,
 			types,
+			setter_position,
 		)
 	}
 

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -755,8 +755,8 @@ impl<'a> Environment<'a> {
 		self.facts.events.push(Event::Throw(value));
 	}
 
-	pub fn return_value(&mut self, returned: TypeId, position: SpanWithSource) {
-		self.facts.events.push(Event::Return { returned, position })
+	pub fn return_value(&mut self, returned: TypeId, returned_position: SpanWithSource) {
+		self.facts.events.push(Event::Return { returned, returned_position })
 	}
 
 	/// Updates **a existing property**

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -609,11 +609,13 @@ impl<'a> Environment<'a> {
 
 			// TODO temp position
 			let mut value = None;
+
 			for event in self.facts.events.iter() {
 				// TODO explain why don't need to detect sets
 				if let Event::ReadsReference {
 					reference: other_reference,
 					reflects_dependency: Some(dep),
+					position,
 				} = event
 				{
 					if reference == *other_reference {
@@ -643,6 +645,7 @@ impl<'a> Environment<'a> {
 				self.facts.events.push(Event::ReadsReference {
 					reference: RootReference::Variable(og_var.get_id()),
 					reflects_dependency: Some(ty),
+					position,
 				});
 
 				ty
@@ -999,6 +1002,7 @@ pub(crate) fn get_this_type_from_constraint(
 	facts: &mut Facts,
 	this_ty: TypeId,
 	types: &mut TypeStore,
+	position: SpanWithSource,
 ) -> TypeId {
 	// TODO `this_ty` can be error here..?
 	if this_ty == TypeId::ERROR_TYPE {
@@ -1034,6 +1038,7 @@ pub(crate) fn get_this_type_from_constraint(
 		if let Event::ReadsReference {
 			reference: other_reference,
 			reflects_dependency: Some(dep),
+			position,
 		} = event
 		{
 			if reference == RootReference::This {
@@ -1049,6 +1054,7 @@ pub(crate) fn get_this_type_from_constraint(
 	facts.events.push(Event::ReadsReference {
 		reference: RootReference::This,
 		reflects_dependency: Some(ty),
+		position,
 	});
 
 	ty

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -746,8 +746,8 @@ impl<'a> Environment<'a> {
 		self.facts.events.push(Event::Throw(value));
 	}
 
-	pub fn return_value(&mut self, returned: TypeId) {
-		self.facts.events.push(Event::Return { returned })
+	pub fn return_value(&mut self, returned: TypeId, position: SpanWithSource) {
+		self.facts.events.push(Event::Return { returned, position })
 	}
 
 	/// Updates **a existing property**

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -488,6 +488,7 @@ impl<'a> Environment<'a> {
 		kind: PublicityKind,
 		types: &mut TypeStore,
 		with: Option<TypeId>,
+		position: SpanWithSource,
 	) -> Option<(PropertyKind, TypeId)> {
 		crate::types::properties::get_property(
 			on,
@@ -497,6 +498,7 @@ impl<'a> Environment<'a> {
 			self,
 			&mut CheckThings,
 			types,
+			position,
 		)
 	}
 
@@ -508,7 +510,7 @@ impl<'a> Environment<'a> {
 		checking_data: &mut CheckingData<U, M>,
 		site: SpanWithSource,
 	) -> TypeId {
-		match self.get_property(on, property, kind, &mut checking_data.types, None) {
+		match self.get_property(on, property, kind, &mut checking_data.types, None, site.clone()) {
 			Some((_, ty)) => ty,
 			None => {
 				checking_data.diagnostics_container.add_error(

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -419,7 +419,11 @@ impl<'a> Environment<'a> {
 
 							let variable_id = variable.get_id();
 
-							self.facts.events.push(Event::SetsVariable(variable_id, new_type));
+							self.facts.events.push(Event::SetsVariable(
+								variable_id,
+								new_type,
+								assignment_position,
+							));
 							self.facts.variable_current_value.insert(variable_id, new_type);
 
 							Ok(new_type)

--- a/checker/src/context/facts.rs
+++ b/checker/src/context/facts.rs
@@ -89,7 +89,9 @@ impl Facts {
 			};
 			// TODO maybe register the environment if function ...
 			// TODO register properties
-			let value = Event::CreateObject { referenced_in_scope_as: ty, prototype };
+			// TODO Needs a position (or not?)
+			let value =
+				Event::CreateObject { referenced_in_scope_as: ty, prototype, position: None };
 			self.events.push(value);
 		}
 

--- a/checker/src/context/facts.rs
+++ b/checker/src/context/facts.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Cow, collections::HashMap};
 
+use source_map::SpanWithSource;
+
 use crate::{
 	behavior::functions::ClosureId,
 	events::{Event, RootReference},
@@ -42,6 +44,7 @@ impl Facts {
 		to: Property,
 		register_setter_event: bool,
 		publicity: PublicityKind,
+		position: Option<SpanWithSource>,
 	) {
 		// crate::utils::notify!("Registering {:?} {:?} {:?}", on, under, to);
 		self.current_properties.entry(on).or_default().push((under, publicity, to.clone()));
@@ -53,6 +56,7 @@ impl Facts {
 				reflects_dependency: None,
 				initialization: true,
 				publicity,
+				position,
 			});
 		}
 	}

--- a/checker/src/context/facts.rs
+++ b/checker/src/context/facts.rs
@@ -61,8 +61,8 @@ impl Facts {
 		}
 	}
 
-	pub(crate) fn throw_value(&mut self, value: TypeId) {
-		self.events.push(Event::Throw(value));
+	pub(crate) fn throw_value(&mut self, value: TypeId, position: SpanWithSource) {
+		self.events.push(Event::Throw(value, position));
 	}
 
 	pub fn get_events(&self) -> &[Event] {

--- a/checker/src/context/mod.rs
+++ b/checker/src/context/mod.rs
@@ -1400,12 +1400,16 @@ impl<T: ContextType> Context<T> {
 		self.parents_iter().map(|env| get_on_ctx!(&env.facts))
 	}
 
-	pub(crate) fn get_value_of_this(&mut self, types: &mut TypeStore) -> TypeId {
+	pub(crate) fn get_value_of_this(
+		&mut self,
+		types: &mut TypeStore,
+		position: SpanWithSource,
+	) -> TypeId {
 		match self.can_use_this {
 			CanUseThis::NotYetSuperToBeCalled { .. } => todo!("Cannot use super before call"),
 			CanUseThis::ConstructorCalled { this_ty } => this_ty,
 			CanUseThis::Yeah { this_ty } => {
-				get_this_type_from_constraint(&mut self.facts, this_ty, types)
+				get_this_type_from_constraint(&mut self.facts, this_ty, types, position)
 			}
 		}
 	}

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -446,7 +446,7 @@ mod defined_errors_and_warnings {
 					returned_type,
 				} => Diagnostic::PositionWithAdditionLabels {
 					reason: format!(
-						"Cannot return {returned_type} because function expected to return {expected_return_type}",
+						"Cannot return {returned_type} because the function is expected to return {expected_return_type}",
 					),
 					labels: vec![(
 						format!("Function annotated to return {expected_return_type} here"),

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -446,8 +446,7 @@ mod defined_errors_and_warnings {
 					returned_type,
 				} => Diagnostic::PositionWithAdditionLabels {
 					reason: format!(
-						"Function is expected to return {expected_return_type} but returned {returned_type} {:?}",
-						returned_position.clone()
+						"Function is expected to return {expected_return_type} but returned {returned_type}",
 					),
 					labels: vec![(
 						format!("The returned {returned_type} came from here."),

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -209,6 +209,7 @@ mod defined_errors_and_warnings {
 			expected_return_type: TypeStringRepresentation,
 			returned_type: TypeStringRepresentation,
 			position: SpanWithSource,
+			returned_position: SpanWithSource,
 		},
 		// TODO are these the same errors?
 		TypeIsNotIndexable(TypeStringRepresentation),
@@ -440,12 +441,18 @@ mod defined_errors_and_warnings {
 				},
 				TypeCheckError::ReturnedTypeDoesNotMatch {
 					position,
+					returned_position,
 					expected_return_type,
 					returned_type,
-				} => Diagnostic::Position {
+				} => Diagnostic::PositionWithAdditionLabels {
 					reason: format!(
-						"Function is expected to return {expected_return_type} but returned {returned_type}",
+						"Function is expected to return {expected_return_type} but returned {returned_type} {:?}",
+						returned_position.clone()
 					),
+					labels: vec![(
+						format!("The returned {returned_type} came from here."),
+						Some(returned_position.clone()),
+					)],
 					position,
 					kind: super::DiagnosticKind::Error,
 				},

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -208,7 +208,7 @@ mod defined_errors_and_warnings {
 		ReturnedTypeDoesNotMatch {
 			expected_return_type: TypeStringRepresentation,
 			returned_type: TypeStringRepresentation,
-			position: SpanWithSource,
+			annotation_position: SpanWithSource,
 			returned_position: SpanWithSource,
 		},
 		// TODO are these the same errors?
@@ -440,19 +440,19 @@ mod defined_errors_and_warnings {
 					kind: super::DiagnosticKind::Error,
 				},
 				TypeCheckError::ReturnedTypeDoesNotMatch {
-					position,
+					annotation_position,
 					returned_position,
 					expected_return_type,
 					returned_type,
 				} => Diagnostic::PositionWithAdditionLabels {
 					reason: format!(
-						"Function is expected to return {expected_return_type} but returned {returned_type}",
+						"Cannot return {returned_type} because function expected to return {expected_return_type}",
 					),
 					labels: vec![(
-						format!("The returned {returned_type} came from here."),
-						Some(returned_position.clone()),
+						format!("Function annotated to return {expected_return_type} here"),
+						Some(annotation_position.clone()),
 					)],
-					position,
+					position: returned_position,
 					kind: super::DiagnosticKind::Error,
 				},
 				TypeCheckError::TypeHasNoGenericParameters(name, position) => {

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -64,12 +64,13 @@ pub(crate) fn apply_event(
 			facts.events.push(Event::SetsVariable(variable, new_value, position));
 			facts.variable_current_value.insert(variable, new_value);
 		}
-		Event::Getter { on, under, reflects_dependency, publicity } => {
+		Event::Getter { on, under, reflects_dependency, publicity, position } => {
 			let on = substitute(on, type_arguments, environment, types);
 			let property = substitute(under, type_arguments, environment, types);
 
-			let (_, value) = get_property(on, under, publicity, None, environment, target, types)
-				.expect("Inferred constraints and checking failed");
+			let (_, value) =
+				get_property(on, under, publicity, None, environment, target, types, position)
+					.expect("Inferred constraints and checking failed");
 
 			if let Some(id) = reflects_dependency {
 				type_arguments.set_id_from_reference(id, value, types);

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -253,7 +253,7 @@ pub(crate) fn apply_event(
 				});
 			}
 		}
-		Event::Return { returned, position } => {
+		Event::Return { returned, returned_position } => {
 			let substituted_returned = substitute(returned, type_arguments, environment, types);
 
 			if substituted_returned != TypeId::ERROR_TYPE {

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -76,7 +76,15 @@ pub(crate) fn apply_event(
 				type_arguments.set_id_from_reference(id, value, types);
 			}
 		}
-		Event::Setter { on, under, new, reflects_dependency, initialization, publicity } => {
+		Event::Setter {
+			on,
+			under,
+			new,
+			reflects_dependency,
+			initialization,
+			publicity,
+			position,
+		} => {
 			let on = substitute(on, type_arguments, environment, types);
 			let under = substitute(under, type_arguments, environment, types);
 
@@ -118,10 +126,11 @@ pub(crate) fn apply_event(
 					};
 				target
 					.get_top_level_facts(environment)
-					.register_property(on, under, new, true, publicity);
+					.register_property(on, under, new, true, publicity, position);
 			} else {
 				let returned =
-					set_property(on, under, publicity, new, environment, target, types).unwrap();
+					set_property(on, under, publicity, new, environment, target, types, position)
+						.unwrap();
 
 				if let Some(id) = reflects_dependency {
 					type_arguments.set_id_from_reference(

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -213,7 +213,7 @@ pub(crate) fn apply_event(
 			}
 		}
 		// TODO extract
-		Event::Conditionally { condition, events_if_truthy, else_events } => {
+		Event::Conditionally { condition, events_if_truthy, else_events, position } => {
 			let condition = substitute(condition, type_arguments, environment, types);
 
 			if let TruthyFalsy::Decidable(result) = is_type_truthy_falsy(condition, types) {
@@ -259,6 +259,7 @@ pub(crate) fn apply_event(
 					condition,
 					events_if_truthy: truthy_facts.events.into_boxed_slice(),
 					else_events: else_facts.events.into_boxed_slice(),
+					position,
 				});
 			}
 		}

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -141,7 +141,7 @@ pub(crate) fn apply_event(
 				}
 			}
 		}
-		Event::CallsType { on, with, reflects_dependency, timing, called_with_new } => {
+		Event::CallsType { on, with, reflects_dependency, timing, called_with_new, position } => {
 			let on = substitute(on, type_arguments, environment, types);
 
 			let with = with

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -23,7 +23,7 @@ pub(crate) fn apply_event(
 	types: &mut TypeStore,
 ) -> EarlyReturn {
 	match event {
-		Event::ReadsReference { reference, reflects_dependency } => {
+		Event::ReadsReference { reference, reflects_dependency, position } => {
 			if let Some(id) = reflects_dependency {
 				let value = match reference {
 					RootReference::Variable(id) => {
@@ -40,7 +40,7 @@ pub(crate) fn apply_event(
 							}
 						}
 					}
-					RootReference::This => this_value.get(environment, types),
+					RootReference::This => this_value.get(environment, types, position),
 				};
 				type_arguments.set_id_from_reference(id, value, types);
 			}

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -45,7 +45,7 @@ pub(crate) fn apply_event(
 				type_arguments.set_id_from_reference(id, value, types);
 			}
 		}
-		Event::SetsVariable(variable, value) => {
+		Event::SetsVariable(variable, value, position) => {
 			let new_value = substitute(value, type_arguments, environment, types);
 
 			// if not closed over!!
@@ -61,7 +61,7 @@ pub(crate) fn apply_event(
 					.insert((*closure_id, RootReference::Variable(variable)), new_value);
 			}
 
-			facts.events.push(Event::SetsVariable(variable, new_value));
+			facts.events.push(Event::SetsVariable(variable, new_value, position));
 			facts.variable_current_value.insert(variable, new_value);
 		}
 		Event::Getter { on, under, reflects_dependency, publicity } => {

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -252,7 +252,7 @@ pub(crate) fn apply_event(
 				});
 			}
 		}
-		Event::Return { returned } => {
+		Event::Return { returned, position } => {
 			let substituted_returned = substitute(returned, type_arguments, environment, types);
 
 			if substituted_returned != TypeId::ERROR_TYPE {

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -272,7 +272,9 @@ pub(crate) fn apply_event(
 				crate::utils::notify!("event returned error so skipped");
 			}
 		}
-		Event::CreateObject { referenced_in_scope_as, prototype } => {
+
+		// TODO Needs a position (or not?)
+		Event::CreateObject { referenced_in_scope_as, prototype, position } => {
 			// TODO only if exposed via set
 
 			// TODO

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -203,10 +203,10 @@ pub(crate) fn apply_event(
 				}
 			}
 		}
-		Event::Throw(thrown) => {
+		Event::Throw(thrown, position) => {
 			let substituted_thrown = substitute(thrown, type_arguments, environment, types);
 
-			target.get_top_level_facts(environment).throw_value(substituted_thrown);
+			target.get_top_level_facts(environment).throw_value(substituted_thrown, position);
 
 			if substituted_thrown != TypeId::ERROR_TYPE {
 				return None;

--- a/checker/src/events/helpers.rs
+++ b/checker/src/events/helpers.rs
@@ -22,7 +22,7 @@ pub(crate) fn get_return_from_events<'a, T: crate::ReadFromFS, M: crate::ASTImpl
 ) -> ReturnedTypeFromBlock {
 	while let Some(event) = iter.next() {
 		match event {
-			Event::Return { returned, position } => {
+			Event::Return { returned, returned_position } => {
 				if let Some((expected_return_type, annotation_span)) = expected_return_type.clone()
 				{
 					let mut behavior = crate::subtyping::BasicEquality {
@@ -55,9 +55,9 @@ pub(crate) fn get_return_from_events<'a, T: crate::ReadFromFS, M: crate::ASTImpl
 										&checking_data.types,
 										false,
 									),
-								position: annotation_span.clone(),
+								annotation_position: annotation_span.clone(),
 								// TODO test with return_position
-								returned_position: position.clone(), // TODO event position here #37
+								returned_position: returned_position.clone(), // TODO event position here #37
 							},
 						);
 					}

--- a/checker/src/events/helpers.rs
+++ b/checker/src/events/helpers.rs
@@ -63,7 +63,7 @@ pub(crate) fn get_return_from_events<'a, T: crate::ReadFromFS, M: crate::ASTImpl
 				}
 				return ReturnedTypeFromBlock::Returned(*returned);
 			}
-			Event::Conditionally { condition: on, events_if_truthy, else_events } => {
+			Event::Conditionally { condition: on, events_if_truthy, else_events, position } => {
 				let return_if_truthy = get_return_from_events(
 					&mut events_if_truthy.iter(),
 					checking_data,

--- a/checker/src/events/helpers.rs
+++ b/checker/src/events/helpers.rs
@@ -56,8 +56,7 @@ pub(crate) fn get_return_from_events<'a, T: crate::ReadFromFS, M: crate::ASTImpl
 										false,
 									),
 								annotation_position: annotation_span.clone(),
-								// TODO test with return_position
-								returned_position: returned_position.clone(), // TODO event position here #37
+								returned_position: returned_position.clone(),
 							},
 						);
 					}

--- a/checker/src/events/helpers.rs
+++ b/checker/src/events/helpers.rs
@@ -22,7 +22,7 @@ pub(crate) fn get_return_from_events<'a, T: crate::ReadFromFS, M: crate::ASTImpl
 ) -> ReturnedTypeFromBlock {
 	while let Some(event) = iter.next() {
 		match event {
-			Event::Return { returned } => {
+			Event::Return { returned, position } => {
 				if let Some((expected_return_type, annotation_span)) = expected_return_type.clone()
 				{
 					let mut behavior = crate::subtyping::BasicEquality {
@@ -55,8 +55,9 @@ pub(crate) fn get_return_from_events<'a, T: crate::ReadFromFS, M: crate::ASTImpl
 										&checking_data.types,
 										false,
 									),
-								position: annotation_span,
-								// TODO event position here #37
+								position: annotation_span.clone(),
+								// TODO test with return_position
+								returned_position: position.clone(), // TODO event position here #37
 							},
 						);
 					}

--- a/checker/src/events/helpers.rs
+++ b/checker/src/events/helpers.rs
@@ -172,7 +172,7 @@ pub(crate) fn get_return_from_events<'a, T: crate::ReadFromFS, M: crate::ASTImpl
 					}
 				};
 			}
-			Event::Throw(_) => {
+			Event::Throw(_, _) => {
 				// TODO ReturnedTypeFromBlock::Thrown? however this does work
 				return ReturnedTypeFromBlock::Returned(TypeId::NEVER_TYPE);
 			}
@@ -188,7 +188,7 @@ pub(crate) fn get_return_from_events<'a, T: crate::ReadFromFS, M: crate::ASTImpl
 pub(crate) fn extract_throw_events(events: Vec<Event>, thrown: &mut Vec<TypeId>) -> Vec<Event> {
 	let mut new_events = Vec::new();
 	for event in events.into_iter() {
-		if let Event::Throw(value) = event {
+		if let Event::Throw(value, position) = event {
 			thrown.push(value);
 		} else {
 			// TODO nested grouping

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -59,6 +59,7 @@ pub enum Event {
 		under: TypeId,
 		reflects_dependency: Option<TypeId>,
 		publicity: PublicityKind,
+		position: SpanWithSource,
 	},
 	/// All changes to the value of a property
 	Setter {

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -73,6 +73,7 @@ pub enum Event {
 		/// see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields
 		initialization: bool,
 		publicity: PublicityKind,
+		position: Option<SpanWithSource>,
 	},
 
 	/// This includes closed over variables, anything dependent

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -52,7 +52,7 @@ pub enum Event {
 		position: SpanWithSource,
 	},
 	/// Also used for DCE
-	SetsVariable(VariableId, TypeId),
+	SetsVariable(VariableId, TypeId, SpanWithSource),
 	/// Mostly trivial, sometimes can call a function :(
 	Getter {
 		on: TypeId,

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -88,7 +88,12 @@ pub enum Event {
 	/// From a `throw ***` statement (or expression)
 	Throw(TypeId, SpanWithSource),
 	/// Run events conditionally
-	Conditionally { condition: TypeId, events_if_truthy: Box<[Event]>, else_events: Box<[Event]> },
+	Conditionally {
+		condition: TypeId,
+		events_if_truthy: Box<[Event]>,
+		else_events: Box<[Event]>,
+		position: Option<SpanWithSource>,
+	},
 	/// TODO not sure but whatever
 	Return { returned: TypeId, returned_position: SpanWithSource },
 	/// *lil bit magic*, handles:

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -83,6 +83,7 @@ pub enum Event {
 		reflects_dependency: Option<TypeId>,
 		timing: CallingTiming,
 		called_with_new: CalledWithNew,
+		position: SpanWithSource,
 	},
 	/// From a `throw ***` statement (or expression)
 	Throw(TypeId),

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -46,7 +46,11 @@ pub enum Event {
 	/// Reads variable
 	///
 	/// Can be used for DCE reasons, or finding variables in context
-	ReadsReference { reference: RootReference, reflects_dependency: Option<TypeId> },
+	ReadsReference {
+		reference: RootReference,
+		reflects_dependency: Option<TypeId>,
+		position: SpanWithSource,
+	},
 	/// Also used for DCE
 	SetsVariable(VariableId, TypeId),
 	/// Mostly trivial, sometimes can call a function :(

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -88,7 +88,7 @@ pub enum Event {
 	/// Run events conditionally
 	Conditionally { condition: TypeId, events_if_truthy: Box<[Event]>, else_events: Box<[Event]> },
 	/// TODO not sure but whatever
-	Return { returned: TypeId, position: SpanWithSource },
+	Return { returned: TypeId, returned_position: SpanWithSource },
 	/// *lil bit magic*, handles:
 	/// - Creating objects `{}`
 	/// - Creating objects with prototypes:

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -86,7 +86,7 @@ pub enum Event {
 		position: SpanWithSource,
 	},
 	/// From a `throw ***` statement (or expression)
-	Throw(TypeId),
+	Throw(TypeId, SpanWithSource),
 	/// Run events conditionally
 	Conditionally { condition: TypeId, events_if_truthy: Box<[Event]>, else_events: Box<[Event]> },
 	/// TODO not sure but whatever

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -6,7 +6,7 @@ use crate::{
 	behavior::functions::ThisValue,
 	context::{calling::Target, facts::PublicityKind, get_on_ctx, CallCheckingBehavior},
 	types::{calling::CalledWithNew, properties::Property},
-	FunctionId, GeneralContext, VariableId,
+	FunctionId, GeneralContext, SpanWithSource, VariableId,
 };
 
 pub(crate) mod application;
@@ -83,7 +83,7 @@ pub enum Event {
 	/// Run events conditionally
 	Conditionally { condition: TypeId, events_if_truthy: Box<[Event]>, else_events: Box<[Event]> },
 	/// TODO not sure but whatever
-	Return { returned: TypeId },
+	Return { returned: TypeId, position: SpanWithSource },
 	/// *lil bit magic*, handles:
 	/// - Creating objects `{}`
 	/// - Creating objects with prototypes:

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 pub(crate) mod application;
 pub(crate) mod helpers;
 pub(crate) use application::apply_event;
+use source_map::Span;
 
 use crate::{
 	types::functions::SynthesisedArgument,
@@ -117,6 +118,7 @@ pub enum Event {
 		///
 		/// This is also for the specialization (somehow)
 		referenced_in_scope_as: TypeId,
+		position: Option<SpanWithSource>,
 	},
 	// Registration(Registration),
 }

--- a/checker/src/synthesis/classes.rs
+++ b/checker/src/synthesis/classes.rs
@@ -131,9 +131,17 @@ pub(super) fn synthesise_class_declaration<
 						if static_kw.is_some() {
 							static_properties.push((key, publicity, property));
 						} else {
-							environment
-								.facts
-								.register_property(class_type, key, property, true, publicity);
+							let member_position =
+								member.position.clone().with_source(environment.get_source());
+
+							environment.facts.register_property(
+								class_type,
+								key,
+								property,
+								true,
+								publicity,
+								Some(member_position),
+							);
 							// TODO check not already exists
 
 							// if let Some(existing_property) = existing_property {

--- a/checker/src/synthesis/expressions.rs
+++ b/checker/src/synthesis/expressions.rs
@@ -425,11 +425,18 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 					todo!()
 				};
 
+			let access_position = position.clone().with_source(environment.get_source());
 			// TODO
 			let publicity = PublicityKind::Public;
 
-			let get_property =
-				environment.get_property(on, property, publicity, &mut checking_data.types, None);
+			let get_property = environment.get_property(
+				on,
+				property,
+				publicity,
+				&mut checking_data.types,
+				None,
+				access_position,
+			);
 
 			match get_property {
 				Some((kind, result)) => match kind {
@@ -559,12 +566,14 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 			let indexee = synthesise_expression(indexee, environment, checking_data);
 			let indexer = synthesise_multiple_expression(indexer, environment, checking_data);
 
+			let index_position = position.clone().with_source(environment.get_source());
 			let get_property = environment.get_property(
 				indexee,
 				indexer,
 				PublicityKind::Public,
 				&mut checking_data.types,
 				None,
+				index_position,
 			);
 
 			match get_property {

--- a/checker/src/synthesis/expressions.rs
+++ b/checker/src/synthesis/expressions.rs
@@ -462,7 +462,10 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 			}
 		}
 		Expression::ThisReference(..) => {
-			Instance::RValue(environment.get_value_of_this(&mut checking_data.types))
+			let position = SynthesisableExpression::get_position(expression)
+				.clone()
+				.with_source(environment.get_source());
+			Instance::RValue(environment.get_value_of_this(&mut checking_data.types, position))
 		}
 		Expression::SuperExpression(reference, position) => match reference {
 			SuperReference::Call { arguments } => {
@@ -856,7 +859,12 @@ pub(super) fn synthesise_class_fields<T: crate::ReadFromFS>(
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, super::EznoParser>,
 ) {
-	let this = environment.get_value_of_this(&mut checking_data.types);
+	// TODO: Needs clarification. This only passes the position of the first field. Should we pass all fields positions?
+	let fields_position = SynthesisableExpression::get_position(&fields[0].2)
+		.clone()
+		.with_source(environment.get_source());
+
+	let this = environment.get_value_of_this(&mut checking_data.types, fields_position);
 	for (under, publicity, mut expression) in fields {
 		let new = synthesise_expression(&expression, environment, checking_data);
 		environment.facts.events.push(Event::Setter {

--- a/checker/src/synthesis/expressions.rs
+++ b/checker/src/synthesis/expressions.rs
@@ -859,7 +859,9 @@ pub(super) fn synthesise_class_fields<T: crate::ReadFromFS>(
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, super::EznoParser>,
 ) {
+	todo!("get event position");
 	// TODO: Needs clarification. This only passes the position of the first field. Should we pass all fields positions?
+	// Placeholder implementation that passes the position of the first field in order to satisfy the compiler
 	let fields_position = SynthesisableExpression::get_position(&fields[0].2)
 		.clone()
 		.with_source(environment.get_source());

--- a/checker/src/synthesis/expressions.rs
+++ b/checker/src/synthesis/expressions.rs
@@ -861,7 +861,7 @@ pub(super) fn synthesise_class_fields<T: crate::ReadFromFS>(
 ) {
 	todo!("get event position");
 	// TODO: Needs clarification. This only passes the position of the first field. Should we pass all fields positions?
-	// Placeholder implementation that passes the position of the first field in order to satisfy the compiler
+	// TODO: Placeholder. This placeholder implementation retrieves the position of the first field in order to satisfy the compiler
 	let fields_position = SynthesisableExpression::get_position(&fields[0].2)
 		.clone()
 		.with_source(environment.get_source());

--- a/checker/src/synthesis/extensions/jsx.rs
+++ b/checker/src/synthesis/extensions/jsx.rs
@@ -41,11 +41,14 @@ pub(crate) fn synthesise_jsx_element<T: crate::ReadFromFS>(
 
 	for attribute in element.attributes.iter() {
 		let (name, attribute_value) = synthesise_attribute(attribute, environment, checking_data);
+		let attribute_position =
+			attribute.get_position().clone().with_source(environment.get_source());
 		attributes_object.append(
 			environment,
 			name,
 			crate::Property::Value(attribute_value),
 			crate::context::facts::PublicityKind::Public,
+			Some(attribute_position),
 		);
 
 		// let constraint = environment
@@ -136,12 +139,14 @@ pub(crate) fn synthesise_jsx_element<T: crate::ReadFromFS>(
 				.types
 				.new_constant_type(Constant::Number((idx as f64).try_into().unwrap()));
 
+			let child_position = child.get_position().clone().with_source(environment.get_source());
 			let child = synthesise_jsx_child(child, environment, checking_data);
 			synthesised_child_nodes.append(
 				environment,
 				property,
 				crate::Property::Value(child),
 				crate::context::facts::PublicityKind::Public,
+				Some(child_position),
 			);
 		}
 

--- a/checker/src/synthesis/functions.rs
+++ b/checker/src/synthesis/functions.rs
@@ -205,7 +205,9 @@ impl SynthesisableFunctionBody for ExpressionOrBlock {
 		match self {
 			ExpressionOrBlock::Expression(expression) => {
 				let returned = synthesise_expression(expression, environment, checking_data);
-				environment.return_value(returned);
+				let position =
+					expression.get_position().clone().with_source(environment.get_source());
+				environment.return_value(returned, position);
 			}
 			ExpressionOrBlock::Block(block) => {
 				block.synthesise_function_body(environment, checking_data)

--- a/checker/src/synthesis/interfaces.rs
+++ b/checker/src/synthesis/interfaces.rs
@@ -104,6 +104,7 @@ impl SynthesiseInterfaceBehavior for OnToType {
 			InterfaceValue::Value(value) => Property::Value(value),
 		};
 
+		// TODO: `None` position passed
 		environment.facts.register_property(self.0, under, ty, false, publicity, None)
 	}
 

--- a/checker/src/synthesis/interfaces.rs
+++ b/checker/src/synthesis/interfaces.rs
@@ -104,7 +104,7 @@ impl SynthesiseInterfaceBehavior for OnToType {
 			InterfaceValue::Value(value) => Property::Value(value),
 		};
 
-		environment.facts.register_property(self.0, under, ty, false, publicity)
+		environment.facts.register_property(self.0, under, ty, false, publicity, None)
 	}
 
 	fn interface_type(&self) -> Option<TypeId> {

--- a/checker/src/synthesis/statements.rs
+++ b/checker/src/synthesis/statements.rs
@@ -71,7 +71,10 @@ pub(super) fn synthesise_statement<T: crate::ReadFromFS>(
 			} else {
 				TypeId::UNDEFINED_TYPE
 			};
-			environment.return_value(returned);
+
+			let position = return_statement.2.clone().with_source(environment.get_source());
+
+			environment.return_value(returned, position);
 		}
 		Statement::IfStatement(if_statement) => {
 			let condition =

--- a/checker/src/synthesis/statements.rs
+++ b/checker/src/synthesis/statements.rs
@@ -269,7 +269,8 @@ pub(super) fn synthesise_statement<T: crate::ReadFromFS>(
 		}
 		Statement::Throw(stmt) => {
 			let thrown_value = synthesise_multiple_expression(&stmt.1, environment, checking_data);
-			environment.throw_value(thrown_value)
+			let thrown_position = stmt.2.clone().with_source(environment.get_source());
+			environment.throw_value(thrown_value, thrown_position)
 		}
 		Statement::Labelled { position, name, statement } => {
 			checking_data.raise_unimplemented_error(

--- a/checker/src/synthesis/type_annotations.rs
+++ b/checker/src/synthesis/type_annotations.rs
@@ -325,12 +325,16 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 
 						let item_ty =
 							synthesise_type_annotation(type_annotation, environment, checking_data);
-
+						let ty_position = type_annotation
+							.get_position()
+							.clone()
+							.with_source(environment.get_source());
 						obj.append(
 							environment,
 							idx_ty,
 							Property::Value(item_ty),
 							PublicityKind::Public,
+							Some(ty_position),
 						);
 					}
 					SpreadKind::Spread => {
@@ -342,11 +346,13 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 			let constant = Constant::Number((members.len() as f64).try_into().unwrap());
 			let length_value = checking_data.types.new_constant_type(constant);
 
+			// TODO: Does `constant` have a position? Or should it have one?
 			obj.append(
 				environment,
 				TypeId::LENGTH_AS_STRING,
 				Property::Value(length_value),
 				PublicityKind::Public,
+				None,
 			);
 
 			obj.build_object()

--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -299,12 +299,18 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 							.types
 							.new_constant_type(Constant::Number((idx as f64).try_into().unwrap()));
 
+						let field_position = variable_field
+							.get_position()
+							.clone()
+							.with_source(environment.get_source());
+
 						let value = environment.get_property(
 							value,
 							idx,
 							PublicityKind::Public,
 							&mut checking_data.types,
 							None,
+							field_position,
 						);
 
 						if let Some((_, value)) = value {
@@ -339,6 +345,9 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 							VariableIdentifier::Cursor(..) => todo!(),
 						};
 
+						let get_position_with_source =
+							get_position.clone().with_source(environment.get_source());
+
 						// TODO if LHS = undefined ...? conditional
 						// TODO record information
 						let property = environment.get_property(
@@ -347,6 +356,7 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 							PublicityKind::Public,
 							&mut checking_data.types,
 							None,
+							get_position_with_source,
 						);
 						let value = match property {
 							Some((_, value)) => value,
@@ -382,6 +392,7 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 							PublicityKind::Public,
 							&mut checking_data.types,
 							None,
+							position.clone().with_source(environment.get_source()),
 						);
 
 						let value = match property_value {

--- a/checker/src/types/calling.rs
+++ b/checker/src/types/calling.rs
@@ -189,7 +189,7 @@ fn create_generic_function_call<'a, E: CallCheckingBehavior>(
 		call_site_type_arguments,
 		// TODO clone
 		arguments.clone(),
-		call_site,
+		call_site.clone(),
 		environment,
 		behavior,
 		types,
@@ -214,6 +214,7 @@ fn create_generic_function_call<'a, E: CallCheckingBehavior>(
 				called_with_new,
 				// Don't care about output.
 				reflects_dependency: None,
+				position: call_site.clone(),
 			});
 
 			return Ok(result);
@@ -241,6 +242,7 @@ fn create_generic_function_call<'a, E: CallCheckingBehavior>(
 		timing: crate::events::CallingTiming::Synchronous,
 		called_with_new,
 		reflects_dependency,
+		position: call_site.clone(),
 	});
 
 	// TODO should wrap result in open poly
@@ -362,7 +364,7 @@ impl FunctionType {
 						call_site_type_arguments,
 						parent_type_arguments,
 						arguments,
-						call_site,
+						call_site.clone(),
 						environment,
 						behavior,
 						types,
@@ -387,6 +389,7 @@ impl FunctionType {
 					reflects_dependency: Some(ty),
 					timing: crate::events::CallingTiming::Synchronous,
 					called_with_new,
+					position: call_site.clone(),
 				});
 
 				return Ok(FunctionCallResult {

--- a/checker/src/types/others.rs
+++ b/checker/src/types/others.rs
@@ -19,11 +19,14 @@ pub(crate) fn create_object_for_type(
 		ty @ Type::And(left, right) | ty @ Type::Or(left, right) => {
 			let kind = if matches!(ty, Type::And(..)) { "and" } else { "or" };
 			let (left, right) = (*left, *right);
+
+			// TODO: Do we need positions for the following appends?
 			obj.append(
 				environment,
 				types.new_constant_type(Constant::String("kind".into())),
 				crate::Property::Value(types.new_constant_type(Constant::String(kind.into()))),
 				PublicityKind::Public,
+				None,
 			);
 			let left = create_object_for_type(left, environment, types);
 			let right = create_object_for_type(right, environment, types);
@@ -32,23 +35,28 @@ pub(crate) fn create_object_for_type(
 				types.new_constant_type(Constant::String("left".into())),
 				crate::Property::Value(left),
 				PublicityKind::Public,
+				None,
 			);
 			obj.append(
 				environment,
 				types.new_constant_type(Constant::String("right".into())),
 				crate::Property::Value(right),
 				PublicityKind::Public,
+				None,
 			);
 		}
 		Type::RootPolyType(_) => todo!(),
 		Type::Constructor(_) => todo!(),
 		Type::NamedRooted { name, parameters, nominal } => {
 			let name = name.clone();
+
+			// TODO: Do we need positions for the following appends?
 			obj.append(
 				environment,
 				types.new_constant_type(Constant::String("name".into())),
 				crate::Property::Value(types.new_constant_type(Constant::String(name))),
 				PublicityKind::Public,
+				None,
 			);
 
 			if !matches!(ty, TypeId::BOOLEAN_TYPE | TypeId::STRING_TYPE | TypeId::NUMBER_TYPE) {
@@ -63,6 +71,7 @@ pub(crate) fn create_object_for_type(
 						key,
 						crate::Property::Value(value),
 						PublicityKind::Public,
+						None,
 					);
 				}
 
@@ -71,6 +80,7 @@ pub(crate) fn create_object_for_type(
 					types.new_constant_type(Constant::String("properties".into())),
 					crate::Property::Value(inner_object.build_object()),
 					PublicityKind::Public,
+					None,
 				);
 			}
 		}
@@ -80,6 +90,7 @@ pub(crate) fn create_object_for_type(
 				types.new_constant_type(Constant::String("constant".into())),
 				crate::Property::Value(ty),
 				PublicityKind::Public,
+				None,
 			);
 		}
 		Type::Function(_, _) => todo!(),
@@ -94,6 +105,7 @@ pub(crate) fn create_object_for_type(
 				types.new_constant_type(Constant::String("kind".into())),
 				value,
 				PublicityKind::Public,
+				None,
 			);
 
 			// TODO array
@@ -107,6 +119,7 @@ pub(crate) fn create_object_for_type(
 					key,
 					crate::Property::Value(value),
 					PublicityKind::Public,
+					None,
 				);
 			}
 
@@ -115,6 +128,7 @@ pub(crate) fn create_object_for_type(
 				types.new_constant_type(Constant::String("properties".into())),
 				crate::Property::Value(inner_object.build_object()),
 				PublicityKind::Public,
+				None,
 			);
 		}
 		Type::SpecialObject(_) => todo!(),

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -63,6 +63,7 @@ pub(crate) fn get_property<'a, E: CallCheckingBehavior>(
 	environment: &mut Environment,
 	behavior: &mut E,
 	types: &mut TypeStore,
+	position: SpanWithSource,
 ) -> Option<(PropertyKind, TypeId)> {
 	if on == TypeId::ERROR_TYPE || under == TypeId::ERROR_TYPE {
 		return Some((PropertyKind::Direct, TypeId::ERROR_TYPE));
@@ -102,6 +103,7 @@ pub(crate) fn get_property<'a, E: CallCheckingBehavior>(
 		under,
 		reflects_dependency,
 		publicity,
+		position,
 	});
 
 	let (GetResult::AccessIntroducesDependence(value) | GetResult::FromAObject(value)) = value

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -390,6 +390,7 @@ pub(crate) fn set_property<'a, E: CallCheckingBehavior>(
 	environment: &mut Environment,
 	behavior: &mut E,
 	types: &mut TypeStore,
+	setter_position: Option<SpanWithSource>,
 ) -> Result<Option<TypeId>, SetPropertyError> {
 	// TODO
 	// if environment.is_not_writeable(on, under) {
@@ -474,6 +475,7 @@ pub(crate) fn set_property<'a, E: CallCheckingBehavior>(
 						// TODO
 						reflects_dependency: None,
 						initialization: false,
+						position: setter_position,
 					});
 				}
 				Property::Getter(_) => todo!(),
@@ -492,6 +494,7 @@ pub(crate) fn set_property<'a, E: CallCheckingBehavior>(
 			new,
 			register_setter_event,
 			publicity,
+			setter_position,
 		);
 	}
 	Ok(None)


### PR DESCRIPTION
This is a draft PR to improve the diagnostics message as indicated in [ issue 37](https://github.com/kaleidawave/ezno/issues/37). 

I've managed to add the position of the return to the `ReturnedTypeDoesNotMatch` error. 

If the solution is acceptable, I can do the same for the other variants.