### PR TITLE
Parser and general small fixes

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -20,6 +20,7 @@ jobs:
       sponsors: ${{ steps.get-sponsors.outputs.sponsors }}
 
     steps:
+      - uses: actions/checkout@v3
       - name: Get version
         id: get-version
         run: |

--- a/parser/src/functions.rs
+++ b/parser/src/functions.rs
@@ -1,14 +1,14 @@
 use std::{fmt::Debug, marker::PhantomData};
 
+use crate::tsx_keywords;
 use crate::{
 	parse_bracketed, to_string_bracketed, ASTNode, Block, ExpressionOrStatementPosition,
 	ExpressionPosition, GenericTypeConstraint, Keyword, ParseOptions, ParseResult, TSXToken,
 	TypeAnnotation, VisitSettings, Visitable,
 };
-use crate::{tsx_keywords, TSXKeyword};
 use derive_partial_eq_extras::PartialEqExtras;
 use source_map::{Span, ToString};
-use tokenizer_lib::{Token, TokenReader};
+use tokenizer_lib::TokenReader;
 
 pub use crate::parameters::*;
 
@@ -350,9 +350,12 @@ pub(crate) fn function_header_from_reader_with_async_keyword(
 	parse_regular_header(reader, async_keyword)
 }
 
+#[cfg(feature = "extras")]
 pub(crate) fn parse_function_location(
 	reader: &mut impl TokenReader<TSXToken, source_map::Start>,
 ) -> Option<FunctionLocationModifier> {
+	use crate::{TSXKeyword, Token};
+
 	if let Some(Token(TSXToken::Keyword(TSXKeyword::Server | TSXKeyword::Module), _)) =
 		reader.peek()
 	{

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -290,9 +290,28 @@ pub fn lex_script(
 							if script[..idx].ends_with('_') {
 								return_err!(LexingErrors::InvalidUnderscore)
 							} else if *fractional {
-								return_err!(LexingErrors::SecondDecimalPoint);
+								// Catch for spread token `...`
+								if start + 1 == idx {
+									let automaton = TSXToken::new_automaton();
+									let derive_finite_automaton::GetNextResult::NewState(
+										dot_state_one,
+									) = automaton.get_next('.')
+									else {
+										unreachable!()
+									};
+									let derive_finite_automaton::GetNextResult::NewState(
+										dot_state_two,
+									) = dot_state_one.get_next('.')
+									else {
+										unreachable!()
+									};
+									state = LexingState::Symbol(dot_state_two);
+								} else {
+									return_err!(LexingErrors::SecondDecimalPoint);
+								}
+							} else {
+								*fractional = true;
 							}
-							*fractional = true;
 						} else {
 							return_err!(LexingErrors::NumberLiteralCannotHaveDecimalPoint);
 						}

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -82,23 +82,43 @@ impl Quoted {
 pub struct ParseOptions {
 	/// Parsing of [JSX](https://facebook.github.io/jsx/) (includes some additions)
 	pub jsx: bool,
+	/// Allow custom characters in JSX attributes
 	pub special_jsx_attributes: bool,
+	/// Parses decorators on items
 	pub decorators: bool,
 	pub generator_keyword: bool,
+	/// Skip **all** comments from the AST
 	pub include_comments: bool,
-
+	/// See [crate::extensions::is_expression::IsExpression]
 	pub is_expressions: bool,
-	pub server_blocks: bool,
-	pub module_blocks: bool,
+	/// Allows functions to be prefixed with 'server'
+	pub server_functions: bool,
+	/// Allows functions to be prefixed with 'module'
+	pub module_functions: bool,
 	/// For LSP allows incomplete AST for completions. TODO tidy up
 	pub slots: bool,
 }
+
 impl ParseOptions {
 	fn get_lex_options(&self) -> LexerOptions {
 		LexerOptions {
 			include_comments: self.include_comments,
 			lex_jsx: self.jsx,
 			allow_unsupported_characters_in_jsx_attribute_keys: self.special_jsx_attributes,
+		}
+	}
+
+	pub fn all_features() -> Self {
+		Self {
+			jsx: true,
+			special_jsx_attributes: true,
+			include_comments: true,
+			decorators: true,
+			slots: true,
+			generator_keyword: true,
+			server_functions: true,
+			module_functions: true,
+			is_expressions: true,
 		}
 	}
 }
@@ -113,8 +133,8 @@ impl Default for ParseOptions {
 			decorators: true,
 			slots: false,
 			generator_keyword: true,
-			server_blocks: false,
-			module_blocks: false,
+			server_functions: false,
+			module_functions: false,
 			is_expressions: true,
 		}
 	}

--- a/parser/src/tokens.rs
+++ b/parser/src/tokens.rs
@@ -322,9 +322,9 @@ pub enum TSXKeyword {
     Private, Public, Protected,
     // TS Keywords
     As, Declare, Readonly, Infer, Is, Satisfies, Namespace, KeyOf,
-    // Extra blocks
+    // Extra function modifiers
     #[cfg(feature = "extras")] Server, #[cfg(feature = "extras")] Module,
-    // Type changes
+    // Type declaration changes
     #[cfg(feature = "extras")] Nominal, #[cfg(feature = "extras")] Performs,
 
     #[cfg(feature = "extras")]

--- a/src/ast_explorer.rs
+++ b/src/ast_explorer.rs
@@ -124,7 +124,12 @@ impl ExplorerSubCommand {
 				let mut fs =
 					parser::source_map::MapFileStore::<parser::source_map::NoPathMap>::default();
 				let source_id = fs.new_source_id(path.unwrap_or_default(), input.clone());
-				let res = Expression::from_string(input, Default::default(), source_id, None);
+				let res = Expression::from_string(
+					input,
+					parser::ParseOptions::all_features(),
+					source_id,
+					None,
+				);
 				match res {
 					Ok(res) => {
 						if cfg.json {
@@ -144,7 +149,12 @@ impl ExplorerSubCommand {
 				let mut fs =
 					parser::source_map::MapFileStore::<parser::source_map::NoPathMap>::default();
 				let source_id = fs.new_source_id(path.unwrap_or_default(), input.clone());
-				let res = Module::from_string(input, Default::default(), source_id, None);
+				let res = Module::from_string(
+					input,
+					parser::ParseOptions::all_features(),
+					source_id,
+					None,
+				);
 				match res {
 					Ok(res) => {
 						if cfg.json {

--- a/src/js-cli-and-library/package.json
+++ b/src/js-cli-and-library/package.json
@@ -13,6 +13,9 @@
 		},
 		"./initialised": {
 			"import": "./dist/initialised.mjs"
+		},
+		"./cli": {
+			"import": "./dist/cli.mjs"
 		}
 	},
 	"scripts": {

--- a/src/js-cli-and-library/src/index.mjs
+++ b/src/js-cli-and-library/src/index.mjs
@@ -1,2 +1,2 @@
-import init, { initSync, build, check, parse_expression, parse_module, just_imports } from "../build/ezno_lib.js";
-export { init, initSync, build, check, parse_expression, parse_module, just_imports };
+import init, { initSync, build, check, parse_expression, parse_module, just_imports, get_version } from "../build/ezno_lib.js";
+export { init, initSync, build, check, parse_expression, parse_module, just_imports, get_version };

--- a/src/js-cli-and-library/src/initialised.js
+++ b/src/js-cli-and-library/src/initialised.js
@@ -1,4 +1,4 @@
-import { initSync, build, check, parse_expression, parse_module, just_imports } from "./index.mjs";
+import { initSync, build, check, parse_expression, parse_module, just_imports, get_version } from "./index.mjs";
 import { readFileSync } from "node:fs";
 
 const wasmPath = new URL("./shared/ezno_lib_bg.wasm", import.meta.url);
@@ -8,4 +8,4 @@ if (wasmPath.protocol === "https:") {
     initSync(readFileSync(wasmPath));
 }
 
-export { build, check, parse_expression, parse_module, just_imports }
+export { build, check, parse_expression, parse_module, just_imports, get_version }

--- a/src/js-cli-and-library/test.mjs
+++ b/src/js-cli-and-library/test.mjs
@@ -1,4 +1,4 @@
-import { build, check, parse_expression } from "./dist/initialised.mjs";
+import { build, check, parse_expression, get_version } from "./dist/initialised.mjs";
 import assert, { deepStrictEqual, equal } from "node:assert";
 
 function buildTest() {
@@ -35,3 +35,5 @@ function checkTest() {
 checkTest()
 
 console.log(parse_expression("x = 4 + 2"))
+
+console.log(get_version())

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -22,7 +22,7 @@ pub(crate) fn print_info() {
 	if let Some(sponsors) = SPONSORS {
 		print_to_cli(format_args!("Supported by: {sponsors}. Join them @ {SPONSORS_PATH}"));
 	} else {
-		print_to_cli(format_args!("Sponsor the project @ {SPONSORS_PATH}"));
+		print_to_cli(format_args!("Support the project @ {SPONSORS_PATH}"));
 	}
 	print_to_cli(format_args!("For help run --help"));
 }

--- a/src/wasm_bindings.rs
+++ b/src/wasm_bindings.rs
@@ -107,7 +107,7 @@ pub fn parse_module_to_json(input: String) -> JsValue {
 	}
 }
 
-#[wasm_bindgen(js_name = just_imports)]
+#[wasm_bindgen]
 pub fn just_imports(input: String) -> JsValue {
 	use parser::{ASTNode, Module, SourceId};
 
@@ -123,4 +123,9 @@ pub fn just_imports(input: String) -> JsValue {
 			serde_wasm_bindgen::to_value(&(parse_error.reason, parse_error.position)).unwrap()
 		}
 	}
+}
+
+#[wasm_bindgen]
+pub fn get_version() -> JsValue {
+	serde_wasm_bindgen::to_value(&env!("CARGO_PKG_VERSION")).unwrap()
 }


### PR DESCRIPTION
- Fixes spread token lexing getting confused with number literals with leading decimal (e.g. `.4`)
- Added *function location modifier*
- Added `get_version` to WASM/JS library
- Added a checkout before getting the version for the GH releases