### PR TITLE
Improvements to checker

### DIFF
--- a/checker/definitions/internal.d.ts
+++ b/checker/definitions/internal.d.ts
@@ -36,18 +36,23 @@ interface nominal Array<T> {
         }
     }
 
-    last() performs {
-        return this[this.length - 1]
-    }
+    // last() performs {
+    //     return this[this.length - 1]
+    // }
 }
 
 interface Math {
     sin(x: number): number performs const sin;
     cos(x: number): number performs const cos;
     tan(x: number): number performs const tan;
-    trunc(x: number): number performs const trunc;
+    floor(x: number): number performs const floor;
     sqrt(x: number): number performs const sqrt;
     cbrt(x: number): number performs const cbrt;
+
+    // TODO newer method
+    trunc(x: number): number performs const trunc;
+
+    PI: 3.141592653589793
 }
 
 interface nominal string {
@@ -69,9 +74,26 @@ interface JSON {
     stringify(input: any): string;
 }
 
+interface Function {
+    bind(this_ty: any): Function performs const bind;
+}
+
+interface Object {
+    setPrototypeOf(on: object, to: object): object performs const set_prototype;
+
+    getPrototypeOf(on: object): object | null performs const get_prototype;
+
+    // create(prototype: object): object performs {
+    //     const n = {};
+    //     Object.setProtoTypeOf(n, prototype);
+    //     return n
+    // }
+}
+
 declare var JSON: JSON;
 declare var Math: Math;
 declare var console: Console;
+declare var Object: Object;
 
 declare function JSXH(tagname: string, attributes: any, children?: any) performs {
     return tagname
@@ -87,5 +109,5 @@ interface FormData {
 @client
 declare const document: Document;
 
-@server
-declare function createItem(a: any);
+// @server
+// declare function createItem(a: any);

--- a/checker/definitions/internal.d.ts
+++ b/checker/definitions/internal.d.ts
@@ -73,6 +73,19 @@ declare var JSON: JSON;
 declare var Math: Math;
 declare var console: Console;
 
-declare function JSXH(tagname: string, attributes: any, children: any) performs {
+declare function JSXH(tagname: string, attributes: any, children?: any) performs {
     return tagname
 }
+
+interface Document {
+    title: string
+}
+
+interface FormData {
+}
+
+@client
+declare const document: Document;
+
+@server
+declare function createItem(a: any);

--- a/checker/docs/architecture tricks.md
+++ b/checker/docs/architecture tricks.md
@@ -1,14 +1,10 @@
 > Building a type checker is hard. Here are some tricks that Ezno uses to keep the codebase small and simple
 
-### Specializing generics
+### Specialising/substituting generics
 Finding the values for generics is done during subtype checking #TODO
 
-### Object keys are types
-When `x.t` a `"t"` type is created.
-
-#TODO how does casting work
-
 ## Internal #TODO
+
 - `Environment::parents_iter`
 - `get_on_ctx!`
 - `Logical`

--- a/checker/docs/checking.md
+++ b/checker/docs/checking.md
@@ -9,8 +9,8 @@ These happen in a few places
 
 This is implemented in `types/sub-typing`
 
-#### Specializing
-This subtype checking also doubles as a way to specialize generic types that were not or could not be specified as a specific arguments. This is implicitly / inferred, so not explicit arguments.
+#### Specialising/substituting
+This subtype checking also doubles as a way to specialise generic types that were not or could not be specified as a specific arguments. This is implicitly / inferred, so not explicit arguments.
 
 ### `type` querying
 
@@ -18,7 +18,7 @@ Rather than checking whether types are subtypes of some base type, these are con
 - Property access (and destructuring)
 - Is callable (the parameters can be checked)
 
-> These could be implemented using the first method. Property access could be implemented by checking and specializing using `{ [name]: T }`, but doesn't
+> These could be implemented using the first method. Property access could be implemented by checking and substituting using `{ [name]: T }`, but doesn't
 
 ## Checking a program
 Starts with a list of statements.
@@ -45,7 +45,6 @@ There are three stages to hoisting.
     - Return type synthesised
 
 #### Still working out
-- Imports, exports?
 - Types cannot mutate structure
     - Where do callable interfaces go? (need to be functions)
     - interface extends (needs to be aliases)

--- a/checker/docs/events.md
+++ b/checker/docs/events.md
@@ -10,7 +10,7 @@ They reference things in the type system. Their are no values, only type referen
 The side effects of a function are bundled into the events in the function. Side effects = events that
 
 ### Function synthesis and calling
-When synthesizing a function, events are recorded. They are then held on the function type. When calling that function, the events are replayed with the current state of the program.
+When synthesising a function, events are recorded. They are then held on the function type. When calling that function, the events are replayed with the current state of the program.
 
 ## Using as an IR
 The events can be used as an intermediate representation as a a representation of the program in a lowered syntax.

--- a/checker/docs/not-supported.md
+++ b/checker/docs/not-supported.md
@@ -1,0 +1,16 @@
+While Ezno is have a high JS compatibility, the following compromise the fundamentals of Ezno and are also advised as bad features to use.
+
+Note all of these are not supported in TSC either
+
+Not supporting in JavaScript:
+- dynamic import with a non-constant value. Can introduce unknown and unreliable side effects.
+    - Also just avoid as they slow down things in the checker
+    - Want something [this to be added](https://github.com/tc39/proposal-defer-import-eval) for lazy loading that is statically analyzable
+- `super` calls in a conditional context of a constructor
+    - Really difficult to add the checker without adding enormous complexity and overhead
+    - Means that reference errors
+- `eval` just don't
+- `with`
+
+Not supporting from TypeScript:
+- Function overloading syntax (use generics and matchings)

--- a/checker/docs/parameters.md
+++ b/checker/docs/parameters.md
@@ -1,4 +1,4 @@
-When synthesizing (aka checking) a function a few thing happen:
+When synthesising (aka checking) a function a few thing happen:
 - Parameters are synthesised
 - Ones that are not already generic are made into generics
 

--- a/checker/docs/types.md
+++ b/checker/docs/types.md
@@ -14,9 +14,6 @@
 ### Open poly types
 Poly types retain information and flow of data through the use of higher poly types.
 
-A few differences
-- They are not subject to specialization (#TODO explain why)
-
 ### Objects
 In simple case objects (collections of data) can be considered constant
 

--- a/checker/specification/Cargo.toml
+++ b/checker/specification/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 # Prevent this from interfering with workspaces
-# [workspace]
-# members = ["."]
+[workspace]
+members = ["."]
 
 [[test]]
 name = "specification_test"

--- a/checker/specification/Cargo.toml
+++ b/checker/specification/Cargo.toml
@@ -7,6 +7,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 # Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
 
 [features]
 just-staging = []

--- a/checker/specification/Cargo.toml
+++ b/checker/specification/Cargo.toml
@@ -7,8 +7,11 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 # Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
+
+[features]
+just-staging = []
+staging = []
+all = ["staging"]
 
 [[test]]
 name = "specification_test"

--- a/checker/specification/README.md
+++ b/checker/specification/README.md
@@ -1,0 +1,11 @@
+[The specification](./specification.md) is a markdown document that defines what the behavior of Ezno's checker. It is meant to server both as documentation and what is currently supported as well as a test suite to ensure there isn't a regression in the checker.
+
+[specification.md](./specification.md) defines current behavior which works on the main branch. [staging.md](./staging.md) can be used as a well to introduce behavior during the implementation and remains separated from the rest. It can be enabled with the `staging` features and exclusively with `staging-only`. [to_implement.md](./to_implement.md) contains future tests that do not currently passed. They can be viewed as a target for the checker and copied to staging when ready to implement.
+
+These can all be ran as tests using the markdown to Rust test code transpiler in [build.rs](./build.rs).
+
+- The cases should be brief and only test a specific aspect of the language
+- Each block contains errors, the list afterwards is the expected errors
+- Comments can be in block quotes to explain additional details in the tests
+- Sections are at level three headings (`###`), tests are at level four headings (`####`), the tested code goes a code block with the language tag `ts` and errors in a bullet list after in order
+- Blocks can be split into files with a `// in file.ts` comment, below which all code is in the `file.ts` file. Default is `main.ts`

--- a/checker/specification/specification.md
+++ b/checker/specification/specification.md
@@ -639,6 +639,21 @@ const c = b;
 - Expected false, found true
 - Expected string, found false
 
+#### Set property with key
+
+```ts
+const obj = { a: 2 }
+
+function setProperty(key: string, value) {
+	obj[key] = value;
+}
+
+setProperty("b", 6)
+obj satisfies string;
+```
+
+- Expected string, found {"a": 2, "b": 6, }
+
 ### Control flow
 
 #### Resolving conditional
@@ -896,6 +911,48 @@ try {
 
 - Expected string, found 3
 
+### Types
+
+#### Non existent type
+
+```ts
+type X = number;
+
+const a: Y = 2;
+```
+
+- Cannot find type Y
+
+#### Type has no generics
+
+```ts
+type X = number;
+
+const a: X<number> = 2;
+```
+
+- Type 'X' has no generic parameters
+
+#### Type alias with type parameters
+
+```ts
+type X<T> = T;
+
+(2 satisfies X<string>);
+```
+
+- Expected string, found 2
+
+#### Type annotation missing type arguments
+
+```ts
+type X<T> = T;
+
+(2 satisfies X);
+```
+
+- Type X requires type arguments
+
 ### Imports and exports
 
 #### Import and export named
@@ -957,7 +1014,7 @@ import { MyNumber } from "./types";
 export type MyNumber = string;
 ```
 
-- Expected string, found 2
+- Expected MyNumber, found 2
 
 #### Export let
 

--- a/checker/specification/staging.md
+++ b/checker/specification/staging.md
@@ -1,0 +1,1 @@
+Currently implementing:

--- a/checker/specification/to_implement.md
+++ b/checker/specification/to_implement.md
@@ -208,7 +208,7 @@ x satisfies string;
 #### this
 
 ```ts
-function ChangeThis(this) {
+function ChangeThis() {
 	return this.value
 }
 ```
@@ -342,6 +342,18 @@ function getFirst(a: Array<string>) {
 print_type(getFirst)
 ```
 
+#### Array spread
+
+```ts
+const array1 = [1, 2, 3];
+const array2 = [...array1, 4, 5, 6];
+
+array2.length satisfies 6;
+array2[2] satisfies string;
+```
+
+- Expected string, found 3
+
 #### Simple array map
 
 ```ts
@@ -379,6 +391,8 @@ myTag`Hello ${name}` satisfies "Hi Ben"
 
 #### Object spread
 
+> parser currently broken
+
 ```ts
 const obj1 = { a: 2, b: 3 };
 const obj2 = { b: 4, ...obj1, a: 6 };
@@ -394,20 +408,42 @@ obj1.a satisfies bool;
 
 > This is allowed under non strict casts option (and will return NaN) but the tests run with strict casts on
 
+> This would need to support [Symbol.toPrimitive] + a bunch of error handling
+
 ```ts
 console + 2
 ```
 
 - Expected number, found Console
 
-#### Array spread
+#### Expected argument
+
+> Requires synthesising arguments later ...?
 
 ```ts
-const array1 = [1, 2, 3];
-const array2 = [...array1, 4, 5, 6];
+function map(a: (a: number) => number) {}
 
-array2.length satisfies 6;
-array2[2] satisfies string;
+map(a => a.t)
 ```
 
-- Expected string, found 3
+> No property t on string
+
+#### Index
+
+> Panics specialising property
+
+```ts
+function getFirst(array: Array<string>) {
+    return array[0]
+}
+
+print_type(getFirst)
+```
+
+#### Expected
+
+```ts
+const x: (a: string) => number = (a) => a.to;
+```
+
+> No property to on string

--- a/checker/src/behavior/assignments.rs
+++ b/checker/src/behavior/assignments.rs
@@ -1,8 +1,7 @@
 use source_map::{Span, SpanWithSource};
 
 use crate::{
-	context::facts::PublicityKind, types::properties::PropertyKey, CheckingData, Environment,
-	TypeId,
+	context::facts::Publicity, types::properties::PropertyKey, CheckingData, Environment, TypeId,
 };
 
 use super::operations::{Logical, MathematicalAndBitwise};
@@ -18,12 +17,7 @@ pub enum Assignable {
 #[derive(Clone)]
 pub enum Reference {
 	Variable(String, SpanWithSource),
-	Property {
-		on: TypeId,
-		with: PropertyKey<'static>,
-		publicity: PublicityKind,
-		span: SpanWithSource,
-	},
+	Property { on: TypeId, with: PropertyKey<'static>, publicity: Publicity, span: SpanWithSource },
 }
 
 /// Increment and decrement are are not binary add subtract as they cast their lhs to number

--- a/checker/src/behavior/assignments.rs
+++ b/checker/src/behavior/assignments.rs
@@ -1,20 +1,29 @@
 use source_map::{Span, SpanWithSource};
 
-use crate::{context::facts::PublicityKind, CheckingData, Environment, TypeId};
+use crate::{
+	context::facts::PublicityKind, types::properties::PropertyKey, CheckingData, Environment,
+	TypeId,
+};
 
 use super::operations::{Logical, MathematicalAndBitwise};
 
 pub enum Assignable {
 	Reference(Reference),
-	ObjectDestructuring(Vec<(TypeId, Assignable)>),
+	ObjectDestructuring(Vec<(PropertyKey<'static>, Assignable)>),
 	ArrayDestructuring(Vec<Option<Assignable>>),
 }
 
-// TODO copy, when span copy
+// TODO derive copy, when span derives copy
+// TODO reference
 #[derive(Clone)]
 pub enum Reference {
 	Variable(String, SpanWithSource),
-	Property { on: TypeId, with: TypeId, publicity: PublicityKind, span: SpanWithSource },
+	Property {
+		on: TypeId,
+		with: PropertyKey<'static>,
+		publicity: PublicityKind,
+		span: SpanWithSource,
+	},
 }
 
 /// Increment and decrement are are not binary add subtract as they cast their lhs to number

--- a/checker/src/behavior/assignments.rs
+++ b/checker/src/behavior/assignments.rs
@@ -42,14 +42,3 @@ impl Reference {
 		}
 	}
 }
-
-// TODO
-pub trait SynthesisableExpression<M: crate::ASTImplementation> {
-	fn synthesise_expression<U: crate::ReadFromFS>(
-		&self,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<U, M>,
-	) -> TypeId;
-
-	fn get_position(&self) -> &Span;
-}

--- a/checker/src/behavior/functions.rs
+++ b/checker/src/behavior/functions.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, mem};
 
 use source_map::{SourceId, Span, SpanWithSource};
 
@@ -6,202 +6,13 @@ use super::variables::VariableMutability;
 use crate::{
 	context::{facts::Facts, Context, ContextType},
 	events::Event,
+	synthesis::interfaces::GetterSetter,
 	types::{
-		functions::SynthesisedParameters, poly_types::GenericTypeParameters, properties::Property,
-		FunctionType, TypeStore,
+		classes::ClassProperties, functions::SynthesisedParameters,
+		poly_types::GenericTypeParameters, properties::PropertyValue, FunctionType, TypeStore,
 	},
-	CheckingData, Environment, FunctionId, ReadFromFS, Type, TypeId, VariableId,
+	ASTImplementation, CheckingData, Environment, FunctionId, ReadFromFS, Type, TypeId, VariableId,
 };
-
-/// This is just as an API layer
-pub enum MethodKind {
-	Get,
-	Set,
-	Generator { is_async: bool },
-	Async,
-	Plain,
-}
-
-// pub enum FunctionKind2 {
-// 	ArrowFunction { is_async: bool },
-// 	StatementFunction { is_async: bool, generator: bool },
-// 	ClassConstructor,
-// 	Method { getter_setter_or_generator: MethodKind },
-// }
-
-/// TODO generalize for property registration
-pub trait FunctionRegisterBehavior<M: crate::ASTImplementation> {
-	type Return;
-
-	/// TODO lift T
-	fn function<T: SynthesisableFunction<M>, U: ContextType>(
-		&self,
-		func: &T,
-		func_ty: FunctionType,
-		environment: &mut Context<U>,
-		types: &mut TypeStore,
-	) -> Self::Return;
-}
-
-pub struct RegisterAsType;
-
-impl<M: crate::ASTImplementation> FunctionRegisterBehavior<M> for RegisterAsType {
-	type Return = TypeId;
-
-	fn function<T: SynthesisableFunction<M>, U: ContextType>(
-		&self,
-		func: &T,
-		func_ty: FunctionType,
-		environment: &mut Context<U>,
-		types: &mut TypeStore,
-	) -> Self::Return {
-		let id = func_ty.id;
-		types.functions.insert(id, func_ty);
-		let ty = types.register_type(crate::Type::Function(id, ThisValue::UseParent));
-
-		// TODO: Needs a way to get position (perhaps from a method in `SynthesisableFunction`).
-		// Can `return_type_annotation` be used to get the position?
-		environment.facts.events.push(Event::CreateObject {
-			prototype: crate::events::PrototypeArgument::Function(id),
-			referenced_in_scope_as: ty,
-			position: None,
-		});
-		ty
-	}
-}
-
-/// Because of hoisting. On existing name
-pub struct RegisterOnExisting(pub VariableId);
-
-impl<M: crate::ASTImplementation> FunctionRegisterBehavior<M> for RegisterOnExisting {
-	type Return = ();
-
-	fn function<T: SynthesisableFunction<M>, U: ContextType>(
-		&self,
-		func: &T,
-		func_ty: FunctionType,
-		context: &mut Context<U>,
-		types: &mut TypeStore,
-	) -> Self::Return {
-		let id = func_ty.id;
-		types.functions.insert(id, func_ty);
-		let ty = types.register_type(crate::Type::Function(id, Default::default()));
-		context.facts.variable_current_value.insert(self.0, ty);
-		// TODO Needs a position
-		context.facts.events.push(Event::CreateObject {
-			prototype: crate::events::PrototypeArgument::Function(id),
-			referenced_in_scope_as: ty,
-			position: None,
-		});
-	}
-}
-
-pub struct RegisterOnExistingObject;
-
-impl<M: crate::ASTImplementation> FunctionRegisterBehavior<M> for RegisterOnExistingObject {
-	type Return = Property;
-
-	fn function<T: SynthesisableFunction<M>, U: ContextType>(
-		&self,
-		func: &T,
-		func_ty: FunctionType,
-		environment: &mut Context<U>,
-		types: &mut TypeStore,
-	) -> Self::Return {
-		use crate::behavior::functions::MethodKind;
-		match func.get_kind() {
-			MethodKind::Get => Property::Getter(Box::new(func_ty)),
-			MethodKind::Set => Property::Setter(Box::new(func_ty)),
-			MethodKind::Async | MethodKind::Generator { .. } | MethodKind::Plain => {
-				let id = func_ty.id;
-				types.functions.insert(id, func_ty);
-				let ty = types.register_type(Type::Function(id, Default::default()));
-
-				// TODO Needs a position
-				environment.facts.events.push(Event::CreateObject {
-					prototype: crate::events::PrototypeArgument::Function(id),
-					referenced_in_scope_as: ty,
-					position: None,
-				});
-				Property::Value(ty)
-			}
-		}
-	}
-}
-
-pub trait SynthesisableFunction<M: crate::ASTImplementation> {
-	fn is_declare(&self) -> bool;
-
-	/// TODO vector for badness
-	fn get_kind(&self) -> MethodKind;
-
-	fn id(&self, source_id: SourceId) -> FunctionId;
-
-	/// **THIS FUNCTION IS EXPECTED TO PUT THE TYPE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESISING THEM**
-	fn type_parameters<T: ReadFromFS>(
-		&self,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<T, M>,
-	) -> Option<GenericTypeParameters>;
-
-	/// Has to be the first parameter
-	fn this_constraint<T: ReadFromFS>(
-		&self,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<T, M>,
-	) -> Option<TypeId>;
-
-	/// **THIS FUNCTION IS EXPECTED TO PUT THE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESISING THEM**
-	fn parameters<T: ReadFromFS>(
-		&self,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<T, M>,
-	) -> SynthesisedParameters;
-
-	/// Returned type is extracted from events, thus doesn't expect anything in return
-	fn body<T: ReadFromFS>(
-		&self,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<T, M>,
-	);
-
-	fn return_type_annotation<T: ReadFromFS>(
-		&self,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<T, M>,
-	) -> Option<(TypeId, SpanWithSource)>;
-
-	fn location(&self) -> Option<String> {
-		None
-	}
-}
-
-struct ArrowFunction {
-	is_async: bool,
-}
-
-struct Getter;
-struct Setter;
-
-enum Method {
-	Getter,
-	Setter,
-	Generator { is_async: bool },
-	Regular { is_async: bool },
-}
-
-struct StatementOrExpressionFunction {
-	is_generator: bool,
-	is_async: bool,
-}
-
-struct ClassConstructor {
-	// events..?
-	fields: (),
-}
-
-#[derive(Clone, Debug, Default, binary_serialize_derive::BinarySerializable)]
-pub struct ClosedOverVariables(pub(crate) HashMap<VariableId, TypeId>);
 
 #[derive(Clone, Copy, Debug, Default, binary_serialize_derive::BinarySerializable)]
 pub enum ThisValue {
@@ -223,13 +34,260 @@ impl ThisValue {
 		}
 	}
 
-	pub(crate) fn unwrap(&self) -> TypeId {
+	pub(crate) fn get_passed(&self) -> Option<TypeId> {
 		match self {
-			ThisValue::Passed(value) => *value,
-			ThisValue::UseParent => panic!("Tried to get value of this"),
+			ThisValue::Passed(value) => Some(*value),
+			ThisValue::UseParent => None,
 		}
 	}
 }
+
+pub fn register_arrow_function<T: crate::ReadFromFS, M: crate::ASTImplementation>(
+	expecting: TypeId,
+	is_async: bool,
+	function: &impl SynthesisableFunction<M>,
+	environment: &mut Environment,
+	checking_data: &mut CheckingData<T, M>,
+) -> TypeId {
+	let function_type = environment.new_function(
+		checking_data,
+		function,
+		FunctionRegisterBehavior::ArrowFunction { expecting, is_async },
+	);
+	checking_data.types.new_function_type(function_type)
+}
+
+pub fn register_expression_function<T: crate::ReadFromFS, M: crate::ASTImplementation>(
+	expecting: TypeId,
+	is_async: bool,
+	is_generator: bool,
+	location: Option<String>,
+	function: &impl SynthesisableFunction<M>,
+	environment: &mut Environment,
+	checking_data: &mut CheckingData<T, M>,
+) -> TypeId {
+	let function_type = environment.new_function(
+		checking_data,
+		function,
+		FunctionRegisterBehavior::ExpressionFunction {
+			expecting,
+			is_async,
+			is_generator,
+			location,
+		},
+	);
+	checking_data.types.new_function_type(function_type)
+}
+
+pub fn synthesise_hoisted_statement_function<T: crate::ReadFromFS, M: crate::ASTImplementation>(
+	variable_id: crate::VariableId,
+	is_async: bool,
+	is_generator: bool,
+	location: Option<String>,
+	function: &impl SynthesisableFunction<M>,
+	environment: &mut Environment,
+	checking_data: &mut CheckingData<T, M>,
+) {
+	// TODO get existing by variable_id
+	let behavior = crate::behavior::functions::FunctionRegisterBehavior::StatementFunction {
+		hoisted: variable_id,
+		is_async,
+		is_generator,
+		location,
+	};
+
+	let function = environment.new_function(checking_data, function, behavior);
+	environment
+		.facts
+		.variable_current_value
+		.insert(variable_id, checking_data.types.new_function_type(function));
+}
+
+pub fn function_to_property(
+	getter_setter: GetterSetter,
+	function: FunctionType,
+	types: &mut TypeStore,
+) -> PropertyValue {
+	match getter_setter {
+		GetterSetter::Getter => PropertyValue::Getter(Box::new(function)),
+		GetterSetter::Setter => PropertyValue::Setter(Box::new(function)),
+		GetterSetter::None => PropertyValue::Value(types.new_function_type(function)),
+	}
+}
+
+// pub struct RegisterAsConstructor<'a, M: ASTImplementation> {
+// 	pub class: TypeId,
+// 	pub class_extends: bool,
+// 	pub properties: ClassProperties<'a, M>,
+// }
+
+// impl<'a, M: crate::ASTImplementation> FunctionRegisterBehavior<M> for RegisterAsConstructor<'a, M> {
+// 	type Return = FunctionType;
+
+// 	fn constructor_on(&mut self) -> Option<(TypeId, bool, ClassProperties<M>)> {
+// 		Some((self.class, self.class_extends, mem::take(&mut self.properties)))
+// 	}
+
+// 	fn afterwards<T: SynthesisableFunction<M>, U: ContextType>(
+// 		&self,
+// 		original_function: &T,
+// 		synthesised_function: FunctionType,
+// 		environment: &mut Context<U>,
+// 		types: &mut TypeStore,
+// 	) -> Self::Return {
+// 		synthesised_function
+// 	}
+// }
+
+/// TODO different place
+/// TODO maybe generic
+#[derive(Clone, Debug, binary_serialize_derive::BinarySerializable)]
+pub enum FunctionBehavior {
+	/// For arrow functions, cannot have `this` bound
+	ArrowFunction {
+		is_async: bool,
+	},
+	Method {
+		free_this_id: TypeId,
+		is_async: bool,
+		is_generator: bool,
+	},
+	// Functions defined `function`. Extends above by allowing `new`
+	Function {
+		/// IMPORTANT THIS DOES NOT POINT TO THE OBJECT
+		free_this_id: TypeId,
+		is_async: bool,
+		is_generator: bool,
+	},
+	// Constructors, always new
+	Constructor {
+		/// None is super exists, as that is handled by events
+		non_super_prototype: Option<TypeId>,
+		/// The id of the generic that needs to be pulled out
+		this_object_type: TypeId,
+	},
+}
+
+impl FunctionBehavior {
+	pub(crate) fn can_be_bound(&self) -> bool {
+		matches!(self, Self::Method { .. } | Self::Function { .. })
+	}
+}
+
+/// Covers both actual functions and
+pub trait SynthesisableFunction<M: crate::ASTImplementation> {
+	fn id(&self, source_id: SourceId) -> FunctionId;
+
+	// TODO temp
+	fn has_body(&self) -> bool;
+
+	/// **THIS FUNCTION IS EXPECTED TO PUT THE TYPE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESISING THEM**
+	fn type_parameters<T: ReadFromFS>(
+		&self,
+		environment: &mut Environment,
+		checking_data: &mut CheckingData<T, M>,
+	) -> Option<GenericTypeParameters>;
+
+	fn this_constraint<T: ReadFromFS>(
+		&self,
+		environment: &mut Environment,
+		checking_data: &mut CheckingData<T, M>,
+	) -> Option<TypeId>;
+
+	/// For object literals
+	fn super_constraint<T: ReadFromFS>(
+		&self,
+		environment: &mut Environment,
+		checking_data: &mut CheckingData<T, M>,
+	) -> Option<TypeId>;
+
+	/// **THIS FUNCTION IS EXPECTED TO PUT THE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESISING THEM**
+	fn parameters<T: ReadFromFS>(
+		&self,
+		environment: &mut Environment,
+		checking_data: &mut CheckingData<T, M>,
+		expected_parameters: Option<SynthesisedParameters>,
+	) -> SynthesisedParameters;
+
+	fn return_type_annotation<T: ReadFromFS>(
+		&self,
+		environment: &mut Environment,
+		checking_data: &mut CheckingData<T, M>,
+	) -> Option<(TypeId, SpanWithSource)>;
+
+	/// Returned type is extracted from events, thus doesn't expect anything in return
+	fn body<T: ReadFromFS>(
+		&self,
+		environment: &mut Environment,
+		checking_data: &mut CheckingData<T, M>,
+	);
+}
+
+/// TODO might be generic if FunctionBehavior becomes generic
+pub enum FunctionRegisterBehavior<'a, M: crate::ASTImplementation> {
+	ArrowFunction {
+		expecting: TypeId,
+		is_async: bool,
+	},
+	ExpressionFunction {
+		expecting: TypeId,
+		is_async: bool,
+		is_generator: bool,
+		location: Option<String>,
+	},
+	StatementFunction {
+		hoisted: VariableId,
+		is_async: bool,
+		is_generator: bool,
+		location: Option<String>,
+	},
+	// TODO this will take PartialFunction
+	ObjectMethod {
+		is_async: bool,
+		is_generator: bool,
+		// location: Option<String>,
+	},
+	// TODO this will take PartialFunction
+	ClassMethod {
+		is_async: bool,
+		is_generator: bool,
+		super_type: Option<TypeId>,
+		// location: Option<String>,
+	},
+	Constructor {
+		prototype: TypeId,
+		/// Is this is_some then can use `super()`
+		super_type: Option<TypeId>,
+		properties: ClassProperties<'a, M>,
+	},
+}
+
+impl<'a, M: crate::ASTImplementation> FunctionRegisterBehavior<'a, M> {
+	pub fn is_async(&self) -> bool {
+		match self {
+			FunctionRegisterBehavior::ArrowFunction { is_async, .. }
+			| FunctionRegisterBehavior::ExpressionFunction { is_async, .. }
+			| FunctionRegisterBehavior::StatementFunction { is_async, .. }
+			| FunctionRegisterBehavior::ObjectMethod { is_async, .. }
+			| FunctionRegisterBehavior::ClassMethod { is_async, .. } => *is_async,
+			FunctionRegisterBehavior::Constructor { .. } => false,
+		}
+	}
+
+	pub fn is_generator(&self) -> bool {
+		match self {
+			FunctionRegisterBehavior::ExpressionFunction { is_generator, .. }
+			| FunctionRegisterBehavior::StatementFunction { is_generator, .. }
+			| FunctionRegisterBehavior::ObjectMethod { is_generator, .. }
+			| FunctionRegisterBehavior::ClassMethod { is_generator, .. } => *is_generator,
+			FunctionRegisterBehavior::ArrowFunction { .. }
+			| FunctionRegisterBehavior::Constructor { .. } => false,
+		}
+	}
+}
+
+#[derive(Clone, Debug, Default, binary_serialize_derive::BinarySerializable)]
+pub struct ClosedOverVariables(pub(crate) HashMap<VariableId, TypeId>);
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, binary_serialize_derive::BinarySerializable)]
 pub struct ClosureId(pub(crate) u32);

--- a/checker/src/behavior/functions.rs
+++ b/checker/src/behavior/functions.rs
@@ -4,12 +4,18 @@ use source_map::{SourceId, Span, SpanWithSource};
 
 use super::variables::VariableMutability;
 use crate::{
-	context::{facts::Facts, Context, ContextType},
+	context::{
+		facts::{Facts, Publicity},
+		Context, ContextType,
+	},
 	events::Event,
 	synthesis::interfaces::GetterSetter,
 	types::{
-		classes::ClassProperties, functions::SynthesisedParameters,
-		poly_types::GenericTypeParameters, properties::PropertyValue, FunctionType, TypeStore,
+		classes::ClassValue,
+		functions::SynthesisedParameters,
+		poly_types::GenericTypeParameters,
+		properties::{PropertyKey, PropertyValue},
+		FunctionType, TypeStore,
 	},
 	ASTImplementation, CheckingData, Environment, FunctionId, ReadFromFS, Type, TypeId, VariableId,
 };
@@ -114,30 +120,6 @@ pub fn function_to_property(
 		GetterSetter::None => PropertyValue::Value(types.new_function_type(function)),
 	}
 }
-
-// pub struct RegisterAsConstructor<'a, M: ASTImplementation> {
-// 	pub class: TypeId,
-// 	pub class_extends: bool,
-// 	pub properties: ClassProperties<'a, M>,
-// }
-
-// impl<'a, M: crate::ASTImplementation> FunctionRegisterBehavior<M> for RegisterAsConstructor<'a, M> {
-// 	type Return = FunctionType;
-
-// 	fn constructor_on(&mut self) -> Option<(TypeId, bool, ClassProperties<M>)> {
-// 		Some((self.class, self.class_extends, mem::take(&mut self.properties)))
-// 	}
-
-// 	fn afterwards<T: SynthesisableFunction<M>, U: ContextType>(
-// 		&self,
-// 		original_function: &T,
-// 		synthesised_function: FunctionType,
-// 		environment: &mut Context<U>,
-// 		types: &mut TypeStore,
-// 	) -> Self::Return {
-// 		synthesised_function
-// 	}
-// }
 
 /// TODO different place
 /// TODO maybe generic
@@ -258,9 +240,11 @@ pub enum FunctionRegisterBehavior<'a, M: crate::ASTImplementation> {
 		prototype: TypeId,
 		/// Is this is_some then can use `super()`
 		super_type: Option<TypeId>,
-		properties: ClassProperties<'a, M>,
+		properties: ClassPropertiesToRegister<'a, M>,
 	},
 }
+
+pub struct ClassPropertiesToRegister<'a, M: ASTImplementation>(pub Vec<ClassValue<'a, M>>);
 
 impl<'a, M: crate::ASTImplementation> FunctionRegisterBehavior<'a, M> {
 	pub fn is_async(&self) -> bool {

--- a/checker/src/behavior/functions.rs
+++ b/checker/src/behavior/functions.rs
@@ -102,12 +102,11 @@ impl<M: crate::ASTImplementation> FunctionRegisterBehavior<M> for RegisterOnExis
 		environment: &mut Context<U>,
 		types: &mut TypeStore,
 	) -> Self::Return {
+		use crate::behavior::functions::MethodKind;
 		match func.get_kind() {
-			crate::MethodKind::Get => Property::Getter(Box::new(func_ty)),
-			crate::MethodKind::Set => Property::Setter(Box::new(func_ty)),
-			crate::MethodKind::Async
-			| crate::MethodKind::Generator { .. }
-			| crate::MethodKind::Plain => {
+			MethodKind::Get => Property::Getter(Box::new(func_ty)),
+			MethodKind::Set => Property::Setter(Box::new(func_ty)),
+			MethodKind::Async | MethodKind::Generator { .. } | MethodKind::Plain => {
 				let id = func_ty.id;
 				types.functions.insert(id, func_ty);
 				let ty = types.register_type(Type::Function(id, Default::default()));
@@ -129,7 +128,7 @@ pub trait SynthesisableFunction<M: crate::ASTImplementation> {
 
 	fn id(&self, source_id: SourceId) -> FunctionId;
 
-	/// **THIS FUNCTION IS EXPECTED TO PUT THE TYPE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESIZING THEM**
+	/// **THIS FUNCTION IS EXPECTED TO PUT THE TYPE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESISING THEM**
 	fn type_parameters<T: ReadFromFS>(
 		&self,
 		environment: &mut Environment,
@@ -143,7 +142,7 @@ pub trait SynthesisableFunction<M: crate::ASTImplementation> {
 		checking_data: &mut CheckingData<T, M>,
 	) -> Option<TypeId>;
 
-	/// **THIS FUNCTION IS EXPECTED TO PUT THE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESIZING THEM**
+	/// **THIS FUNCTION IS EXPECTED TO PUT THE PARAMETERS INTO THE ENVIRONMENT WHILE SYNTHESISING THEM**
 	fn parameters<T: ReadFromFS>(
 		&self,
 		environment: &mut Environment,
@@ -162,6 +161,10 @@ pub trait SynthesisableFunction<M: crate::ASTImplementation> {
 		environment: &mut Environment,
 		checking_data: &mut CheckingData<T, M>,
 	) -> Option<(TypeId, SpanWithSource)>;
+
+	fn location(&self) -> Option<String> {
+		None
+	}
 }
 
 struct ArrowFunction {

--- a/checker/src/behavior/mod.rs
+++ b/checker/src/behavior/mod.rs
@@ -1,3 +1,10 @@
+/// Contains implementations of specific JavaScript items and how Ezno handles them.
+/// Contains
+/// - Helper / abstracting functions for synthesising
+/// Does not contain
+/// - Logic stuff
+/// - Context
+/// - Internal structures
 pub mod assignments;
 pub mod constant_functions;
 pub mod functions;

--- a/checker/src/behavior/modules.rs
+++ b/checker/src/behavior/modules.rs
@@ -1,5 +1,7 @@
 use super::variables::VariableMutability;
-use crate::{context::facts::Facts, Diagnostic, TypeId, VariableId, VariableOrImport};
+use crate::{
+	behavior::variables::VariableOrImport, context::facts::Facts, Diagnostic, TypeId, VariableId,
+};
 use derive_enum_from_into::EnumFrom;
 use source_map::Span;
 use std::{collections::HashMap, default, path::PathBuf};

--- a/checker/src/behavior/modules.rs
+++ b/checker/src/behavior/modules.rs
@@ -19,7 +19,6 @@ pub enum ImportKind<'a, T: Iterator<Item = NamePair<'a>>> {
 		under: &'a str,
 		position: Span,
 	},
-	SideEffect,
 	/// From `export * from ...`
 	Everything,
 }

--- a/checker/src/behavior/objects.rs
+++ b/checker/src/behavior/objects.rs
@@ -2,7 +2,7 @@ use source_map::SpanWithSource;
 
 use crate::{
 	context::{
-		facts::{Facts, PublicityKind},
+		facts::{Facts, Publicity},
 		Environment,
 	},
 	types::{
@@ -27,7 +27,7 @@ impl ObjectBuilder {
 	pub fn append(
 		&mut self,
 		environment: &mut Environment,
-		publicity: PublicityKind,
+		publicity: Publicity,
 		under: PropertyKey<'static>,
 		value: PropertyValue,
 		position: Option<SpanWithSource>,

--- a/checker/src/behavior/objects.rs
+++ b/checker/src/behavior/objects.rs
@@ -5,13 +5,16 @@ use crate::{
 		facts::{Facts, PublicityKind},
 		Environment,
 	},
-	types::{properties::Property, TypeStore},
+	types::{
+		properties::{PropertyKey, PropertyValue},
+		TypeStore,
+	},
 	TypeId,
 };
 
 // TODO slice indexes
 pub struct ObjectBuilder {
-	pub(crate) object: TypeId,
+	pub object: TypeId,
 }
 
 impl ObjectBuilder {
@@ -24,12 +27,12 @@ impl ObjectBuilder {
 	pub fn append(
 		&mut self,
 		environment: &mut Environment,
-		under: TypeId,
-		value: Property,
-		property: PublicityKind,
+		publicity: PublicityKind,
+		under: PropertyKey<'static>,
+		value: PropertyValue,
 		position: Option<SpanWithSource>,
 	) {
-		environment.facts.register_property(self.object, under, value, true, property, position)
+		environment.facts.register_property(self.object, publicity, under, value, true, position)
 	}
 
 	pub fn build_object(self) -> TypeId {
@@ -46,8 +49,8 @@ pub enum SpecialObjects {
 		position: (),
 	},
 	Proxy {
-		handler: (),
-		over: (),
+		over: TypeId,
+		handler: TypeId,
 	},
 	/// This cannot be a regular object because of is because of let mutations
 	Import(super::modules::Exported),

--- a/checker/src/behavior/template_literal.rs
+++ b/checker/src/behavior/template_literal.rs
@@ -70,7 +70,7 @@ where
 					let value = part_to_type(p, environment, checking_data);
 					static_parts.append(
 						environment,
-						crate::context::facts::PublicityKind::Public,
+						crate::context::facts::Publicity::Public,
 						crate::types::properties::PropertyKey::from_usize(static_part_count.into()),
 						crate::PropertyValue::Value(value),
 						// TODO should static parts should have position?
@@ -121,6 +121,7 @@ where
 					crate::behavior::operations::MathematicalAndBitwise::Add,
 					other,
 					&mut checking_data.types,
+					checking_data.options.strict_casts,
 				);
 				match result {
 					Ok(result) => acc = result,

--- a/checker/src/behavior/variables.rs
+++ b/checker/src/behavior/variables.rs
@@ -1,6 +1,6 @@
 use source_map::{Span, SpanWithSource};
 
-use crate::context::{environment::ContextSpecifierTemp, AssignmentError};
+use crate::context::{environment::ContextLocation, AssignmentError};
 use crate::{types::TypeId, CheckingData, VariableId};
 use std::fmt::Debug;
 
@@ -15,7 +15,7 @@ pub enum VariableOrImport {
 		/// Location where variable is defined **ALSO UNIQUELY IDENTIFIES THE VARIABLE** as can
 		/// be turned into a [VariableId]
 		declared_at: SpanWithSource,
-		context: ContextSpecifierTemp,
+		context: ContextLocation,
 	},
 	MutableImport {
 		of: VariableId,

--- a/checker/src/behavior/variables.rs
+++ b/checker/src/behavior/variables.rs
@@ -1,6 +1,6 @@
 use source_map::{Span, SpanWithSource};
 
-use crate::context::AssignmentError;
+use crate::context::{environment::ContextSpecifierTemp, AssignmentError};
 use crate::{types::TypeId, CheckingData, VariableId};
 use std::fmt::Debug;
 
@@ -15,6 +15,7 @@ pub enum VariableOrImport {
 		/// Location where variable is defined **ALSO UNIQUELY IDENTIFIES THE VARIABLE** as can
 		/// be turned into a [VariableId]
 		declared_at: SpanWithSource,
+		context: ContextSpecifierTemp,
 	},
 	MutableImport {
 		of: VariableId,
@@ -30,7 +31,7 @@ pub enum VariableOrImport {
 impl VariableOrImport {
 	pub(crate) fn get_id(&self) -> VariableId {
 		match self {
-			VariableOrImport::Variable { mutability: _, declared_at } => {
+			VariableOrImport::Variable { mutability: _, declared_at, .. } => {
 				VariableId(declared_at.source, declared_at.start)
 			}
 			VariableOrImport::MutableImport { import_specified_at, .. }
@@ -42,7 +43,7 @@ impl VariableOrImport {
 
 	pub(crate) fn get_mutability(&self) -> VariableMutability {
 		match self {
-			VariableOrImport::Variable { mutability, declared_at } => *mutability,
+			VariableOrImport::Variable { mutability, declared_at, .. } => *mutability,
 			VariableOrImport::MutableImport { of, constant, import_specified_at } => {
 				VariableMutability::Constant
 			}

--- a/checker/src/context/calling.rs
+++ b/checker/src/context/calling.rs
@@ -1,5 +1,5 @@
 use super::facts::Facts;
-use crate::{Environment, FunctionId};
+use crate::{events::EarlyReturn, Environment, FunctionId};
 
 /// For anything that might involve a call, including gets, sets and actual calls
 pub(crate) trait CallCheckingBehavior {
@@ -84,12 +84,12 @@ impl CallCheckingBehavior for Target {
 impl Target {
 	pub(crate) fn new_conditional_target(
 		&mut self,
-		cb: impl for<'a> FnOnce(&'a mut Target),
-	) -> Facts {
+		cb: impl for<'a> FnOnce(&'a mut Target) -> EarlyReturn,
+	) -> (Facts, EarlyReturn) {
 		self.0.push(TargetKind::Conditional(Facts::default()));
-		cb(self);
+		let result = cb(self);
 		if let Some(TargetKind::Conditional(facts)) = self.0.pop() {
-			facts
+			(facts, result)
 		} else {
 			unreachable!()
 		}

--- a/checker/src/context/facts.rs
+++ b/checker/src/context/facts.rs
@@ -3,9 +3,10 @@ use std::{borrow::Cow, collections::HashMap};
 use source_map::SpanWithSource;
 
 use crate::{
-	behavior::functions::ClosureId,
+	behavior::functions::{ClosureId, ThisValue},
 	events::{Event, RootReference},
-	Property, Type, TypeId, VariableId,
+	types::properties::PropertyKey,
+	PropertyValue, Type, TypeId, VariableId,
 };
 
 /// TODO explain usage
@@ -24,7 +25,8 @@ pub struct Facts {
 
 	/// This can be not have a value if not defined
 	pub(crate) variable_current_value: HashMap<VariableId, TypeId>,
-	pub(crate) current_properties: HashMap<TypeId, Vec<(TypeId, PublicityKind, Property)>>,
+	pub(crate) current_properties:
+		HashMap<TypeId, Vec<(PublicityKind, PropertyKey<'static>, PropertyValue)>>,
 	pub(crate) prototypes: HashMap<TypeId, TypeId>,
 
 	pub(crate) closure_current_values: HashMap<(ClosureId, RootReference), TypeId>,
@@ -33,6 +35,11 @@ pub struct Facts {
 	pub(crate) enumerable: HashMap<(TypeId, TypeId), TypeId>,
 	pub(crate) writable: HashMap<(TypeId, TypeId), TypeId>,
 	pub(crate) frozen: HashMap<TypeId, TypeId>,
+
+	/// For super calls etc
+	///
+	/// TODO not great that this has to be Option to satisfy Default
+	pub(crate) value_of_this: ThisValue,
 }
 
 impl Facts {
@@ -40,14 +47,14 @@ impl Facts {
 	pub fn register_property(
 		&mut self,
 		on: TypeId,
-		under: TypeId,
-		to: Property,
-		register_setter_event: bool,
 		publicity: PublicityKind,
+		under: PropertyKey<'static>,
+		to: PropertyValue,
+		register_setter_event: bool,
 		position: Option<SpanWithSource>,
 	) {
 		// crate::utils::notify!("Registering {:?} {:?} {:?}", on, under, to);
-		self.current_properties.entry(on).or_default().push((under, publicity, to.clone()));
+		self.current_properties.entry(on).or_default().push((publicity, under.clone(), to.clone()));
 		if register_setter_event {
 			self.events.push(Event::Setter {
 				on,
@@ -98,10 +105,10 @@ impl Facts {
 		ty
 	}
 
-	pub fn get_properties_on_type(
+	pub fn get_properties_on_type_for_this_level(
 		&self,
 		ty: TypeId,
-	) -> Option<&Vec<(TypeId, PublicityKind, Property)>> {
+	) -> Option<&Vec<(PublicityKind, PropertyKey, PropertyValue)>> {
 		self.current_properties.get(&ty)
 	}
 

--- a/checker/src/context/facts.rs
+++ b/checker/src/context/facts.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// TODO explain usage
 #[derive(Debug, Clone, Copy, PartialEq, Eq, binary_serialize_derive::BinarySerializable)]
-pub enum PublicityKind {
+pub enum Publicity {
 	Private,
 	Public,
 }
@@ -26,7 +26,7 @@ pub struct Facts {
 	/// This can be not have a value if not defined
 	pub(crate) variable_current_value: HashMap<VariableId, TypeId>,
 	pub(crate) current_properties:
-		HashMap<TypeId, Vec<(PublicityKind, PropertyKey<'static>, PropertyValue)>>,
+		HashMap<TypeId, Vec<(Publicity, PropertyKey<'static>, PropertyValue)>>,
 	pub(crate) prototypes: HashMap<TypeId, TypeId>,
 
 	pub(crate) closure_current_values: HashMap<(ClosureId, RootReference), TypeId>,
@@ -47,7 +47,7 @@ impl Facts {
 	pub fn register_property(
 		&mut self,
 		on: TypeId,
-		publicity: PublicityKind,
+		publicity: Publicity,
 		under: PropertyKey<'static>,
 		to: PropertyValue,
 		register_setter_event: bool,
@@ -108,7 +108,7 @@ impl Facts {
 	pub fn get_properties_on_type_for_this_level(
 		&self,
 		ty: TypeId,
-	) -> Option<&Vec<(PublicityKind, PropertyKey, PropertyValue)>> {
+	) -> Option<&Vec<(Publicity, PropertyKey, PropertyValue)>> {
 		self.current_properties.get(&ty)
 	}
 

--- a/checker/src/context/root.rs
+++ b/checker/src/context/root.rs
@@ -82,7 +82,7 @@ impl RootContext {
 		source: SourceId,
 		module: M::Module,
 		checking_data: &'a mut CheckingData<T, M>,
-	) -> &'a SynthesisedModule<M::Module> {
+	) -> &'a SynthesisedModule<M::OwnedModule> {
 		let mut environment = self.new_lexical_environment(crate::Scope::Module {
 			source,
 			exported: Exported::default(),
@@ -92,7 +92,12 @@ impl RootContext {
 		let crate::Scope::Module { exported, .. } = environment.context_type.scope else {
 			unreachable!()
 		};
-		let module = SynthesisedModule { content: module, exported, facts: environment.facts };
+
+		let module = SynthesisedModule {
+			content: M::owned_module_from_module(module),
+			exported,
+			facts: environment.facts,
+		};
 
 		// TODO better way to do this?
 		checking_data.modules.synthesised_modules.insert(source, module);

--- a/checker/src/context/root.rs
+++ b/checker/src/context/root.rs
@@ -72,7 +72,7 @@ impl RootContext {
 			bases: Default::default(),
 			object_constraints: Default::default(),
 			// TODO
-			can_use_this: crate::context::CanUseThis::Yeah { this_ty: TypeId::ERROR_TYPE },
+			can_reference_this: crate::context::CanReferenceThis::Yeah,
 			facts: Default::default(),
 		}
 	}
@@ -89,7 +89,7 @@ impl RootContext {
 		});
 		M::synthesise_module(&module, source, &mut environment, checking_data);
 
-		let crate::Scope::Module { exported, .. } = environment.context_type.kind else {
+		let crate::Scope::Module { exported, .. } = environment.context_type.scope else {
 			unreachable!()
 		};
 		let module = SynthesisedModule { content: module, exported, facts: environment.facts };
@@ -138,7 +138,7 @@ impl RootContext {
 		// ctx.subtyping_constant_proofs = BinarySerializable::deserialize(&mut bytes, backing_source);
 		// ctx.terms_reverse = BinarySerializable::deserialize(&mut bytes, backing_source);
 		// ctx.proxies = BinarySerializable::deserialize(&mut bytes, backing_source);
-		// ctx.can_use_this = BinarySerializable::deserialize(&mut bytes, backing_source);
+		// ctx.can_reference_this = BinarySerializable::deserialize(&mut bytes, backing_source);
 
 		// Ok(ctx)
 	}

--- a/checker/src/context/root.rs
+++ b/checker/src/context/root.rs
@@ -1,7 +1,8 @@
 use super::{facts::Facts, ClosedOverReferencesInScope, Context, ContextId, ContextType};
 use crate::{
-	behavior::modules::Exported, types::TypeId, CheckingData, Environment, GeneralContext,
-	SynthesisedModule,
+	behavior::modules::{Exported, SynthesisedModule},
+	types::TypeId,
+	CheckingData, Environment, GeneralContext,
 };
 use source_map::SourceId;
 use std::{collections::HashMap, iter::FromIterator};
@@ -86,7 +87,7 @@ impl RootContext {
 			source,
 			exported: Exported::default(),
 		});
-		M::synthesize_module(&module, source, &mut environment, checking_data);
+		M::synthesise_module(&module, source, &mut environment, checking_data);
 
 		let crate::Scope::Module { exported, .. } = environment.context_type.kind else {
 			unreachable!()

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -328,7 +328,7 @@ mod defined_errors_and_warnings {
 								position: argument_position,
 								labels: vec![(
 									format!(
-										"{} was specialized with type {}",
+										"{} was specialised with type {}",
 										parameter_type, restriction
 									),
 									Some(restriction_pos),

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -11,7 +11,7 @@ use crate::{
 		properties::{get_property, set_property, PropertyValue},
 		substitute, Constructor, StructureGenerics, TypeId, TypeStore,
 	},
-	Environment, TruthyFalsy, Type,
+	Decidable, Environment, Type,
 };
 
 pub(crate) fn apply_event(
@@ -233,7 +233,7 @@ pub(crate) fn apply_event(
 		Event::Conditionally { condition, events_if_truthy, else_events, position } => {
 			let condition = substitute(condition, type_arguments, environment, types);
 
-			if let TruthyFalsy::Decidable(result) = is_type_truthy_falsy(condition, types) {
+			if let Decidable::Known(result) = is_type_truthy_falsy(condition, types) {
 				let to_evaluate = if result { events_if_truthy } else { else_events };
 				for event in to_evaluate.iter().cloned() {
 					if let Some(early) =

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -8,7 +8,7 @@ use crate::{
 		functions::SynthesisedArgument,
 		is_type_truthy_falsy,
 		poly_types::FunctionTypeArguments,
-		properties::{get_property, set_property, Property},
+		properties::{get_property, set_property, PropertyValue},
 		substitute, Constructor, StructureGenerics, TypeId, TypeStore,
 	},
 	Environment, TruthyFalsy, Type,
@@ -35,7 +35,7 @@ pub(crate) fn apply_event(
 						match value {
 							Some(ty) => ty,
 							None => {
-								todo!("tdz error");
+								crate::utils::notify!("emit a tdz error");
 								TypeId::ERROR_TYPE
 							}
 						}
@@ -66,11 +66,19 @@ pub(crate) fn apply_event(
 		}
 		Event::Getter { on, under, reflects_dependency, publicity, position } => {
 			let on = substitute(on, type_arguments, environment, types);
-			let property = substitute(under, type_arguments, environment, types);
+			let under = match under {
+				crate::types::properties::PropertyKey::Type(under) => {
+					let ty = substitute(under, type_arguments, environment, types);
+					crate::types::properties::PropertyKey::from_type(ty, &types)
+				}
+				under => under,
+			};
 
 			let (_, value) =
-				get_property(on, under, publicity, None, environment, target, types, position)
-					.expect("Inferred constraints and checking failed");
+				get_property(on, publicity, under, None, environment, target, types, position)
+					.expect(
+						"Inferred or checking failed, could not get property when getting property",
+					);
 
 			if let Some(id) = reflects_dependency {
 				type_arguments.set_id_from_reference(id, value, types);
@@ -86,17 +94,26 @@ pub(crate) fn apply_event(
 			position,
 		} => {
 			let on = substitute(on, type_arguments, environment, types);
-			let under = substitute(under, type_arguments, environment, types);
+			let under = match under {
+				crate::types::properties::PropertyKey::Type(under) => {
+					let ty = substitute(under, type_arguments, environment, types);
+					crate::types::properties::PropertyKey::from_type(ty, &types)
+				}
+				under => under,
+			};
 
 			let new = match new {
-				Property::Value(new) => {
-					Property::Value(substitute(new, type_arguments, environment, types))
+				PropertyValue::Value(new) => {
+					PropertyValue::Value(substitute(new, type_arguments, environment, types))
 				}
 				// For declare property
-				Property::Getter(_) => todo!(),
-				Property::Setter(_) => todo!(),
-				Property::GetterAndSetter(_, _) => todo!(),
-				Property::Deleted => todo!(),
+				PropertyValue::Getter(_) => todo!(),
+				PropertyValue::Setter(_) => todo!(),
+				// TODO this might be a different thing at some point
+				PropertyValue::Deleted => {
+					environment.delete_property(on, under);
+					return None;
+				}
 			};
 
 			let gc = environment.as_general_context();
@@ -126,10 +143,10 @@ pub(crate) fn apply_event(
 					};
 				target
 					.get_top_level_facts(environment)
-					.register_property(on, under, new, true, publicity, position);
+					.register_property(on, publicity, under, new, true, position);
 			} else {
 				let returned =
-					set_property(on, under, publicity, new, environment, target, types, position)
+					set_property(on, publicity, under, new, environment, target, types, position)
 						.unwrap();
 
 				if let Some(id) = reflects_dependency {
@@ -219,23 +236,51 @@ pub(crate) fn apply_event(
 			if let TruthyFalsy::Decidable(result) = is_type_truthy_falsy(condition, types) {
 				let to_evaluate = if result { events_if_truthy } else { else_events };
 				for event in to_evaluate.iter().cloned() {
-					apply_event(event, this_value, type_arguments, environment, target, types);
+					if let Some(early) =
+						apply_event(event, this_value, type_arguments, environment, target, types)
+					{
+						return Some(early);
+					}
 				}
 			} else {
 				// TODO early returns
 
 				// TODO could inject proofs but probably already worked out
-				let truthy_facts = target.new_conditional_target(|target: &mut Target| {
-					for event in events_if_truthy.into_vec() {
-						apply_event(event, this_value, type_arguments, environment, target, types);
-					}
-				});
+				let (truthy_facts, _early_return) =
+					target.new_conditional_target(|target: &mut Target| {
+						for event in events_if_truthy.into_vec() {
+							if let Some(early) = apply_event(
+								event,
+								this_value,
+								type_arguments,
+								environment,
+								target,
+								types,
+							) {
+								return Some(early);
+							}
+						}
+						None
+					});
 
-				let mut else_facts = target.new_conditional_target(|target: &mut Target| {
-					for event in else_events.into_vec() {
-						apply_event(event, this_value, type_arguments, environment, target, types);
-					}
-				});
+				let (mut else_facts, _early_return) =
+					target.new_conditional_target(|target: &mut Target| {
+						for event in else_events.into_vec() {
+							if let Some(early) = apply_event(
+								event,
+								this_value,
+								type_arguments,
+								environment,
+								target,
+								types,
+							) {
+								return Some(early);
+							}
+						}
+						None
+					});
+
+				// TODO early return
 
 				// crate::utils::notify!("TF {:?}\n EF {:?}", truthy_facts, else_facts);
 
@@ -265,19 +310,14 @@ pub(crate) fn apply_event(
 		}
 		Event::Return { returned, returned_position } => {
 			let substituted_returned = substitute(returned, type_arguments, environment, types);
-
 			if substituted_returned != TypeId::ERROR_TYPE {
 				return Some(substituted_returned);
 			} else {
 				crate::utils::notify!("event returned error so skipped");
 			}
 		}
-
 		// TODO Needs a position (or not?)
 		Event::CreateObject { referenced_in_scope_as, prototype, position } => {
-			// TODO only if exposed via set
-
-			// TODO
 			let is_under_dyn = true;
 
 			let new_object_id = match prototype {
@@ -297,8 +337,7 @@ pub(crate) fn apply_event(
 				}
 			};
 
-			// let new_object_id_with_curried_arguments =  new_object_id;
-			// TODO conditionally
+			// TODO conditionally if any properties are structurally generic
 			let new_object_id_with_curried_arguments =
 				curry_arguments(type_arguments, types, new_object_id);
 

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::{
 	behavior::functions::ThisValue,
-	context::{calling::Target, facts::PublicityKind, get_on_ctx, CallCheckingBehavior},
+	context::{calling::Target, facts::Publicity, get_on_ctx, CallCheckingBehavior},
 	types::{
 		calling::CalledWithNew,
 		properties::{PropertyKey, PropertyValue},
@@ -62,7 +62,7 @@ pub enum Event {
 		on: TypeId,
 		under: PropertyKey<'static>,
 		reflects_dependency: Option<TypeId>,
-		publicity: PublicityKind,
+		publicity: Publicity,
 		position: SpanWithSource,
 	},
 	/// All changes to the value of a property
@@ -76,7 +76,7 @@ pub enum Event {
 		/// TODO this is [define] property
 		/// see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields
 		initialization: bool,
-		publicity: PublicityKind,
+		publicity: Publicity,
 		position: Option<SpanWithSource>,
 	},
 
@@ -119,7 +119,7 @@ pub enum Event {
 		prototype: PrototypeArgument,
 		/// This is the id referencing a [Type::AliasTo] that is created
 		///
-		/// This is also for the specialization (somehow)
+		/// This is also for the specialisation (somehow)
 		referenced_in_scope_as: TypeId,
 		position: Option<SpanWithSource>,
 	},

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -5,7 +5,10 @@
 use crate::{
 	behavior::functions::ThisValue,
 	context::{calling::Target, facts::PublicityKind, get_on_ctx, CallCheckingBehavior},
-	types::{calling::CalledWithNew, properties::Property},
+	types::{
+		calling::CalledWithNew,
+		properties::{PropertyKey, PropertyValue},
+	},
 	FunctionId, GeneralContext, SpanWithSource, VariableId,
 };
 
@@ -57,7 +60,7 @@ pub enum Event {
 	/// Mostly trivial, sometimes can call a function :(
 	Getter {
 		on: TypeId,
-		under: TypeId,
+		under: PropertyKey<'static>,
 		reflects_dependency: Option<TypeId>,
 		publicity: PublicityKind,
 		position: SpanWithSource,
@@ -65,9 +68,9 @@ pub enum Event {
 	/// All changes to the value of a property
 	Setter {
 		on: TypeId,
-		under: TypeId,
+		under: PropertyKey<'static>,
 		// Can be a getter through define property
-		new: Property,
+		new: PropertyValue,
 		reflects_dependency: Option<TypeId>,
 		/// THIS DOES NOT CALL SETTERS, JUST SETS VALUE!
 		/// TODO this is [define] property
@@ -120,7 +123,6 @@ pub enum Event {
 		referenced_in_scope_as: TypeId,
 		position: Option<SpanWithSource>,
 	},
-	// Registration(Registration),
 }
 
 #[derive(Debug, Clone, binary_serialize_derive::BinarySerializable)]

--- a/checker/src/synthesis/README.md
+++ b/checker/src/synthesis/README.md
@@ -1,3 +1,5 @@
-Synthesis is parsing types from the AST
+Contains logic between [Ezno's parser](https://github.com/kaleidawave/ezno/tree/main/parser) and the checkers API.
 
-This module is based on Ezno's parser
+If parsing is building abstract syntax tree from a string, synthesis is building types (and other information from abstract syntax tree)
+
+This module is based on [Ezno's parser](https://github.com/kaleidawave/ezno/tree/main/parser), for bindings between Oxc's parser and Ezno check out [oxc_type_synthesis](https://github.com/web-infra-dev/oxc/tree/main/crates/oxc_type_synthesis).

--- a/checker/src/synthesis/assignments.rs
+++ b/checker/src/synthesis/assignments.rs
@@ -8,7 +8,7 @@ use parser::{
 
 use crate::{
 	behavior::assignments::{Assignable, Reference},
-	context::{facts::PublicityKind, Environment},
+	context::{facts::Publicity, Environment},
 	synthesis::expressions::synthesise_expression,
 	types::{properties::PropertyKey, Constant},
 	CheckingData, TypeId,
@@ -127,7 +127,7 @@ pub(crate) fn synthesise_access_to_reference<T: crate::ReadFromFS>(
 			match property {
 				parser::PropertyReference::Standard { property, is_private } => {
 					let publicity =
-						if *is_private { PublicityKind::Private } else { PublicityKind::Public };
+						if *is_private { Publicity::Private } else { Publicity::Public };
 					Reference::Property {
 						on: parent_ty,
 						with: crate::types::properties::PropertyKey::String(Cow::Owned(
@@ -156,7 +156,7 @@ pub(crate) fn synthesise_access_to_reference<T: crate::ReadFromFS>(
 					&checking_data.types,
 				),
 				span: position.clone().with_source(environment.get_source()),
-				publicity: crate::context::facts::PublicityKind::Public,
+				publicity: crate::context::facts::Publicity::Public,
 			}
 		}
 	}

--- a/checker/src/synthesis/assignments.rs
+++ b/checker/src/synthesis/assignments.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use ordered_float::NotNan;
 use parser::{
 	ast::LHSOfAssignment, expressions::assignments::VariableOrPropertyAccess, ASTNode,
@@ -8,11 +10,13 @@ use crate::{
 	behavior::assignments::{Assignable, Reference},
 	context::{facts::PublicityKind, Environment},
 	synthesis::expressions::synthesise_expression,
-	types::Constant,
+	types::{properties::PropertyKey, Constant},
 	CheckingData, TypeId,
 };
 
-use super::{expressions::synthesise_multiple_expression, property_key_as_type};
+use super::{
+	expressions::synthesise_multiple_expression, parser_property_key_to_checker_property_key,
+};
 
 pub(super) fn synthesise_lhs_of_assignment_to_reference<T: crate::ReadFromFS>(
 	lhs: &LHSOfAssignment,
@@ -25,13 +29,11 @@ pub(super) fn synthesise_lhs_of_assignment_to_reference<T: crate::ReadFromFS>(
 				.iter()
 				.map(|item| match item.get_ast_ref() {
 					parser::ObjectDestructuringField::Name(name, _, _) => {
-						let on = checking_data.types.new_constant_type(Constant::String(
-							if let VariableIdentifier::Standard(name, _) = name {
-								name.clone()
-							} else {
-								todo!()
-							},
-						));
+						let on = if let VariableIdentifier::Standard(name, _) = name {
+							PropertyKey::String(Cow::Owned(name.clone()))
+						} else {
+							todo!()
+						};
 						(
 							on,
 							synthesise_object_shorthand_assignable(
@@ -51,10 +53,10 @@ pub(super) fn synthesise_lhs_of_assignment_to_reference<T: crate::ReadFromFS>(
 						// TODO into function
 						match name.get_ast_ref() {
 							parser::VariableField::Name(name) => {
-								let on = property_key_as_type(
+								let on = parser_property_key_to_checker_property_key(
 									from,
 									environment,
-									&mut checking_data.types,
+									checking_data,
 								);
 								let a = synthesise_object_shorthand_assignable(
 									name,
@@ -120,16 +122,17 @@ pub(crate) fn synthesise_access_to_reference<T: crate::ReadFromFS>(
 			position.clone().with_source(environment.get_source()),
 		),
 		VariableOrPropertyAccess::PropertyAccess { parent, property, position } => {
-			let parent_ty = synthesise_expression(&parent, environment, checking_data);
+			let parent_ty =
+				synthesise_expression(&parent, environment, checking_data, TypeId::ANY_TYPE);
 			match property {
 				parser::PropertyReference::Standard { property, is_private } => {
 					let publicity =
 						if *is_private { PublicityKind::Private } else { PublicityKind::Public };
 					Reference::Property {
 						on: parent_ty,
-						with: checking_data
-							.types
-							.new_constant_type(Constant::String(property.clone())),
+						with: crate::types::properties::PropertyKey::String(Cow::Owned(
+							property.clone(),
+						)),
 						span: position.clone().with_source(environment.get_source()),
 						publicity,
 					}
@@ -138,11 +141,20 @@ pub(crate) fn synthesise_access_to_reference<T: crate::ReadFromFS>(
 			}
 		}
 		VariableOrPropertyAccess::Index { indexee, indexer, position } => {
-			let parent_ty = synthesise_expression(&indexee, environment, checking_data);
-			let key_ty = synthesise_multiple_expression(&indexer, environment, checking_data);
+			let parent_ty =
+				synthesise_expression(&indexee, environment, checking_data, TypeId::ANY_TYPE);
+			let key_ty = synthesise_multiple_expression(
+				&indexer,
+				environment,
+				checking_data,
+				TypeId::ANY_TYPE,
+			);
 			Reference::Property {
 				on: parent_ty,
-				with: key_ty,
+				with: crate::types::properties::PropertyKey::from_type(
+					key_ty,
+					&checking_data.types,
+				),
 				span: position.clone().with_source(environment.get_source()),
 				publicity: crate::context::facts::PublicityKind::Public,
 			}

--- a/checker/src/synthesis/block.rs
+++ b/checker/src/synthesis/block.rs
@@ -2,7 +2,7 @@ use parser::{declarations::VariableDeclaration, Declaration, Statement, Statemen
 
 use crate::{
 	behavior::modules::Exported, context::Environment, diagnostics::TypeCheckError, CheckingData,
-	Scope,
+	Scope, TypeId,
 };
 
 use super::{
@@ -109,13 +109,13 @@ pub(crate) fn synthesise_declaration<T: crate::ReadFromFS>(
 							let pair = super::hoisting::export_part_to_name_pair(part);
 							if let Some(pair) = pair {
 								let position = pair.position.with_source(environment.get_source());
-								let value = environment.get_variable_or_error(
+								let value = environment.get_variable_handle_error(
 									pair.value,
 									position,
 									checking_data,
 								);
 								if let crate::Scope::Module { ref mut exported, .. } =
-									environment.context_type.kind
+									environment.context_type.scope
 								{
 									if let Ok(value) = value {
 										exported.named.push((
@@ -132,8 +132,10 @@ pub(crate) fn synthesise_declaration<T: crate::ReadFromFS>(
 				}
 			}
 			parser::declarations::ExportDeclaration::Default { expression, position } => {
-				let result = synthesise_expression(expression, environment, checking_data);
-				if let Scope::Module { ref mut exported, .. } = environment.context_type.kind {
+				// TODO can be inferred sometimes
+				let result =
+					synthesise_expression(expression, environment, checking_data, TypeId::ANY_TYPE);
+				if let Scope::Module { ref mut exported, .. } = environment.context_type.scope {
 					if exported.default.is_some() {
 						checking_data.diagnostics_container.add_error(
 							TypeCheckError::DoubleDefaultExport(

--- a/checker/src/synthesis/block.rs
+++ b/checker/src/synthesis/block.rs
@@ -36,7 +36,7 @@ pub(super) fn synthesise_block<T: crate::ReadFromFS>(
 				}
 			}
 			StatementOrDeclaration::Declaration(declaration) => {
-				synthesize_declaration(declaration, environment, checking_data)
+				synthesise_declaration(declaration, environment, checking_data)
 			}
 		}
 	}
@@ -55,7 +55,7 @@ pub(super) fn synthesise_block<T: crate::ReadFromFS>(
 	}
 }
 
-pub(crate) fn synthesize_declaration<T: crate::ReadFromFS>(
+pub(crate) fn synthesise_declaration<T: crate::ReadFromFS>(
 	declaration: &Declaration,
 	environment: &mut crate::context::Context<crate::context::Syntax<'_>>,
 	checking_data: &mut CheckingData<T, super::EznoParser>,
@@ -72,6 +72,7 @@ pub(crate) fn synthesize_declaration<T: crate::ReadFromFS>(
 				position.clone(),
 				constructor,
 				&mut checking_data.types,
+				None,
 			);
 			if let Err(err) = result {
 				checking_data.diagnostics_container.add_error(TypeCheckError::ReDeclaredVariable {

--- a/checker/src/synthesis/classes.rs
+++ b/checker/src/synthesis/classes.rs
@@ -104,7 +104,7 @@ pub(super) fn synthesise_class_declaration<
 						let ty = environment.new_function(
 							checking_data,
 							constructor,
-							crate::RegisterAsType,
+							crate::behavior::functions::RegisterAsType,
 						);
 
 						class_constructor = Some(ty);
@@ -125,7 +125,7 @@ pub(super) fn synthesise_class_declaration<
 						let property = environment.new_function(
 							checking_data,
 							function,
-							crate::RegisterOnExistingObject,
+							crate::behavior::functions::RegisterOnExistingObject,
 						);
 
 						if static_kw.is_some() {

--- a/checker/src/synthesis/definitions.rs
+++ b/checker/src/synthesis/definitions.rs
@@ -2,7 +2,7 @@ use parser::ASTNode;
 
 use crate::{
 	context::{Names, RootContext},
-	synthesis::{functions::type_function_reference, EznoParser},
+	synthesis::{functions::synthesise_function_annotation, EznoParser},
 	Environment, Facts, TypeId,
 };
 
@@ -70,7 +70,7 @@ pub(super) fn type_definition_file<T: crate::ReadFromFS>(
 			TypeDefinitionModuleDeclaration::Function(func) => {
 				// TODO abstract
 				let declared_at = func.get_position().clone().with_source(source);
-				let base = type_function_reference(
+				let base = synthesise_function_annotation(
 					&func.type_parameters,
 					&func.parameters,
 					func.return_type.as_ref(),
@@ -78,7 +78,7 @@ pub(super) fn type_definition_file<T: crate::ReadFromFS>(
 					checking_data,
 					func.performs.as_ref().into(),
 					declared_at.clone(),
-					crate::types::FunctionKind::Arrow,
+					crate::behavior::functions::FunctionBehavior::ArrowFunction { is_async: false },
 					None,
 				);
 
@@ -89,7 +89,7 @@ pub(super) fn type_definition_file<T: crate::ReadFromFS>(
 					// TODO
 					declared_at,
 					base.effects,
-					base.constant_id,
+					base.constant_function,
 				);
 
 				let behavior = crate::context::VariableRegisterBehavior::Declare {

--- a/checker/src/synthesis/expressions.rs
+++ b/checker/src/synthesis/expressions.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, marker::PhantomData};
+use std::{borrow::Cow, convert::TryInto, marker::PhantomData};
 
 use parser::{
 	expressions::{
@@ -7,15 +7,24 @@ use parser::{
 		MultipleExpression, SpecialOperators, SpreadExpression, SuperReference, TemplateLiteral,
 	},
 	operators::{BinaryAssignmentOperator, UnaryOperator, UnaryPrefixAssignmentOperator},
-	ASTNode, Expression,
+	ASTNode, Expression, MethodHeader,
 };
 
-use crate::{behavior::variables::VariableWithValue, synthesis::property_key_as_type};
+use crate::{
+	behavior::{
+		functions::{
+			register_arrow_function, register_expression_function, FunctionRegisterBehavior,
+			SynthesisableFunction,
+		},
+		variables::VariableWithValue,
+	},
+	synthesis::parser_property_key_to_checker_property_key,
+	types::properties::PropertyKey,
+};
 
 use crate::{
 	behavior::{
 		assignments::Assignable,
-		functions::{RegisterAsType, RegisterOnExistingObject},
 		objects::ObjectBuilder,
 		operations::{
 			evaluate_logical_operation_with_expression,
@@ -34,6 +43,7 @@ use crate::{
 
 use super::{
 	assignments::{synthesise_access_to_reference, synthesise_lhs_of_assignment_to_reference},
+	classes::synthesise_class_declaration,
 	extensions::{is_expression::synthesise_is_expression, jsx::synthesise_jsx_root},
 	type_annotations::synthesise_type_annotation,
 	EznoParser,
@@ -43,14 +53,15 @@ pub(super) fn synthesise_multiple_expression<T: crate::ReadFromFS>(
 	expression: &MultipleExpression,
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, super::EznoParser>,
+	expecting: TypeId,
 ) -> TypeId {
 	match expression {
 		MultipleExpression::Multiple { lhs, rhs, position: _ } => {
-			synthesise_multiple_expression(lhs, environment, checking_data);
-			synthesise_expression(rhs, environment, checking_data)
+			synthesise_multiple_expression(lhs, environment, checking_data, TypeId::ANY_TYPE);
+			synthesise_expression(rhs, environment, checking_data, expecting)
 		}
 		MultipleExpression::Single(expression) => {
-			synthesise_expression(expression, environment, checking_data)
+			synthesise_expression(expression, environment, checking_data, expecting)
 		}
 	}
 }
@@ -59,6 +70,7 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 	expression: &Expression,
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, super::EznoParser>,
+	expecting: TypeId,
 ) -> TypeId {
 	let instance: Instance = match expression {
 		Expression::Comment(..) => unreachable!("Should have skipped this higher up"),
@@ -77,22 +89,20 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 			return checking_data.types.new_constant_type(Constant::Boolean(*value))
 		}
 		Expression::ArrayLiteral(elements, _) => {
+			/// TODO spread + count length
 			fn synthesise_array_item<T: crate::ReadFromFS>(
 				idx: usize,
 				element: &SpreadExpression,
 				environment: &mut Environment,
 				checking_data: &mut CheckingData<T, super::EznoParser>,
-			) -> (TypeId, TypeId) {
+			) -> (PropertyKey<'static>, TypeId) {
 				match element {
 					SpreadExpression::NonSpread(element) => {
+						// TODO based off above
+						let expecting = TypeId::ANY_TYPE;
 						let expression_type =
-							synthesise_expression(element, environment, checking_data);
-						(
-							checking_data.types.new_constant_type(Constant::Number(
-								(idx as f64).try_into().unwrap(),
-							)),
-							expression_type,
-						)
+							synthesise_expression(element, environment, checking_data, expecting);
+						(PropertyKey::from_usize(idx), expression_type)
 					}
 					SpreadExpression::Spread(expr, position) => {
 						{
@@ -102,21 +112,11 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 							);
 						}
 						crate::utils::notify!("Skipping spread");
-						(
-							checking_data.types.new_constant_type(Constant::Number(
-								(idx as f64).try_into().unwrap(),
-							)),
-							TypeId::ERROR_TYPE,
-						)
+						(PropertyKey::from_usize(idx), TypeId::ERROR_TYPE)
 					}
 					SpreadExpression::Empty => {
 						crate::utils::notify!("Empty expression temp as empty");
-						(
-							checking_data.types.new_constant_type(Constant::Number(
-								(idx as f64).try_into().unwrap(),
-							)),
-							TypeId::UNDEFINED_TYPE,
-						)
+						(PropertyKey::from_usize(idx), TypeId::UNDEFINED_TYPE)
 					}
 				}
 			}
@@ -133,9 +133,9 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 				let (key, value) = synthesise_array_item(idx, value, environment, checking_data);
 				basis.append(
 					environment,
-					key,
-					crate::types::properties::Property::Value(value),
 					PublicityKind::Public,
+					key,
+					crate::types::properties::PropertyValue::Value(value),
 					Some(spread_expression_position),
 				);
 			}
@@ -146,20 +146,20 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 			// TODO: Should there be a position here?
 			basis.append(
 				environment,
-				TypeId::LENGTH_AS_STRING,
-				crate::types::properties::Property::Value(len),
 				PublicityKind::Public,
+				PropertyKey::String("length".into()),
+				crate::types::properties::PropertyValue::Value(len),
 				None,
 			);
 
 			Instance::RValue(basis.build_object())
 		}
-		Expression::ObjectLiteral(object_literal) => {
-			let synthesise_object_literal =
-				synthesise_object_literal(object_literal, checking_data, environment);
-
-			Instance::RValue(synthesise_object_literal)
-		}
+		Expression::ObjectLiteral(object_literal) => Instance::RValue(synthesise_object_literal(
+			object_literal,
+			checking_data,
+			environment,
+			expecting,
+		)),
 		Expression::TemplateLiteral(TemplateLiteral { tag, parts, position }) => {
 			let mut parts_iter = parts.iter().map(|part| match part {
 				parser::expressions::TemplateLiteralPart::Static(value) => {
@@ -169,13 +169,20 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 					crate::behavior::template_literal::TemplateLiteralPart::Dynamic(&**expr)
 				}
 			});
-			let tag =
-				tag.as_ref().map(|expr| synthesise_expression(expr, environment, checking_data));
+			let tag = tag.as_ref().map(|expr| {
+				synthesise_expression(expr, environment, checking_data, TypeId::ANY_TYPE)
+			});
 
-			synthesise_template_literal(tag, parts_iter, environment, checking_data)
+			Instance::RValue(synthesise_template_literal(
+				tag,
+				parts_iter,
+				position,
+				environment,
+				checking_data,
+			))
 		}
 		Expression::BinaryOperation { lhs, operator, rhs, .. } => {
-			let lhs_ty = synthesise_expression(&*lhs, environment, checking_data);
+			let lhs_ty = synthesise_expression(&*lhs, environment, checking_data, TypeId::ANY_TYPE);
 
 			if let BinaryOperator::LogicalAnd
 			| BinaryOperator::LogicalOr
@@ -199,7 +206,7 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 				.unwrap();
 			}
 
-			let rhs_ty = synthesise_expression(&*rhs, environment, checking_data);
+			let rhs_ty = synthesise_expression(&*rhs, environment, checking_data, TypeId::ANY_TYPE);
 
 			if lhs_ty == TypeId::ERROR_TYPE || rhs_ty == TypeId::ERROR_TYPE {
 				return TypeId::ERROR_TYPE;
@@ -259,7 +266,12 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 					todo!("cast to number")
 				}
 				UnaryOperator::Negation | UnaryOperator::BitwiseNot | UnaryOperator::LogicalNot => {
-					let operand_type = synthesise_expression(&*operand, environment, checking_data);
+					let operand_type = synthesise_expression(
+						&*operand,
+						environment,
+						checking_data,
+						TypeId::ANY_TYPE,
+					);
 					let operator = match operator {
 						UnaryOperator::Negation => PureUnary::Negation,
 						UnaryOperator::BitwiseNot => PureUnary::BitwiseNot,
@@ -278,8 +290,12 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 				UnaryOperator::Await => todo!(),
 				UnaryOperator::TypeOf => todo!(),
 				UnaryOperator::Void => {
-					let _operand_type =
-						synthesise_expression(&*operand, environment, checking_data);
+					let _operand_type = synthesise_expression(
+						&*operand,
+						environment,
+						checking_data,
+						TypeId::ANY_TYPE,
+					);
 					return TypeId::UNDEFINED_TYPE;
 				}
 				UnaryOperator::Delete => {
@@ -287,21 +303,52 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 					// TODO more expressions
 					match &**operand {
 						Expression::PropertyAccess { parent, property, is_optional, position } => {
-							let on = synthesise_expression(parent, environment, checking_data);
+							let on = synthesise_expression(
+								parent,
+								environment,
+								checking_data,
+								TypeId::ANY_TYPE,
+							);
 							match property {
-								parser::PropertyReference::Standard { property, is_private: _ } => {
-									let property = checking_data
-										.types
-										.new_constant_type(Constant::String(property.clone()));
-									let result = environment.remove_property(on, property);
+								parser::PropertyReference::Standard {
+									property,
+									is_private: _is_private,
+								} => {
+									let result = environment.delete_property(
+										on,
+										PropertyKey::String(Cow::Owned(property.clone())),
+									);
 									return if result { TypeId::TRUE } else { TypeId::FALSE };
 								}
 								parser::PropertyReference::Cursor(_) => todo!(),
 							}
 						}
+						Expression::Index { indexee, indexer, is_optional, position } => {
+							let indexee = synthesise_expression(
+								indexee,
+								environment,
+								checking_data,
+								TypeId::ANY_TYPE,
+							);
+							let indexer = synthesise_multiple_expression(
+								indexer,
+								environment,
+								checking_data,
+								TypeId::ANY_TYPE,
+							);
+
+							let property = PropertyKey::from_type(indexer, &checking_data.types);
+							let result = environment.delete_property(indexee, property);
+							return if result { TypeId::TRUE } else { TypeId::FALSE };
+						}
 						_ => {
-							let _operand_type =
-								synthesise_expression(&*operand, environment, checking_data);
+							crate::utils::notify!("Deleting non property raise warning");
+							let _operand_type = synthesise_expression(
+								&*operand,
+								environment,
+								checking_data,
+								TypeId::ANY_TYPE,
+							);
 							return TypeId::FALSE;
 						}
 					}
@@ -407,7 +454,7 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 			}
 		}
 		Expression::VariableReference(name, position) => {
-			let get_variable_or_alternatives = environment.get_variable_or_error(
+			let get_variable_or_alternatives = environment.get_variable_handle_error(
 				name.as_str(),
 				position.clone().with_source(environment.get_source()),
 				checking_data,
@@ -419,10 +466,10 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 			}
 		}
 		Expression::PropertyAccess { parent, position, property, .. } => {
-			let on = synthesise_expression(parent, environment, checking_data);
+			let on = synthesise_expression(parent, environment, checking_data, TypeId::ANY_TYPE);
 			let property =
 				if let parser::PropertyReference::Standard { property, is_private: _ } = property {
-					checking_data.types.new_constant_type(Constant::String(property.clone()))
+					PropertyKey::String(Cow::Borrowed(property.as_str()))
 				} else {
 					todo!()
 				};
@@ -431,58 +478,54 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 			// TODO
 			let publicity = PublicityKind::Public;
 
-			let get_property = environment.get_property(
+			let result = environment.get_property_handle_errors(
 				on,
-				property,
 				publicity,
-				&mut checking_data.types,
-				None,
+				property,
+				checking_data,
 				access_position,
 			);
 
-			match get_property {
-				Some((kind, result)) => match kind {
-					PropertyKind::Getter => Instance::GValue(result),
-					// TODO instance.property...?
-					PropertyKind::Generic | PropertyKind::Direct => Instance::RValue(result),
-				},
-				None => {
-					// TODO could do a positional reference to the variable...?
-					checking_data.diagnostics_container.add_error(
-						TypeCheckError::PropertyDoesNotExist {
-							property: TypeStringRepresentation::from_type_id(
-								property,
-								&environment.as_general_context(),
-								&checking_data.types,
-								checking_data.options.debug_types,
-							),
-							on: TypeStringRepresentation::from_type_id(
-								on,
-								&environment.as_general_context(),
-								&checking_data.types,
-								checking_data.options.debug_types,
-							),
-							site: position.clone().with_source(environment.get_source()),
-						},
-					);
-
-					return TypeId::ERROR_TYPE;
-				}
+			match result {
+				Ok(instance) => instance,
+				Err(_) => return TypeId::ERROR_TYPE,
 			}
 		}
-		Expression::ThisReference(..) => {
-			let position = SynthesisableExpression::get_position(expression)
-				.clone()
-				.with_source(environment.get_source());
+		Expression::Index { indexee, indexer, position, .. } => {
+			let indexee =
+				synthesise_expression(indexee, environment, checking_data, TypeId::ANY_TYPE);
+			let indexer = synthesise_multiple_expression(
+				indexer,
+				environment,
+				checking_data,
+				TypeId::ANY_TYPE,
+			);
+
+			let index_position = position.clone().with_source(environment.get_source());
+			// TODO handle differently?
+			let result = environment.get_property_handle_errors(
+				indexee,
+				PublicityKind::Public,
+				PropertyKey::from_type(indexer, &checking_data.types),
+				checking_data,
+				index_position,
+			);
+
+			match result {
+				Ok(instance) => instance,
+				Err(_) => return TypeId::ERROR_TYPE,
+			}
+		}
+		Expression::ThisReference(pos) => {
+			let position = pos.clone().with_source(environment.get_source());
 			Instance::RValue(environment.get_value_of_this(&mut checking_data.types, position))
 		}
 		Expression::SuperExpression(reference, position) => match reference {
 			SuperReference::Call { arguments } => {
-				let constructor =
-					environment.get_current_constructor().expect("not in constructor");
-
 				todo!();
 
+				// let constructor =
+				// 	environment.get_current_constructor().expect("not in constructor");
 				// let crate::ConstructorInformation {
 				// 	fields,
 				// 	class_constructor_ty,
@@ -534,7 +577,8 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 		},
 		Expression::NewTarget(..) => todo!(),
 		Expression::FunctionCall { function, type_arguments, arguments, position, .. } => {
-			let on = synthesise_expression(&*function, environment, checking_data);
+			let on =
+				synthesise_expression(&*function, environment, checking_data, TypeId::ANY_TYPE);
 
 			let (result, special) = call_function(
 				on,
@@ -551,8 +595,9 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 			Instance::RValue(result)
 		}
 		Expression::ConstructorCall { constructor, type_arguments, arguments, position } => {
-			let on = synthesise_expression(&*constructor, environment, checking_data);
-			let called_with_new = CalledWithNew::New { import_new: on };
+			let on =
+				synthesise_expression(&*constructor, environment, checking_data, TypeId::ANY_TYPE);
+			let called_with_new = CalledWithNew::New { on };
 			let (result, _) = call_function(
 				on,
 				called_with_new,
@@ -564,87 +609,61 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 			);
 			Instance::RValue(result)
 		}
-		Expression::Index { indexee, indexer, position, .. } => {
-			let indexee = synthesise_expression(indexee, environment, checking_data);
-			let indexer = synthesise_multiple_expression(indexer, environment, checking_data);
-
-			let index_position = position.clone().with_source(environment.get_source());
-			let get_property = environment.get_property(
-				indexee,
-				indexer,
-				PublicityKind::Public,
-				&mut checking_data.types,
-				None,
-				index_position,
-			);
-
-			match get_property {
-				Some((kind, result)) => match kind {
-					PropertyKind::Getter => Instance::GValue(result),
-					// TODO instance.property...?
-					PropertyKind::Generic | PropertyKind::Direct => Instance::RValue(result),
-				},
-				None => {
-					// TODO could do a positional reference to the variable...?
-					checking_data.diagnostics_container.add_error(
-						TypeCheckError::PropertyDoesNotExist {
-							property: TypeStringRepresentation::from_type_id(
-								indexer,
-								&environment.as_general_context(),
-								&checking_data.types,
-								checking_data.options.debug_types,
-							),
-							on: TypeStringRepresentation::from_type_id(
-								indexee,
-								&environment.as_general_context(),
-								&checking_data.types,
-								checking_data.options.debug_types,
-							),
-							site: position.clone().with_source(environment.get_source()),
-						},
-					);
-
-					return TypeId::ERROR_TYPE;
-				}
-			}
-		}
 		Expression::ConditionalTernaryExpression {
 			condition, truthy_result, falsy_result, ..
 		} => {
-			let condition = synthesise_expression(condition, environment, checking_data);
+			let condition =
+				synthesise_expression(condition, environment, checking_data, TypeId::ANY_TYPE);
 
 			Instance::RValue(environment.new_conditional_context(
 				condition,
 				|env: &mut Environment, data: &mut CheckingData<T, EznoParser>| {
-					synthesise_expression(&truthy_result, env, data)
+					synthesise_expression(&truthy_result, env, data, expecting)
 				},
 				Some(|env: &mut Environment, data: &mut CheckingData<T, EznoParser>| {
-					synthesise_expression(&falsy_result, env, data)
+					synthesise_expression(&falsy_result, env, data, expecting)
 				}),
 				checking_data,
 			))
 		}
-		Expression::ExpressionFunction(function) => {
-			Instance::RValue(environment.new_function(checking_data, function, RegisterAsType))
-		}
-		Expression::ArrowFunction(arrow_function) => Instance::RValue(environment.new_function(
+		Expression::ArrowFunction(function) => Instance::RValue(register_arrow_function(
+			expecting,
+			function.header.is_some(),
+			function,
+			environment,
 			checking_data,
-			arrow_function,
-			RegisterAsType,
 		)),
+		Expression::ExpressionFunction(function) => {
+			let is_async = function.header.is_async();
+			let is_generator = function.header.is_generator();
+			let location = function.header.get_location().map(|location| match location {
+				parser::functions::FunctionLocationModifier::Server(_) => "server".to_owned(),
+				parser::functions::FunctionLocationModifier::Module(_) => "module".to_owned(),
+			});
+			Instance::RValue(register_expression_function(
+				expecting,
+				is_async,
+				is_generator,
+				location,
+				function,
+				environment,
+				checking_data,
+			))
+		}
+
 		Expression::Null(_) => return TypeId::NULL_TYPE,
 		Expression::JSXRoot(jsx_root) => {
 			Instance::RValue(synthesise_jsx_root(jsx_root, environment, checking_data))
 		}
 		Expression::PostfixComment(expression, _comment, _)
 		| Expression::PrefixComment(_comment, expression, _) => {
-			Instance::RValue(synthesise_expression(expression, environment, checking_data))
+			return synthesise_expression(expression, environment, checking_data, expecting)
 		}
 		Expression::ParenthesizedExpression(inner_expression, _) => Instance::RValue(
-			synthesise_multiple_expression(inner_expression, environment, checking_data),
+			synthesise_multiple_expression(inner_expression, environment, checking_data, expecting),
 		),
-		Expression::ClassExpression(_) => {
-			todo!()
+		Expression::ClassExpression(class) => {
+			Instance::RValue(synthesise_class_declaration(class, environment, checking_data))
 		}
 		Expression::Cursor { cursor_id, position } => todo!(),
 		Expression::SpecialOperators(operator, position) => match operator {
@@ -655,11 +674,11 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 					),
 				);
 
-				return synthesise_expression(value, environment, checking_data);
+				return synthesise_expression(value, environment, checking_data, expecting);
 			}
 			SpecialOperators::IsExpression { value, is_keyword, type_annotation } => todo!(),
 			SpecialOperators::SatisfiesExpression { value, type_annotation, .. } => {
-				let value = synthesise_expression(value, environment, checking_data);
+				let value = synthesise_expression(value, environment, checking_data, expecting);
 				let satisfying =
 					synthesise_type_annotation(type_annotation, environment, checking_data);
 
@@ -672,10 +691,28 @@ pub(super) fn synthesise_expression<T: crate::ReadFromFS>(
 
 				return value;
 			}
-			SpecialOperators::InExpression { .. } => todo!(),
+			SpecialOperators::InExpression { lhs, rhs } => {
+				let lhs = match lhs {
+					parser::expressions::InExpressionLHS::PrivateProperty(_) => todo!(),
+					parser::expressions::InExpressionLHS::Expression(lhs) => {
+						synthesise_expression(lhs, environment, checking_data, TypeId::ANY_TYPE)
+					}
+				};
+				let rhs = synthesise_expression(rhs, environment, checking_data, TypeId::ANY_TYPE);
+				let result =
+					environment.property_in(rhs, PropertyKey::from_type(lhs, &checking_data.types));
+
+				Instance::RValue(if result { TypeId::TRUE } else { TypeId::FALSE })
+			}
 			SpecialOperators::InstanceOfExpression { .. } => todo!(),
 		},
-		Expression::DynamicImport { .. } => todo!(),
+		Expression::DynamicImport { position, .. } => {
+			checking_data.raise_unimplemented_error(
+				"dynamic import",
+				position.clone().with_source(environment.get_source()),
+			);
+			return TypeId::ERROR_TYPE;
+		}
 		Expression::IsExpression(is_expr) => {
 			Instance::RValue(synthesise_is_expression(is_expr, environment, checking_data))
 		}
@@ -796,6 +833,7 @@ fn call_function<T: crate::ReadFromFS>(
 	)
 }
 
+/// TODO do lazily
 fn synthesise_arguments<T: crate::ReadFromFS>(
 	arguments: &Vec<SpreadExpression>,
 	environment: &mut Environment,
@@ -823,7 +861,8 @@ fn synthesise_arguments<T: crate::ReadFromFS>(
 				// ) {
 				// 	crate::utils::notify!("TODO absolute function here");
 				// }
-				let ty = synthesise_expression(expr, environment, checking_data);
+				// TODO expecting here
+				let ty = synthesise_expression(expr, environment, checking_data, TypeId::ANY_TYPE);
 				Some(SynthesisedArgument::NonSpread {
 					ty,
 					position: ASTNode::get_position(expr)
@@ -836,39 +875,11 @@ fn synthesise_arguments<T: crate::ReadFromFS>(
 		.collect::<Vec<SynthesisedArgument>>()
 }
 
-pub(super) fn synthesise_class_fields<T: crate::ReadFromFS>(
-	fields: Vec<(TypeId, PublicityKind, Expression)>,
-	environment: &mut Environment,
-	checking_data: &mut CheckingData<T, super::EznoParser>,
-) {
-	todo!("get event position");
-	// TODO: Needs clarification. This only passes the position of the first field. Should we pass all fields positions?
-	// TODO: Placeholder. This placeholder implementation retrieves the position of the first field in order to satisfy the compiler
-	let fields_position = SynthesisableExpression::get_position(&fields[0].2)
-		.clone()
-		.with_source(environment.get_source());
-
-	let this = environment.get_value_of_this(&mut checking_data.types, fields_position);
-	for (under, publicity, mut expression) in fields {
-		let new = synthesise_expression(&expression, environment, checking_data);
-		environment.facts.events.push(Event::Setter {
-			on: this,
-			new: crate::types::properties::Property::Value(new),
-			under,
-			reflects_dependency: None,
-			initialization: true,
-			publicity,
-			position: Some(fields_position),
-		});
-		todo!()
-		// environment.new_property(this, under, new, false);
-	}
-}
-
 pub(super) fn synthesise_object_literal<T: crate::ReadFromFS>(
 	ObjectLiteral { members, .. }: &ObjectLiteral,
 	checking_data: &mut CheckingData<T, super::EznoParser>,
 	environment: &mut Environment,
+	expected: TypeId,
 ) -> TypeId {
 	let mut object_builder =
 		ObjectBuilder::new(None, &mut checking_data.types, &mut environment.facts);
@@ -883,8 +894,8 @@ pub(super) fn synthesise_object_literal<T: crate::ReadFromFS>(
 				);
 			}
 			ObjectLiteralMember::Shorthand(name, position) => {
-				let key = checking_data.types.new_constant_type(Constant::String(name.clone()));
-				let get_variable = environment.get_variable_or_error(
+				let key = PropertyKey::String(Cow::Owned(name.clone()));
+				let get_variable = environment.get_variable_handle_error(
 					name,
 					position.clone().with_source(environment.get_source()),
 					checking_data,
@@ -905,23 +916,30 @@ pub(super) fn synthesise_object_literal<T: crate::ReadFromFS>(
 
 				object_builder.append(
 					environment,
-					key,
-					crate::types::properties::Property::Value(value),
 					PublicityKind::Public,
+					key,
+					crate::types::properties::PropertyValue::Value(value),
 					Some(member_position),
 				);
 			}
 			ObjectLiteralMember::Property(key, expression, _) => {
-				let key =
-					property_key_as_type(key.get_ast_ref(), environment, &mut checking_data.types);
+				let key = parser_property_key_to_checker_property_key(
+					key.get_ast_ref(),
+					environment,
+					checking_data,
+				);
 
-				let value = synthesise_expression(expression, environment, checking_data);
-				let value = crate::types::properties::Property::Value(value);
+				// TODO base of above
+				let expecting = TypeId::ANY_TYPE;
+				let value =
+					synthesise_expression(expression, environment, checking_data, expecting);
+
+				let value = crate::types::properties::PropertyValue::Value(value);
 				object_builder.append(
 					environment,
+					PublicityKind::Public,
 					key,
 					value,
-					PublicityKind::Public,
 					Some(member_position),
 				);
 
@@ -944,20 +962,36 @@ pub(super) fn synthesise_object_literal<T: crate::ReadFromFS>(
 				// )
 			}
 			ObjectLiteralMember::Method(method) => {
-				let key = property_key_as_type(
+				let key = parser_property_key_to_checker_property_key(
 					method.name.get_ast_ref(),
 					environment,
-					&mut checking_data.types,
+					checking_data,
 				);
 
-				let property =
-					environment.new_function(checking_data, method, RegisterOnExistingObject);
+				let behavior = crate::behavior::functions::FunctionRegisterBehavior::ObjectMethod {
+					is_async: method.header.as_ref().map(|h| h.is_async()).unwrap_or_default(),
+					is_generator: method
+						.header
+						.as_ref()
+						.map(|h| h.is_generator())
+						.unwrap_or_default(),
+				};
+
+				let function = environment.new_function(checking_data, method, behavior);
+
+				let property = match &method.header {
+					Some(MethodHeader::Get(_)) => crate::PropertyValue::Getter(Box::new(function)),
+					Some(MethodHeader::Set(_)) => crate::PropertyValue::Setter(Box::new(function)),
+					_ => {
+						crate::PropertyValue::Value(checking_data.types.new_function_type(function))
+					}
+				};
 
 				object_builder.append(
 					environment,
+					PublicityKind::Public,
 					key,
 					property,
-					PublicityKind::Public,
 					Some(member_position),
 				)
 			}

--- a/checker/src/synthesis/extensions/is_expression.rs
+++ b/checker/src/synthesis/extensions/is_expression.rs
@@ -12,8 +12,13 @@ pub(crate) fn synthesise_is_expression<T: crate::ReadFromFS>(
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, crate::synthesis::EznoParser>,
 ) -> TypeId {
-	let matcher =
-		synthesise_multiple_expression(&is_expression.matcher, environment, checking_data);
+	// TODO expecting
+	let matcher = synthesise_multiple_expression(
+		&is_expression.matcher,
+		environment,
+		checking_data,
+		TypeId::ANY_TYPE,
+	);
 
 	let mut returned = TypeId::UNDEFINED_TYPE;
 	for (condition, code) in is_expression.branches.iter() {

--- a/checker/src/synthesis/extensions/jsx.rs
+++ b/checker/src/synthesis/extensions/jsx.rs
@@ -51,7 +51,7 @@ pub(crate) fn synthesise_jsx_element<T: crate::ReadFromFS>(
 			attribute.get_position().clone().with_source(environment.get_source());
 		attributes_object.append(
 			environment,
-			crate::context::facts::PublicityKind::Public,
+			crate::context::facts::Publicity::Public,
 			name,
 			crate::PropertyValue::Value(attribute_value),
 			Some(attribute_position),
@@ -147,7 +147,7 @@ pub(crate) fn synthesise_jsx_element<T: crate::ReadFromFS>(
 			let child = synthesise_jsx_child(child, environment, checking_data);
 			synthesised_child_nodes.append(
 				environment,
-				crate::context::facts::PublicityKind::Public,
+				crate::context::facts::Publicity::Public,
 				property,
 				crate::PropertyValue::Value(child),
 				Some(child_position),

--- a/checker/src/synthesis/extensions/jsx.rs
+++ b/checker/src/synthesis/extensions/jsx.rs
@@ -416,7 +416,11 @@ fn synthesise_attribute<T: crate::ReadFromFS>(
 			(name, checking_data.types.new_constant_type(crate::Constant::String(value.clone())))
 		}
 		JSXAttribute::Dynamic(name, expression, attribute_id) => {
-			// Do not care about the returned value at this point, just for synthesizing the type into the map
+			if let Expression::ExpressionFunction(_) = &**expression {
+				// TODO temp context
+				environment.context_type.context = Some("client".to_owned());
+			}
+			// Do not care about the returned value at this point, just for synthesising the type into the map
 			(name, synthesise_expression(expression, environment, checking_data))
 		}
 		JSXAttribute::BooleanAttribute(name, _) => (name, TypeId::TRUE),

--- a/checker/src/synthesis/functions.rs
+++ b/checker/src/synthesis/functions.rs
@@ -1,6 +1,6 @@
 //! Function tings. Contains parameter synthesis, function body synthesis
 
-use std::mem;
+use std::{env, mem};
 
 use parser::{
 	expressions::ExpressionOrBlock, ASTNode, Block, FunctionBase, FunctionBased,
@@ -10,13 +10,13 @@ use parser::{
 use source_map::{SourceId, Span, SpanWithSource};
 
 use crate::{
-	behavior::functions::{MethodKind, SynthesisableFunction},
-	context::{CanUseThis, Context, ContextType, Scope},
+	behavior::functions::{FunctionBehavior, SynthesisableFunction},
+	context::{CanReferenceThis, Context, ContextType, Scope},
 	types::poly_types::GenericTypeParameters,
 	types::{
 		functions::{SynthesisedParameter, SynthesisedParameters, SynthesisedRestParameter},
 		poly_types::generic_type_arguments::TypeArgumentStore,
-		FunctionKind, FunctionType, StructureGenerics,
+		FunctionType, StructureGenerics,
 	},
 	types::{Constructor, Type, TypeId},
 	CheckingData, Environment, FunctionId,
@@ -30,7 +30,7 @@ use super::{
 trait FunctionBasedItem: FunctionBased {
 	type ObjectTypeId;
 
-	fn get_kind(func: &FunctionBase<Self>) -> MethodKind;
+	// fn get_function_kind(func: &FunctionBase<Self>) -> FunctionKind;
 
 	fn location(func: &FunctionBase<Self>) -> Option<String> {
 		None
@@ -41,25 +41,23 @@ trait FunctionBasedItem: FunctionBased {
 impl FunctionBasedItem for parser::functions::bases::StatementFunctionBase {
 	type ObjectTypeId = ();
 
-	fn get_kind(func: &FunctionBase<Self>) -> MethodKind {
-		match (func.header.is_async(), func.header.is_generator()) {
-			(is_async, true) => MethodKind::Generator { is_async },
-			(true, false) => MethodKind::Async,
-			(false, false) => MethodKind::Plain,
-		}
-	}
+	// fn get_function_kind(func: &FunctionBase<Self>) -> FunctionKind {
+	// 	FunctionKind::StatementFunction {
+	// 		is_async: func.header.is_async(),
+	// 		generator: func.header.is_generator(),
+	// 	}
+	// }
 }
 
 impl FunctionBasedItem for parser::functions::bases::ExpressionFunctionBase {
 	type ObjectTypeId = ();
 
-	fn get_kind(func: &FunctionBase<Self>) -> MethodKind {
-		match (func.header.is_async(), func.header.is_generator()) {
-			(is_async, true) => MethodKind::Generator { is_async },
-			(true, false) => MethodKind::Async,
-			(false, false) => MethodKind::Plain,
-		}
-	}
+	// fn get_function_kind(func: &FunctionBase<Self>) -> FunctionKind {
+	// 	FunctionKind::StatementFunction {
+	// 		is_async: func.header.is_async(),
+	// 		generator: func.header.is_generator(),
+	// 	}
+	// }
 
 	fn location(func: &FunctionBase<Self>) -> Option<String> {
 		match &func.header {
@@ -86,53 +84,34 @@ impl FunctionBasedItem for parser::functions::bases::ExpressionFunctionBase {
 impl FunctionBasedItem for parser::functions::bases::ArrowFunctionBase {
 	type ObjectTypeId = ();
 
-	fn get_kind(func: &FunctionBase<Self>) -> MethodKind {
-		let is_async = func.header.is_some();
-		if is_async {
-			MethodKind::Async
-		} else {
-			MethodKind::Plain
-		}
-	}
-}
-
-// TODO don't use From
-impl<'a> From<&'a Option<parser::MethodHeader>> for MethodKind {
-	fn from(value: &'a Option<parser::MethodHeader>) -> Self {
-		match value {
-			Some(parser::MethodHeader::Get(_)) => MethodKind::Get,
-			Some(parser::MethodHeader::Set(_)) => MethodKind::Set,
-			Some(
-				parser::MethodHeader::Generator(a, _) | parser::MethodHeader::GeneratorStar(a, _),
-			) => MethodKind::Generator { is_async: a.is_some() },
-			Some(parser::MethodHeader::Async(_)) => MethodKind::Async,
-			None => MethodKind::Plain,
-		}
-	}
+	// fn get_function_kind(func: &FunctionBase<Self>) -> FunctionKind {
+	// 	let is_async = func.header.is_some();
+	// 	FunctionKind::ArrowFunction { is_async }
+	// }
 }
 
 impl FunctionBasedItem for parser::functions::bases::ObjectLiteralMethodBase {
 	type ObjectTypeId = Option<TypeId>;
 
-	fn get_kind(func: &FunctionBase<Self>) -> MethodKind {
-		From::from(&func.header)
-	}
+	// fn get_function_kind(func: &FunctionBase<Self>) -> FunctionKind {
+	// 	FunctionKind::Method(From::from(&func.header))
+	// }
 }
 
 impl FunctionBasedItem for parser::functions::bases::ClassFunctionBase {
 	type ObjectTypeId = Option<TypeId>;
 
-	fn get_kind(func: &FunctionBase<Self>) -> MethodKind {
-		From::from(&func.header)
-	}
+	// fn get_function_kind(func: &FunctionBase<Self>) -> FunctionKind {
+	// 	FunctionKind::Method(From::from(&func.header))
+	// }
 }
 
 impl FunctionBasedItem for parser::functions::bases::ClassConstructorBase {
 	type ObjectTypeId = Option<TypeId>;
 
-	fn get_kind(func: &FunctionBase<Self>) -> MethodKind {
-		MethodKind::Plain
-	}
+	// fn get_function_kind(func: &FunctionBase<Self>) -> FunctionKind {
+	// 	FunctionKind::ClassConstructor
+	// }
 }
 
 impl<U: FunctionBased + 'static> SynthesisableFunction<super::EznoParser>
@@ -141,8 +120,12 @@ where
 	U: FunctionBasedItem,
 	U::Body: SynthesisableFunctionBody,
 {
-	fn is_declare(&self) -> bool {
-		false
+	fn id(&self, source_id: SourceId) -> FunctionId {
+		FunctionId(source_id, self.get_position().start)
+	}
+
+	fn has_body(&self) -> bool {
+		true
 	}
 
 	fn type_parameters<T: crate::ReadFromFS>(
@@ -155,33 +138,38 @@ where
 			.map(|ty_params| synthesise_type_parameters(&ty_params, environment, checking_data))
 	}
 
-	fn id(&self, source_id: SourceId) -> FunctionId {
-		FunctionId(source_id, self.get_position().start)
-	}
-
 	fn this_constraint<T: crate::ReadFromFS>(
 		&self,
 		environment: &mut Environment,
 		checking_data: &mut CheckingData<T, super::EznoParser>,
 	) -> Option<TypeId> {
-		// TODO
-		None
+		if let Some((ref annotation, _)) = self.parameters.this_type {
+			crate::utils::notify!("Synthesising this restriction");
+			Some(synthesise_type_annotation(annotation, environment, checking_data))
+		} else {
+			None
+		}
+	}
+
+	fn super_constraint<T: crate::ReadFromFS>(
+		&self,
+		environment: &mut Environment,
+		checking_data: &mut CheckingData<T, super::EznoParser>,
+	) -> Option<TypeId> {
+		if let Some((ref annotation, _)) = self.parameters.super_type {
+			Some(synthesise_type_annotation(annotation, environment, checking_data))
+		} else {
+			None
+		}
 	}
 
 	fn parameters<T: crate::ReadFromFS>(
 		&self,
 		environment: &mut Environment,
 		checking_data: &mut CheckingData<T, super::EznoParser>,
+		expected_parameters: Option<SynthesisedParameters>,
 	) -> SynthesisedParameters {
 		synthesise_function_parameters(&self.parameters, environment, checking_data)
-	}
-
-	fn body<T: crate::ReadFromFS>(
-		&self,
-		environment: &mut Environment,
-		checking_data: &mut CheckingData<T, super::EznoParser>,
-	) {
-		self.body.synthesise_function_body(environment, checking_data)
 	}
 
 	fn return_type_annotation<T: crate::ReadFromFS>(
@@ -197,12 +185,12 @@ where
 		})
 	}
 
-	fn get_kind(&self) -> MethodKind {
-		U::get_kind(self)
-	}
-
-	fn location(&self) -> Option<String> {
-		U::location(self)
+	fn body<T: crate::ReadFromFS>(
+		&self,
+		environment: &mut Environment,
+		checking_data: &mut CheckingData<T, super::EznoParser>,
+	) {
+		self.body.synthesise_function_body(environment, checking_data)
 	}
 }
 
@@ -234,7 +222,9 @@ impl SynthesisableFunctionBody for ExpressionOrBlock {
 	) {
 		match self {
 			ExpressionOrBlock::Expression(expression) => {
-				let returned = synthesise_expression(expression, environment, checking_data);
+				// TODO expecting
+				let returned =
+					synthesise_expression(expression, environment, checking_data, TypeId::ANY_TYPE);
 				let position =
 					expression.get_position().clone().with_source(environment.get_source());
 				environment.return_value(returned, position);
@@ -288,7 +278,7 @@ pub(crate) fn synthesise_type_parameters<T: crate::ReadFromFS>(
 /// Expected parameter types will be in the same order as the parameters
 ///
 /// TODO reduce with other
-pub(super) fn type_function_parameters_from_reference<T: crate::ReadFromFS>(
+pub(super) fn synthesise_type_annotation_function_parameters<T: crate::ReadFromFS>(
 	reference_parameters: &parser::type_annotations::TypeAnnotationFunctionParameters,
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, super::EznoParser>,
@@ -452,10 +442,12 @@ fn get_parameter_name<T: parser::VariableFieldKind>(
 	}
 }
 
-/// This synthesises is for function types, references and interfaces.
+/// This synthesise is for function types, references and interfaces.
 ///
 /// TODO should always take effect annotations (right?)
-pub(super) fn type_function_reference<T: crate::ReadFromFS, S: ContextType>(
+///
+/// TODO abstract
+pub(super) fn synthesise_function_annotation<T: crate::ReadFromFS, S: ContextType>(
 	type_parameters: &Option<Vec<GenericTypeConstraint>>,
 	parameters: &parser::type_annotations::TypeAnnotationFunctionParameters,
 	// This Option rather than Option because function type references are always some
@@ -464,57 +456,128 @@ pub(super) fn type_function_reference<T: crate::ReadFromFS, S: ContextType>(
 	checking_data: &mut CheckingData<T, super::EznoParser>,
 	performs: super::Performs,
 	position: source_map::SpanWithSource,
-	kind: FunctionKind,
+	mut behavior: FunctionBehavior,
 	on_interface: Option<TypeId>,
 ) -> FunctionType {
+	// TODO don't have to create new environment if no generic type parameters or performs body
 	environment
 		.new_lexical_environment_fold_into_parent(
-			Scope::FunctionReference {},
+			Scope::FunctionAnnotation {},
 			checking_data,
 			|environment, checking_data| {
-				let type_parameters: Option<GenericTypeParameters> = if let Some(type_parameters) =
-					type_parameters
-				{
-					Some(synthesise_type_parameters(type_parameters, environment, checking_data))
-				} else {
-					None
-				};
-
-				let parameters =
-					type_function_parameters_from_reference(parameters, environment, checking_data);
-
-				let return_type = return_type
-					.as_ref()
-					.map(|reference| {
-						synthesise_type_annotation(reference, environment, checking_data)
-					})
-					.unwrap_or(TypeId::UNDEFINED_TYPE);
-
-				let (effects, constant_id) = match performs {
+				match performs {
 					Performs::Block(block) => {
-						environment.can_use_this = CanUseThis::Yeah {
-							// TODO use local this
-							this_ty: on_interface.unwrap_or(TypeId::ANY_TYPE),
+						let new_scope = if let Some(on_interface) = on_interface {
+							let free_this_type = checking_data.types.register_type(
+								Type::RootPolyType(crate::types::PolyNature::FreeVariable {
+									reference: crate::events::RootReference::This,
+									based_on: on_interface,
+								}),
+							);
+							if let FunctionBehavior::Method { ref mut free_this_id, .. } = behavior
+							{
+								*free_this_id = free_this_type;
+							} else {
+								unreachable!()
+							}
+							crate::context::environment::FunctionScope::MethodFunction {
+								free_this_type,
+								is_async: true,
+								is_generator: true,
+							}
+						} else {
+							crate::context::environment::FunctionScope::ArrowFunction {
+								free_this_type: TypeId::ERROR_TYPE,
+								is_async: true,
+							}
 						};
-						// TODO new environment ?
-						synthesise_block(&block.0, environment, checking_data);
-						(mem::take(&mut environment.facts.events), None)
-					}
-					Performs::Const(id) => (Default::default(), Some(id)),
-					Performs::None => (Default::default(), Default::default()),
-				};
+						let mut env =
+							environment.new_lexical_environment(Scope::Function(new_scope));
 
-				FunctionType {
-					// TODO
-					id: FunctionId(position.source, position.start),
-					parameters,
-					return_type,
-					type_parameters,
-					effects,
-					free_variables: Default::default(),
-					closed_over_variables: Default::default(),
-					kind,
-					constant_id,
+						let type_parameters: Option<GenericTypeParameters> =
+							if let Some(type_parameters) = type_parameters {
+								Some(synthesise_type_parameters(
+									type_parameters,
+									&mut env,
+									checking_data,
+								))
+							} else {
+								None
+							};
+
+						let parameters = synthesise_type_annotation_function_parameters(
+							parameters,
+							&mut env,
+							checking_data,
+						);
+
+						let return_type = return_type
+							.as_ref()
+							.map(|reference| {
+								synthesise_type_annotation(reference, &mut env, checking_data)
+							})
+							.unwrap_or(TypeId::UNDEFINED_TYPE);
+
+						env.can_reference_this = CanReferenceThis::Yeah;
+
+						synthesise_block(&block.0, &mut env, checking_data);
+
+						// TODO inject properties back
+						FunctionType {
+							// TODO
+							id: FunctionId(position.source, position.start),
+							parameters,
+							return_type,
+							type_parameters,
+							effects: env.facts.events,
+							free_variables: Default::default(),
+							closed_over_variables: Default::default(),
+							behavior,
+							constant_function: None,
+						}
+					}
+					other => {
+						let type_parameters: Option<GenericTypeParameters> =
+							if let Some(type_parameters) = type_parameters {
+								Some(synthesise_type_parameters(
+									type_parameters,
+									environment,
+									checking_data,
+								))
+							} else {
+								None
+							};
+
+						let parameters = synthesise_type_annotation_function_parameters(
+							parameters,
+							environment,
+							checking_data,
+						);
+
+						let return_type = return_type
+							.as_ref()
+							.map(|reference| {
+								synthesise_type_annotation(reference, environment, checking_data)
+							})
+							.unwrap_or(TypeId::UNDEFINED_TYPE);
+
+						FunctionType {
+							// TODO
+							id: FunctionId(position.source, position.start),
+							parameters,
+							return_type,
+							type_parameters,
+							effects: Vec::new(),
+							free_variables: Default::default(),
+							closed_over_variables: Default::default(),
+							behavior,
+							constant_function: match other {
+								Performs::Block(_) => unreachable!(),
+								Performs::Const(id) => Some(id),
+								Performs::None => None,
+							},
+						}
+					}
 				}
 			},
 		)

--- a/checker/src/synthesis/interfaces.rs
+++ b/checker/src/synthesis/interfaces.rs
@@ -6,7 +6,7 @@ use parser::{
 use crate::{
 	behavior::functions::{self, ThisValue},
 	context::{
-		facts::PublicityKind,
+		facts::Publicity,
 		Environment, {Context, ContextType},
 	},
 	synthesis::parser_property_key_to_checker_property_key,
@@ -81,17 +81,17 @@ impl SynthesiseInterfaceBehavior for OnToType {
 		let (publicity, under) = match key {
 			ParserPropertyKeyType::ClassProperty(key) => (
 				if matches!(key, parser::PropertyKey::Ident(_, _, true)) {
-					PublicityKind::Private
+					Publicity::Private
 				} else {
-					PublicityKind::Public
+					Publicity::Public
 				},
 				parser_property_key_to_checker_property_key(key, environment, checking_data),
 			),
 			ParserPropertyKeyType::ObjectProperty(key) => (
-				PublicityKind::Public,
+				Publicity::Public,
 				parser_property_key_to_checker_property_key(key, environment, checking_data),
 			),
-			ParserPropertyKeyType::Type(ty) => (PublicityKind::Public, PropertyKey::Type(ty)),
+			ParserPropertyKeyType::Type(ty) => (Publicity::Public, PropertyKey::Type(ty)),
 		};
 		let ty = match value {
 			InterfaceValue::Function(function, getter_setter) => match getter_setter {

--- a/checker/src/synthesis/interfaces.rs
+++ b/checker/src/synthesis/interfaces.rs
@@ -120,7 +120,7 @@ pub(super) fn synthesise_signatures<T: crate::ReadFromFS, B: SynthesiseInterface
 	checking_data: &mut CheckingData<T, super::EznoParser>,
 ) -> B {
 	/// TODO check members declared before
-	fn synthesize_members<T: crate::ReadFromFS, B: SynthesiseInterfaceBehavior>(
+	fn synthesise_members<T: crate::ReadFromFS, B: SynthesiseInterfaceBehavior>(
 		members: &[Decorated<InterfaceMember>],
 		environment: &mut Context<crate::context::environment::Syntax<'_>>,
 		checking_data: &mut CheckingData<T, super::EznoParser>,
@@ -190,7 +190,6 @@ pub(super) fn synthesise_signatures<T: crate::ReadFromFS, B: SynthesiseInterface
 				} => {
 					// TODO think this is okay
 					let key = synthesise_type_annotation(indexer_type, environment, checking_data);
-					crate::utils::notify!("Indexer {:?}", key);
 					let value = synthesise_type_annotation(return_type, environment, checking_data);
 					behavior.register(
 						PropertyOrType::Type(key),
@@ -250,13 +249,13 @@ pub(super) fn synthesise_signatures<T: crate::ReadFromFS, B: SynthesiseInterface
 					// TODO set constraint by modifying type
 					environment.named_types.insert(parameter.name().to_owned(), *ty);
 				}
-				synthesize_members(signatures, environment, checking_data, &mut behavior);
+				synthesise_members(signatures, environment, checking_data, &mut behavior);
 			},
 		);
 
 		behavior
 	} else {
-		synthesize_members(signatures, environment, checking_data, &mut behavior);
+		synthesise_members(signatures, environment, checking_data, &mut behavior);
 		behavior
 	}
 }

--- a/checker/src/synthesis/mod.rs
+++ b/checker/src/synthesis/mod.rs
@@ -98,6 +98,7 @@ impl crate::ASTImplementation for EznoParser {
 	type ParseOptions = parser::ParseOptions;
 	type ParseError = (parser::ParseError, SourceId);
 	type Module = parser::Module;
+	type OwnedModule = parser::Module;
 	type DefinitionFile = parser::TypeDefinitionModule;
 	type TypeAnnotation = parser::TypeAnnotation;
 	type TypeParameter = parser::GenericTypeConstraint;
@@ -162,6 +163,10 @@ impl crate::ASTImplementation for EznoParser {
 		checking_data: &mut crate::CheckingData<T, Self>,
 	) -> TypeId {
 		synthesise_type_annotation(annotation, environment, checking_data)
+	}
+
+	fn owned_module_from_module(module: Self::Module) -> Self::OwnedModule {
+		module
 	}
 }
 

--- a/checker/src/synthesis/statements.rs
+++ b/checker/src/synthesis/statements.rs
@@ -5,15 +5,17 @@ use crate::{
 	context::{ClosedOverReferencesInScope, ContextId, Scope},
 	diagnostics::TypeCheckError,
 	events::Event,
-	CheckingData, Environment, SynthesisableConditional, TypeId, VariableOrImport,
+	synthesis::EznoParser,
+	CheckingData, Environment, TypeId,
 };
 use parser::{
+	expressions::MultipleExpression,
 	statements::{ConditionalElseStatement, UnconditionalElseStatement},
-	ASTNode, BlockOrSingleStatement, Statement,
+	ASTNode, BlockOrSingleStatement, Expression, Statement,
 };
 use std::collections::HashMap;
 
-pub type ExportedItems = HashMap<String, VariableOrImport>;
+pub type ExportedItems = HashMap<String, crate::behavior::variables::VariableOrImport>;
 pub type ReturnResult = Option<TypeId>;
 
 pub(super) fn synthesise_statement<T: crate::ReadFromFS>(
@@ -74,101 +76,178 @@ pub(super) fn synthesise_statement<T: crate::ReadFromFS>(
 			environment.return_value(returned);
 		}
 		Statement::IfStatement(if_statement) => {
-			let condition =
-				synthesise_multiple_expression(&if_statement.condition, environment, checking_data);
+			fn run_condition<T: crate::ReadFromFS>(
+				current: (&MultipleExpression, &BlockOrSingleStatement),
+				others: &[(&MultipleExpression, &BlockOrSingleStatement)],
+				last: Option<&BlockOrSingleStatement>,
+				environment: &mut Environment,
+				checking_data: &mut CheckingData<T, super::EznoParser>,
+			) {
+				let condition =
+					synthesise_multiple_expression(current.0, environment, checking_data);
 
-			environment.new_conditional_context(
-				condition,
-				IfStatementBranch::Branch(&if_statement.inner),
-				if !if_statement.else_conditions.is_empty() || if_statement.trailing_else.is_some()
-				{
-					Some(IfStatementBranch::NestedConditional {
-						conditional_elses: &if_statement.else_conditions,
-						unconditional_else: if_statement.trailing_else.as_ref(),
-					})
-				} else {
-					None
-				},
-				checking_data,
-			);
-
-			/// Necessary because the parser treats it as a list rather than a tree
-			enum IfStatementBranch<'a> {
-				Branch(&'a BlockOrSingleStatement),
-				NestedConditional {
-					conditional_elses: &'a [ConditionalElseStatement],
-					unconditional_else: Option<&'a UnconditionalElseStatement>,
-				},
-			}
-
-			// TODO tidy
-			impl<'a> SynthesisableConditional<super::EznoParser> for IfStatementBranch<'a> {
-				type ExpressionResult = ();
-
-				fn synthesise_condition<T: crate::ReadFromFS>(
-					self,
-					environment: &mut Environment,
-					checking_data: &mut CheckingData<T, super::EznoParser>,
-				) -> Self::ExpressionResult {
-					match self {
-						IfStatementBranch::Branch(branch) => match branch {
-							BlockOrSingleStatement::Braced(statements) => {
-								synthesise_block(&statements.0, environment, checking_data)
-							}
-							BlockOrSingleStatement::SingleStatement(statement) => {
-								synthesise_statement(statement, environment, checking_data)
-							}
-						},
-						IfStatementBranch::NestedConditional {
-							conditional_elses,
-							unconditional_else,
-						} => {
-							if let [current, other @ ..] = conditional_elses {
-								let condition = synthesise_multiple_expression(
-									&current.condition,
-									environment,
-									checking_data,
-								);
-								environment.new_conditional_context(
-									condition,
-									IfStatementBranch::Branch(&current.inner),
-									if !other.is_empty() || unconditional_else.is_some() {
-										Some(IfStatementBranch::NestedConditional {
-											conditional_elses: other,
-											unconditional_else: unconditional_else.clone(),
-										})
-									} else {
-										None
-									},
-									checking_data,
-								);
+				environment.new_conditional_context(
+					condition,
+					|env: &mut Environment, data: &mut CheckingData<T, EznoParser>| {
+						synthesise_block_or_single_statement(&current.1, env, data)
+					},
+					if !others.is_empty() || last.is_some() {
+						Some(|env: &mut Environment, data: &mut CheckingData<T, EznoParser>| {
+							if let [current, others @ ..] = &others {
+								run_condition(*current, others, last, env, data)
 							} else {
-								match &unconditional_else.unwrap().inner {
-									BlockOrSingleStatement::Braced(statements) => {
-										synthesise_block(&statements.0, environment, checking_data)
-									}
-									BlockOrSingleStatement::SingleStatement(statement) => {
-										synthesise_statement(statement, environment, checking_data)
-									}
-								}
+								synthesise_block_or_single_statement(last.unwrap(), env, data)
 							}
-						}
-					}
-				}
-
-				fn conditional_expression_result(
-					_: TypeId,
-					_: Self::ExpressionResult,
-					_: Self::ExpressionResult,
-					_: &mut crate::types::TypeStore,
-				) -> Self::ExpressionResult {
-					()
-				}
-
-				fn default_result() -> Self::ExpressionResult {
-					()
-				}
+						})
+					} else {
+						None
+					},
+					checking_data,
+				)
 			}
+
+			let others = if_statement
+				.else_conditions
+				.iter()
+				.map(|cond| (&cond.condition, &cond.inner))
+				.collect::<Vec<_>>();
+
+			let last = if_statement.trailing_else.as_ref().map(|b| &b.inner);
+
+			run_condition(
+				(&if_statement.condition, &if_statement.inner),
+				others.as_slice(),
+				last,
+				environment,
+				checking_data,
+			)
+
+			// environment.new_conditional_context(
+			// 	condition,
+			// |environment, checking_data| ,
+			// 	if !if_statement.else_conditions.is_empty() || if_statement.trailing_else.is_some()
+			// 	{
+			// 		Some(|environment, checking_data| {
+			// 			if let [current, other @ ..] = &if_statement.else_conditions {
+			// 				let condition = synthesise_multiple_expression(
+			// 					&current.condition,
+			// 					environment,
+			// 					checking_data,
+			// 				);
+			// 				environment.new_conditional_context(
+			// 					condition,
+			// 					|environment, checking_data| {
+			// 						synthesise_block_or_single_statement(
+			// 							&current,
+			// 							environment,
+			// 							checking_data,
+			// 						)
+			// 					},
+			// 					if !other.is_empty() || unconditional_else.is_some() {
+			// 						Some(IfStatementBranch::NestedConditional {
+			// 							conditional_elses: other,
+			// 							unconditional_else: unconditional_else.clone(),
+			// 						})
+			// 					} else {
+			// 						None
+			// 					},
+			// 					checking_data,
+			// 				);
+			// 			} else {
+			// 				synthesise_block_or_single_statement(
+			// 					if_statement.trailing_else.unwrap(),
+			// 					environment,
+			// 					checking_data,
+			// 				)
+			// 			}
+			// 		})
+			// 	// Some(IfStatementBranch::NestedConditional {
+			// 	// 	conditional_elses: &if_statement.else_conditions,
+			// 	// 	unconditional_else: if_statement.trailing_else.as_ref(),
+			// 	// })
+			// 	} else {
+			// 		None
+			// 	},
+			// 	checking_data,
+			// );
+
+			// Necessary because the parser treats it as a list rather than a tree
+			// enum IfStatementBranch<'a> {
+			// 	Branch(&'a BlockOrSingleStatement),
+			// 	NestedConditional {
+			// 		conditional_elses: &'a [ConditionalElseStatement],
+			// 		unconditional_else: Option<&'a UnconditionalElseStatement>,
+			// 	},
+			// }
+
+			// // TODO tidy
+			// impl<'a> SynthesisableConditional<super::EznoParser> for IfStatementBranch<'a> {
+			// 	type ExpressionResult = ();
+
+			// 	fn synthesise_condition<T: crate::ReadFromFS>(
+			// 		self,
+			// 		environment: &mut Environment,
+			// 		checking_data: &mut CheckingData<T, super::EznoParser>,
+			// 	) -> Self::ExpressionResult {
+			// 		match self {
+			// 			IfStatementBranch::Branch(branch) => match branch {
+			// 				BlockOrSingleStatement::Braced(statements) => {
+			// 					synthesise_block(&statements.0, environment, checking_data)
+			// 				}
+			// 				BlockOrSingleStatement::SingleStatement(statement) => {
+			// 					synthesise_statement(statement, environment, checking_data)
+			// 				}
+			// 			},
+			// 			IfStatementBranch::NestedConditional {
+			// 				conditional_elses,
+			// 				unconditional_else,
+			// 			} => {
+			// 				if let [current, other @ ..] = conditional_elses {
+			// 					let condition = synthesise_multiple_expression(
+			// 						&current.condition,
+			// 						environment,
+			// 						checking_data,
+			// 					);
+			// 					environment.new_conditional_context(
+			// 						condition,
+			// 						IfStatementBranch::Branch(&current.inner),
+			// 						if !other.is_empty() || unconditional_else.is_some() {
+			// 							Some(IfStatementBranch::NestedConditional {
+			// 								conditional_elses: other,
+			// 								unconditional_else: unconditional_else.clone(),
+			// 							})
+			// 						} else {
+			// 							None
+			// 						},
+			// 						checking_data,
+			// 					);
+			// 				} else {
+			// 					match &unconditional_else.unwrap().inner {
+			// 						BlockOrSingleStatement::Braced(statements) => {
+			// 							synthesise_block(&statements.0, environment, checking_data)
+			// 						}
+			// 						BlockOrSingleStatement::SingleStatement(statement) => {
+			// 							synthesise_statement(statement, environment, checking_data)
+			// 						}
+			// 					}
+			// 				}
+			// 			}
+			// 		}
+			// 	}
+
+			// 	fn conditional_expression_result(
+			// 		_: TypeId,
+			// 		_: Self::ExpressionResult,
+			// 		_: Self::ExpressionResult,
+			// 		_: &mut crate::types::TypeStore,
+			// 	) -> Self::ExpressionResult {
+			// 		()
+			// 	}
+
+			// 	fn default_result() -> Self::ExpressionResult {
+			// 		()
+			// 	}
+			// }
 		}
 		Statement::SwitchStatement(stmt) => {
 			checking_data.diagnostics_container.add_error(TypeCheckError::Unsupported {
@@ -319,18 +398,18 @@ fn synthesise_block_or_single_statement<T: crate::ReadFromFS>(
 	block_or_single_statement: &BlockOrSingleStatement,
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, super::EznoParser>,
-	scope: Scope,
-) -> ((), Option<(Vec<Event>, ClosedOverReferencesInScope)>, ContextId) {
-	environment.new_lexical_environment_fold_into_parent(
-		scope,
-		checking_data,
-		|environment, checking_data| match block_or_single_statement {
-			BlockOrSingleStatement::Braced(block) => {
-				synthesise_block(&block.0, environment, checking_data)
-			}
-			BlockOrSingleStatement::SingleStatement(statement) => {
-				synthesise_statement(statement, environment, checking_data)
-			}
-		},
-	)
+) {
+	match block_or_single_statement {
+		BlockOrSingleStatement::Braced(block) => {
+			synthesise_block(&block.0, environment, checking_data)
+		}
+		BlockOrSingleStatement::SingleStatement(statement) => {
+			synthesise_statement(statement, environment, checking_data)
+		}
+	}
+	// environment.new_lexical_environment_fold_into_parent(
+	// 	scope,
+	// 	checking_data,
+	// 	|environment, checking_data|
+	// )
 }

--- a/checker/src/synthesis/statements.rs
+++ b/checker/src/synthesis/statements.rs
@@ -25,7 +25,12 @@ pub(super) fn synthesise_statement<T: crate::ReadFromFS>(
 ) {
 	match statement {
 		Statement::Expression(expression) => {
-			synthesise_multiple_expression(expression, environment, checking_data);
+			synthesise_multiple_expression(
+				expression,
+				environment,
+				checking_data,
+				TypeId::ANY_TYPE,
+			);
 		}
 		// Statement::ExportStatement(_export_statement) => {
 		// if let Some(out_exports) = out_exports {
@@ -69,7 +74,13 @@ pub(super) fn synthesise_statement<T: crate::ReadFromFS>(
 		// }
 		Statement::Return(return_statement) => {
 			let returned = if let Some(ref expression) = return_statement.1 {
-				synthesise_multiple_expression(expression, environment, checking_data)
+				// TODO expecting based of expected return type
+				synthesise_multiple_expression(
+					expression,
+					environment,
+					checking_data,
+					TypeId::ANY_TYPE,
+				)
 			} else {
 				TypeId::UNDEFINED_TYPE
 			};
@@ -86,8 +97,12 @@ pub(super) fn synthesise_statement<T: crate::ReadFromFS>(
 				environment: &mut Environment,
 				checking_data: &mut CheckingData<T, super::EznoParser>,
 			) {
-				let condition =
-					synthesise_multiple_expression(current.0, environment, checking_data);
+				let condition = synthesise_multiple_expression(
+					current.0,
+					environment,
+					checking_data,
+					TypeId::ANY_TYPE,
+				);
 
 				environment.new_conditional_context(
 					condition,
@@ -347,7 +362,12 @@ pub(super) fn synthesise_statement<T: crate::ReadFromFS>(
 			);
 		}
 		Statement::Throw(stmt) => {
-			let thrown_value = synthesise_multiple_expression(&stmt.1, environment, checking_data);
+			let thrown_value = synthesise_multiple_expression(
+				&stmt.1,
+				environment,
+				checking_data,
+				TypeId::ANY_TYPE,
+			);
 			let thrown_position = stmt.2.clone().with_source(environment.get_source());
 			environment.throw_value(thrown_value, thrown_position)
 		}

--- a/checker/src/synthesis/type_annotations.rs
+++ b/checker/src/synthesis/type_annotations.rs
@@ -26,7 +26,7 @@ use source_map::{SourceId, SpanWithSource};
 
 use crate::{
 	behavior::objects::ObjectBuilder,
-	context::facts::PublicityKind,
+	context::facts::Publicity,
 	diagnostics::{TypeCheckError, TypeCheckWarning},
 	subtyping::{self, type_is_subtype, BasicEquality, SubTypeResult},
 	synthesis::functions::synthesise_function_annotation,
@@ -354,7 +354,7 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 
 						obj.append(
 							environment,
-							PublicityKind::Public,
+							Publicity::Public,
 							PropertyKey::from_usize(idx),
 							PropertyValue::Value(item_ty),
 							Some(ty_position),
@@ -372,7 +372,7 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 			// TODO: Does `constant` have a position? Or should it have one?
 			obj.append(
 				environment,
-				PublicityKind::Public,
+				Publicity::Public,
 				PropertyKey::String("length".into()),
 				PropertyValue::Value(length_value),
 				None,
@@ -388,7 +388,7 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 			let indexer = synthesise_type_annotation(indexer, environment, checking_data);
 			if let Some(prop) = environment.get_property_unbound(
 				indexee,
-				PublicityKind::Public,
+				Publicity::Public,
 				crate::types::properties::PropertyKey::Type(indexer),
 				&checking_data.types,
 			) {

--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -11,21 +11,17 @@ use crate::{
 	behavior::variables::VariableMutability,
 	context::{facts::PublicityKind, Context, ContextType},
 	diagnostics::{TypeCheckError, TypeStringRepresentation},
-	synthesis::property_key_as_type,
-	types::Constant,
+	synthesis::parser_property_key_to_checker_property_key,
+	types::{printing::print_type, properties::PropertyKey, Constant},
 	CheckingData, Environment, TypeId,
 };
 
 /// For eagerly registering variables, before the statement and its RHS is actually evaluate
 ///
 /// TODO shouldn't return type, for performs...
-pub(crate) fn register_variable<
-	T: crate::ReadFromFS,
-	U: parser::VariableFieldKind,
-	V: ContextType,
->(
+pub(crate) fn register_variable<T: crate::ReadFromFS, U: parser::VariableFieldKind>(
 	name: &parser::VariableField<U>,
-	environment: &mut Context<V>,
+	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, super::EznoParser>,
 	behavior: crate::context::VariableRegisterBehavior,
 	constraint: Option<TypeId>,
@@ -85,13 +81,11 @@ pub(crate) fn register_variable<
 					}
 					ArrayDestructuringField::Name(name, _) => {
 						let property_constraint = constraint.map(|constraint| {
-							let under = checking_data
-								.types
-								.new_constant_type(Constant::Number(NotNan::from(idx as u32)));
+							let under = crate::types::properties::PropertyKey::from_usize(idx);
 							let property_constraint = environment.get_property_unbound(
 								constraint,
-								under,
 								PublicityKind::Public,
+								under.clone(),
 								&checking_data.types,
 							);
 							match property_constraint {
@@ -99,12 +93,10 @@ pub(crate) fn register_variable<
 								None => {
 									checking_data.diagnostics_container.add_error(
 										TypeCheckError::PropertyDoesNotExist {
-											property: TypeStringRepresentation::from_type_id(
-												constraint,
-												&environment.as_general_context(),
-												&checking_data.types,
-												false,
-											),
+											property: match under {
+												PropertyKey::String(s) => crate::diagnostics::PropertyRepresentation::StringKey(s.to_string()),
+												PropertyKey::Type(t) => crate::diagnostics::PropertyRepresentation::Type(print_type(t, &checking_data.types, &environment.as_general_context(), false))
+											},
 											on: TypeStringRepresentation::from_type_id(
 												constraint,
 												&environment.as_general_context(),
@@ -174,12 +166,16 @@ pub(crate) fn register_variable<
 					}
 					ObjectDestructuringField::Map { from, name, default_value, position } => {
 						let property_constraint = constraint.map(|constraint| {
-							let under =
-								property_key_as_type(from, environment, &mut checking_data.types);
+							let under = parser_property_key_to_checker_property_key(
+								from,
+								environment,
+								checking_data,
+							);
 							let property_constraint = environment.get_property_unbound(
 								constraint,
-								under,
 								PublicityKind::Public,
+								// TODO different above
+								under.clone(),
 								&checking_data.types,
 							);
 							match property_constraint {
@@ -187,12 +183,10 @@ pub(crate) fn register_variable<
 								None => {
 									checking_data.diagnostics_container.add_error(
 										TypeCheckError::PropertyDoesNotExist {
-											property: TypeStringRepresentation::from_type_id(
-												constraint,
-												&environment.as_general_context(),
-												&checking_data.types,
-												false,
-											),
+											property: match under {
+												PropertyKey::String(s) => crate::diagnostics::PropertyRepresentation::StringKey(s.to_string()),
+												PropertyKey::Type(t) => crate::diagnostics::PropertyRepresentation::Type(print_type(t, &checking_data.types, &environment.as_general_context(), false))
+											},
 											on: TypeStringRepresentation::from_type_id(
 												constraint,
 												&environment.as_general_context(),
@@ -248,7 +242,12 @@ pub(super) fn synthesise_variable_declaration_item<
 		.map(|(ty, pos)| (*ty, pos.clone()));
 
 	let value_ty = if let Some(value) = U::as_option_expr_ref(&variable_declaration.expression) {
-		let value_ty = super::expressions::synthesise_expression(value, environment, checking_data);
+		let value_ty = super::expressions::synthesise_expression(
+			value,
+			environment,
+			checking_data,
+			TypeId::ANY_TYPE,
+		);
 
 		if let Some((var_ty, ta_pos)) = var_ty_and_pos {
 			crate::behavior::variables::check_variable_initialization(
@@ -281,7 +280,8 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 			let id = crate::VariableId(environment.get_source(), get_position.start);
 			environment.register_initial_variable_declaration_value(id, value);
 			if let Some(mutability) = exported {
-				if let crate::Scope::Module { ref mut exported, .. } = environment.context_type.kind
+				if let crate::Scope::Module { ref mut exported, .. } =
+					environment.context_type.scope
 				{
 					let existing =
 						exported.named.push((name.as_str().to_owned(), (id, mutability)));
@@ -295,9 +295,7 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 				match item {
 					ArrayDestructuringField::Spread(_, _) => todo!(),
 					ArrayDestructuringField::Name(variable_field, _) => {
-						let idx = checking_data
-							.types
-							.new_constant_type(Constant::Number((idx as f64).try_into().unwrap()));
+						let idx = PropertyKey::from_usize(idx);
 
 						let field_position = variable_field
 							.get_position()
@@ -306,8 +304,8 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 
 						let value = environment.get_property(
 							value,
-							idx,
 							PublicityKind::Public,
+							idx,
 							&mut checking_data.types,
 							None,
 							field_position,
@@ -339,9 +337,9 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 						let id = crate::VariableId(environment.get_source(), get_position.start);
 
 						let key_ty = match name {
-							VariableIdentifier::Standard(name, _) => checking_data
-								.types
-								.new_constant_type(Constant::String(name.clone())),
+							VariableIdentifier::Standard(name, _) => {
+								crate::types::properties::PropertyKey::String(Cow::Borrowed(name))
+							}
 							VariableIdentifier::Cursor(..) => todo!(),
 						};
 
@@ -352,8 +350,8 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 						// TODO record information
 						let property = environment.get_property(
 							value,
-							key_ty,
 							PublicityKind::Public,
+							key_ty,
 							&mut checking_data.types,
 							None,
 							get_position_with_source,
@@ -367,6 +365,7 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 										else_expression,
 										environment,
 										checking_data,
+										TypeId::ANY_TYPE,
 									)
 								} else {
 									// TODO emit error
@@ -378,18 +377,19 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 						environment.register_initial_variable_declaration_value(id, value)
 					}
 					ObjectDestructuringField::Map { from, name, default_value, position } => {
-						let key_ty = super::property_key_as_type(
+						let key_ty = super::parser_property_key_to_checker_property_key(
 							from,
 							environment,
-							&mut checking_data.types,
+							checking_data,
 						);
 
 						// TODO if LHS = undefined ...? conditional
 						// TODO record information
 						let property_value = environment.get_property(
 							value,
-							key_ty,
 							PublicityKind::Public,
+							// TODO different above
+							key_ty,
 							&mut checking_data.types,
 							None,
 							position.clone().with_source(environment.get_source()),
@@ -400,7 +400,12 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 							None => {
 								// TODO non decidable error
 								if let Some(default_value) = default_value {
-									synthesise_expression(default_value, environment, checking_data)
+									synthesise_expression(
+										default_value,
+										environment,
+										checking_data,
+										TypeId::ANY_TYPE,
+									)
 								} else {
 									// TODO emit error
 									TypeId::ERROR_TYPE

--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -251,7 +251,7 @@ pub(super) fn synthesise_variable_declaration_item<
 		let value_ty = super::expressions::synthesise_expression(value, environment, checking_data);
 
 		if let Some((var_ty, ta_pos)) = var_ty_and_pos {
-			crate::check_variable_initialization(
+			crate::behavior::variables::check_variable_initialization(
 				(var_ty, ta_pos),
 				(value_ty, value.get_position().clone().with_source(environment.get_source())),
 				environment,

--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -9,7 +9,7 @@ use parser::{
 use super::{expressions::synthesise_expression, type_annotations::synthesise_type_annotation};
 use crate::{
 	behavior::variables::VariableMutability,
-	context::{facts::PublicityKind, Context, ContextType},
+	context::{facts::Publicity, Context, ContextType},
 	diagnostics::{TypeCheckError, TypeStringRepresentation},
 	synthesis::parser_property_key_to_checker_property_key,
 	types::{printing::print_type, properties::PropertyKey, Constant},
@@ -84,7 +84,7 @@ pub(crate) fn register_variable<T: crate::ReadFromFS, U: parser::VariableFieldKi
 							let under = crate::types::properties::PropertyKey::from_usize(idx);
 							let property_constraint = environment.get_property_unbound(
 								constraint,
-								PublicityKind::Public,
+								Publicity::Public,
 								under.clone(),
 								&checking_data.types,
 							);
@@ -173,7 +173,7 @@ pub(crate) fn register_variable<T: crate::ReadFromFS, U: parser::VariableFieldKi
 							);
 							let property_constraint = environment.get_property_unbound(
 								constraint,
-								PublicityKind::Public,
+								Publicity::Public,
 								// TODO different above
 								under.clone(),
 								&checking_data.types,
@@ -304,7 +304,7 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 
 						let value = environment.get_property(
 							value,
-							PublicityKind::Public,
+							Publicity::Public,
 							idx,
 							&mut checking_data.types,
 							None,
@@ -350,7 +350,7 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 						// TODO record information
 						let property = environment.get_property(
 							value,
-							PublicityKind::Public,
+							Publicity::Public,
 							key_ty,
 							&mut checking_data.types,
 							None,
@@ -387,7 +387,7 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 						// TODO record information
 						let property_value = environment.get_property(
 							value,
-							PublicityKind::Public,
+							Publicity::Public,
 							// TODO different above
 							key_ty,
 							&mut checking_data.types,

--- a/checker/src/types/calling.rs
+++ b/checker/src/types/calling.rs
@@ -522,7 +522,7 @@ impl FunctionType {
 			mut type_restrictions,
 			mut locally_held_functions,
 			argument_position_and_parameter_idx: _,
-		} = self.synthesize_parameters::<E>(
+		} = self.synthesise_parameters::<E>(
 			arguments,
 			seeding_context,
 			environment,
@@ -775,7 +775,7 @@ impl FunctionType {
 		})
 	}
 
-	fn synthesize_parameters<E: CallCheckingBehavior>(
+	fn synthesise_parameters<E: CallCheckingBehavior>(
 		&self,
 		arguments: &[SynthesisedArgument],
 		mut seeding_context: SeedingContext,

--- a/checker/src/types/calling.rs
+++ b/checker/src/types/calling.rs
@@ -772,7 +772,7 @@ impl FunctionType {
 			}
 		}
 
-		// set events should cover property specialization here:
+		// set events should cover property specialisation here:
 		let returned_type = if let Some(returned_type) = early_return {
 			returned_type
 		} else {

--- a/checker/src/types/calling.rs
+++ b/checker/src/types/calling.rs
@@ -3,10 +3,12 @@ use std::{collections::HashMap, iter, vec};
 
 use crate::{
 	behavior::{
-		constant_functions::{call_constant_function, ConstantResult},
-		functions::ThisValue,
+		constant_functions::{call_constant_function, ConstantFunctionError, ConstantOutput},
+		functions::{FunctionBehavior, ThisValue},
 	},
-	context::{calling::CheckThings, get_value_of_variable, CallCheckingBehavior, Environment},
+	context::{
+		calling::CheckThings, get_value_of_variable, CallCheckingBehavior, Environment, Logical,
+	},
 	diagnostics::{TypeCheckError, TypeStringRepresentation},
 	events::{apply_event, Event, RootReference},
 	subtyping::{type_is_subtype, BasicEquality, NonEqualityReason, SubTypeResult},
@@ -22,7 +24,7 @@ use super::{
 	poly_types::{
 		generic_type_arguments::StructureGenericArguments, FunctionTypeArguments, SeedingContext,
 	},
-	Constructor, FunctionKind, PolyNature, StructureGenerics, TypeStore,
+	Constructor, PolyNature, StructureGenerics, TypeStore,
 };
 
 pub fn call_type_handle_errors<T: crate::ReadFromFS, M: crate::ASTImplementation>(
@@ -100,49 +102,7 @@ pub(crate) fn call_type<'a, E: CallCheckingBehavior>(
 		});
 	}
 
-	let ty = types.get_type_by_id(on);
-	if let Type::FunctionReference(func, this_value) | Type::Function(func, this_value) = ty {
-		// TODO clone ...
-		let function_type = types.functions.get(func).unwrap().clone();
-		function_type.call(
-			called_with_new,
-			*this_value,
-			call_site_type_arguments,
-			None,
-			&arguments,
-			call_site,
-			environment,
-			behavior,
-			types,
-			true,
-		)
-	} else if let Type::Constructor(Constructor::StructureGenerics(StructureGenerics {
-		on,
-		arguments: structure_arguments,
-	})) = ty
-	{
-		// TODO class with this_value
-		if let Type::FunctionReference(func, this_value) | Type::Function(func, this_value) =
-			types.get_type_by_id(*on)
-		{
-			// TODO clone ...
-			let function_type = types.functions.get(func).unwrap().clone();
-			function_type.call(
-				called_with_new,
-				*this_value,
-				call_site_type_arguments,
-				Some(structure_arguments.clone()),
-				&arguments,
-				call_site,
-				environment,
-				behavior,
-				types,
-				true,
-			)
-		} else {
-			todo!()
-		}
-	} else if let Some(constraint) = environment.get_poly_base(on, types) {
+	if let Some(constraint) = environment.get_poly_base(on, types) {
 		create_generic_function_call(
 			constraint,
 			called_with_new,
@@ -156,15 +116,117 @@ pub(crate) fn call_type<'a, E: CallCheckingBehavior>(
 			types,
 		)
 	} else {
-		return Err(vec![FunctionCallingError::NotCallable {
-			calling: crate::diagnostics::TypeStringRepresentation::from_type_id(
-				on,
-				&environment.as_general_context(),
+		// pub enum Callable {
+		// 	Function()
+		// }
+
+		let callable = get_logical_callable_from_type(on, &types);
+
+		if let Some(logical) = callable {
+			let structure_generics = None;
+			call_logical(
+				logical,
 				types,
-				false,
-			),
+				called_with_new,
+				call_site_type_arguments,
+				structure_generics,
+				arguments,
+				&call_site,
+				environment,
+				behavior,
+			)
+		} else {
+			return Err(vec![FunctionCallingError::NotCallable {
+				calling: crate::diagnostics::TypeStringRepresentation::from_type_id(
+					on,
+					&environment.as_general_context(),
+					types,
+					false,
+				),
+				call_site,
+			}]);
+		}
+	}
+}
+
+fn call_logical<E: CallCheckingBehavior>(
+	logical: Logical<(FunctionId, ThisValue)>,
+	types: &mut TypeStore,
+	called_with_new: CalledWithNew,
+	call_site_type_arguments: Option<Vec<(TypeId, source_map::BaseSpan<SourceId>)>>,
+	structure_generics: Option<StructureGenericArguments>,
+	arguments: Vec<SynthesisedArgument>,
+	call_site: &source_map::BaseSpan<SourceId>,
+	environment: &mut Environment,
+	behavior: &mut E,
+) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
+	match logical {
+		Logical::Pure((func, this_value)) => {
+			if let Some(function_type) = types.functions.get(&func) {
+				function_type.clone().call(
+					called_with_new,
+					this_value,
+					call_site_type_arguments,
+					structure_generics,
+					&arguments,
+					call_site.clone(),
+					environment,
+					behavior,
+					types,
+					true,
+				)
+			} else {
+				todo!("recursive function type")
+			}
+		}
+		Logical::Or { left, right } => todo!(),
+		Logical::Implies { on, antecedent } => call_logical(
+			*on,
+			types,
+			called_with_new,
+			call_site_type_arguments,
+			Some(antecedent),
+			arguments,
 			call_site,
-		}]);
+			environment,
+			behavior,
+		),
+	}
+}
+
+fn get_logical_callable_from_type(
+	on: TypeId,
+	types: &TypeStore,
+) -> Option<Logical<(FunctionId, ThisValue)>> {
+	match types.get_type_by_id(on) {
+		Type::And(_, _) => todo!(),
+		Type::Or(left, right) => {
+			if let (Some(left), Some(right)) = (
+				get_logical_callable_from_type(*left, types),
+				get_logical_callable_from_type(*right, types),
+			) {
+				Some(Logical::Or { left: Box::new(left), right: Box::new(right) })
+			} else {
+				None
+			}
+		}
+		Type::Constructor(Constructor::StructureGenerics(generic)) => {
+			get_logical_callable_from_type(generic.on, types).map(|res| Logical::Implies {
+				on: Box::new(res),
+				antecedent: generic.arguments.clone(),
+			})
+		}
+		Type::RootPolyType(_) | Type::Constructor(_) => todo!(),
+
+		Type::AliasTo { to, name, parameters } => {
+			if parameters.is_some() {
+				todo!()
+			}
+			get_logical_callable_from_type(*to, types)
+		}
+		Type::NamedRooted { .. } | Type::Constant(_) | Type::Object(_) => None,
+		Type::FunctionReference(f, t) | Type::Function(f, t) => Some(Logical::Pure((*f, *t))),
+		Type::SpecialObject(_) => todo!(),
 	}
 }
 
@@ -180,8 +242,7 @@ fn create_generic_function_call<'a, E: CallCheckingBehavior>(
 	behavior: &mut E,
 	types: &mut TypeStore,
 ) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
-	// match constraint {
-	// 	PolyBase::Fixed { to, is_open_poly } => {
+	// TODO don't like how it is mixed
 	let result = call_type(
 		constraint,
 		called_with_new,
@@ -197,14 +258,16 @@ fn create_generic_function_call<'a, E: CallCheckingBehavior>(
 
 	let with = arguments.into_boxed_slice();
 
-	// TODO
+	// TODO work this out
 	let is_open_poly = false;
 	let reflects_dependency = if !is_open_poly {
 		// Skip constant types
 		if matches!(result.returned_type, TypeId::UNDEFINED_TYPE | TypeId::NULL_TYPE)
 			|| matches!(
 				types.get_type_by_id(result.returned_type),
-				Type::Constant(..) | Type::Object(super::ObjectNature::RealDeal)
+				Type::Constant(..)
+					| Type::Object(super::ObjectNature::RealDeal)
+					| Type::SpecialObject(..)
 			) {
 			// TODO nearest fact
 			environment.facts.events.push(Event::CallsType {
@@ -280,7 +343,9 @@ pub enum FunctionCallingError {
 		requirement: TypeStringRepresentation,
 		found: TypeStringRepresentation,
 	},
-	Recursed(FunctionId, SpanWithSource),
+	CyclicRecursion(FunctionId, SpanWithSource),
+	NoLogicForIdentifier(String, SpanWithSource),
+	NeedsToBeCalledWithNewKeyword(SpanWithSource),
 }
 
 pub struct InfoDiagnostic(pub String);
@@ -297,10 +362,11 @@ pub struct FunctionCallResult {
 #[derive(Debug, Default, Clone, Copy, binary_serialize_derive::BinarySerializable)]
 pub enum CalledWithNew {
 	New {
-		import_new: TypeId,
+		// [See new.target](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target), which contains a reference to what called new. This does not == this_type
+		on: TypeId,
 	},
 	SpecialSuperCall {
-		on: TypeId,
+		this_type: TypeId,
 	},
 	#[default]
 	None,
@@ -313,7 +379,7 @@ impl FunctionType {
 	pub(crate) fn call<'a, E: CallCheckingBehavior>(
 		&self,
 		called_with_new: CalledWithNew,
-		this_value: ThisValue,
+		mut this_value: ThisValue,
 		call_site_type_arguments: Option<Vec<(TypeId, SpanWithSource)>>,
 		parent_type_arguments: Option<StructureGenericArguments>,
 		arguments: &[SynthesisedArgument],
@@ -321,7 +387,7 @@ impl FunctionType {
 		environment: &mut Environment,
 		behavior: &mut E,
 		types: &mut crate::TypeStore,
-		// This fixes recursion
+		// This fixes recursive case of call_function
 		call_constant: bool,
 	) -> Result<FunctionCallResult, Vec<FunctionCallingError>> {
 		// TODO check that parameters vary
@@ -338,7 +404,7 @@ impl FunctionType {
 			// return Err(vec![reason])
 		}
 
-		if let (Some(const_fn_ident), true) = (self.constant_id.as_deref(), call_constant) {
+		if let (Some(const_fn_ident), true) = (self.constant_function.as_deref(), call_constant) {
 			let has_dependent_argument = arguments.iter().any(|arg| {
 				types
 					.get_type_by_id(arg.into_type().expect("dependent spread types"))
@@ -351,10 +417,57 @@ impl FunctionType {
 				"debug_type"
 					| "print_type" | "debug_effects"
 					| "satisfies" | "is_dependent"
-					| "call" | "bind"
+					| "bind" | "create_proxy"
 			);
 
-			if !call_anyway && has_dependent_argument {
+			// Most of the time don't call using constant function if an argument is dependent.
+			// But sometimes do for the cases above
+			if call_anyway || !has_dependent_argument {
+				// TODO event
+				let result = call_constant_function(
+					const_fn_ident,
+					this_value,
+					&call_site_type_arguments,
+					arguments,
+					types,
+					environment,
+				);
+
+				match result {
+					Ok(ConstantOutput::Value(value)) => {
+						// Very special
+						let special = if const_fn_ident == "compile_type_to_object" {
+							Some(SpecialExpressions::CompileOut)
+						} else {
+							None
+						};
+						return Ok(FunctionCallResult {
+							returned_type: value,
+							warnings: Default::default(),
+							called: None,
+							special,
+						});
+					}
+					Ok(ConstantOutput::Diagnostic(diagnostic)) => {
+						return Ok(FunctionCallResult {
+							returned_type: TypeId::UNDEFINED_TYPE,
+							warnings: vec![InfoDiagnostic(diagnostic)],
+							called: None,
+							// TODO!!
+							special: Some(SpecialExpressions::Marker),
+						});
+					}
+					Err(ConstantFunctionError::NoLogicForIdentifier(name)) => {
+						let item = FunctionCallingError::NoLogicForIdentifier(name, call_site);
+						return Err(vec![item]);
+					}
+					Err(ConstantFunctionError::BadCall) => {
+						crate::utils::notify!(
+							"Constant function calling failed, not constant params"
+						);
+					}
+				}
+			} else if has_dependent_argument {
 				let with = arguments.to_vec().into_boxed_slice();
 				// TODO with cloned!!
 				let result = self
@@ -398,44 +511,6 @@ impl FunctionType {
 					called: None,
 					special: None,
 				});
-			} else {
-				// TODO event
-				let result = call_constant_function(
-					const_fn_ident,
-					this_value,
-					&call_site_type_arguments,
-					arguments,
-					types,
-					environment,
-				);
-
-				if let Ok(returned) = result {
-					match returned {
-						ConstantResult::Value(returned_type) => {
-							return Ok(FunctionCallResult {
-								returned_type,
-								warnings: Default::default(),
-								called: None,
-								special: if const_fn_ident == "compile_type_to_object" {
-									Some(SpecialExpressions::CompileOut)
-								} else {
-									None
-								},
-							});
-						}
-						ConstantResult::Diagnostic(diagnostic) => {
-							return Ok(FunctionCallResult {
-								returned_type: TypeId::UNDEFINED_TYPE,
-								warnings: vec![InfoDiagnostic(diagnostic)],
-								called: None,
-								// TODO!!
-								special: Some(SpecialExpressions::Marker),
-							});
-						}
-					}
-				} else {
-					crate::utils::notify!("Constant function calling failed, not constant params");
-				}
 			}
 		}
 
@@ -460,72 +535,85 @@ impl FunctionType {
 			argument_position_and_parameter_idx: (SpanWithSource::NULL_SPAN, 0),
 		};
 
-		match self.kind {
-			FunctionKind::Arrow => {}
-			// match get_set {
-			// crate::GetSetGeneratorOrNone::Generator => todo!(),
-			// crate::GetSetGeneratorOrNone::Get
-			// | crate::GetSetGeneratorOrNone::Set
-			// | crate::GetSetGeneratorOrNone::None => {
-			// 	if !matches!(called_with_new, CalledWithNew::None) {
-			// 		todo!("Error");
-			// 	}
-			// }
-			// },
-			// class_prototype, class_constructor
-			FunctionKind::ClassConstructor {} => {
-				todo!()
-				// match called_with_new {
-				// 	CalledWithNew::New { .. } => {}
-				// 	CalledWithNew::SpecialSuperCall { on } => {
-				// 		type_arguments.set_this(on);
-				// 		this_argument = Some(on);
-				// 	}
-				// 	CalledWithNew::None => {
-				// 		todo!("Error")
-				// 	}
-				// }
+		match self.behavior {
+			FunctionBehavior::ArrowFunction { is_async } => {}
+			FunctionBehavior::Method { free_this_id, .. } => {
+				let value_of_this =
+					this_value.get_passed().expect("method has no 'this' passed :?");
+				crate::utils::notify!("ftid {:?} & vot {:?}", free_this_id, value_of_this);
+				// TODO checking
+				seeding_context
+					.type_arguments
+					.insert(free_this_id, vec![(value_of_this, SpanWithSource::NULL_SPAN, 0)]);
 			}
-			FunctionKind::Function { function_prototype } => {
-				if let (CalledWithNew::None { .. }, ThisValue::Passed(arg)) =
-					(called_with_new, this_value)
-				{
-					// TODO
-					seeding_context
-						.type_arguments
-						.insert(TypeId::THIS_ARG, vec![(arg, SpanWithSource::NULL_SPAN, 0)]);
+			FunctionBehavior::Function { is_async, is_generator, free_this_id } => {
+				match called_with_new {
+					CalledWithNew::New { on } => {
+						crate::utils::notify!("TODO set prototype");
+						// if let Some(prototype) = non_super_prototype {
+						// let this_ty = environment.create_this(prototype, types);
+						let value_of_this =
+							types.register_type(Type::Object(crate::types::ObjectNature::RealDeal));
+
+						seeding_context.type_arguments.insert(
+							// TODO
+							free_this_id,
+							vec![(value_of_this, SpanWithSource::NULL_SPAN, 0)],
+						);
+					}
+					CalledWithNew::SpecialSuperCall { this_type } => todo!(),
+					CalledWithNew::None => {
+						// TODO
+						let value_of_this = this_value.get(environment, types, call_site.clone());
+
+						seeding_context.type_arguments.insert(
+							free_this_id,
+							vec![(value_of_this, SpanWithSource::NULL_SPAN, 0)],
+						);
+					}
 				}
 			}
-			FunctionKind::Method { get_set: _ } => {}
+			FunctionBehavior::Constructor { non_super_prototype, this_object_type } => {
+				if let CalledWithNew::None = called_with_new {
+					errors.push(FunctionCallingError::NeedsToBeCalledWithNewKeyword(
+						call_site.clone(),
+					));
+				}
+			}
 		}
 
-		let arg = match called_with_new {
-			CalledWithNew::New { import_new } => import_new,
-			CalledWithNew::SpecialSuperCall { .. } => {
-				let ty = this_value.unwrap();
-				let on = crate::types::printing::print_type(
-					ty,
-					types,
-					&environment.as_general_context(),
-					true,
-				);
-				crate::utils::notify!("This argument {}", on);
-				ty
-			}
-			CalledWithNew::None => TypeId::UNDEFINED_TYPE,
-		};
+		{
+			let import_new_argument = match called_with_new {
+				CalledWithNew::New { on } => on,
+				CalledWithNew::SpecialSuperCall { .. } => {
+					todo!()
+					// let ty = this_value.0;
+					// let on = crate::types::printing::print_type(
+					// 	ty,
+					// 	types,
+					// 	&environment.as_general_context(),
+					// 	true,
+					// );
+					// crate::utils::notify!("This argument {}", on);
+					// ty
+				}
+				// In spec == undefined
+				CalledWithNew::None => TypeId::UNDEFINED_TYPE,
+			};
 
-		// TODO on type arguments, not seeding context
-		seeding_context
-			.type_arguments
-			.insert(TypeId::NEW_TARGET_ARG, vec![(arg, SpanWithSource::NULL_SPAN, 0)]);
+			// TODO on type arguments, not seeding context
+			seeding_context.type_arguments.insert(
+				TypeId::NEW_TARGET_ARG,
+				vec![(import_new_argument, SpanWithSource::NULL_SPAN, 0)],
+			);
+		}
 
 		let SeedingContext {
 			type_arguments: mut found,
 			mut type_restrictions,
 			mut locally_held_functions,
 			argument_position_and_parameter_idx: _,
-		} = self.synthesise_parameters::<E>(
+		} = self.synthesise_arguments::<E>(
 			arguments,
 			seeding_context,
 			environment,
@@ -534,7 +622,8 @@ impl FunctionType {
 			call_site,
 		);
 
-		let mut type_arguments = map_vec::Map::new();
+		// take the found and inject back into what it resolved
+		let mut result_type_arguments = map_vec::Map::new();
 
 		for (item, values) in found.into_iter() {
 			let mut into_iter = values.into_iter();
@@ -587,7 +676,7 @@ impl FunctionType {
 			}
 
 			// TODO position is just the first
-			type_arguments.insert(item, (value, argument_position));
+			result_type_arguments.insert(item, (value, argument_position));
 		}
 		// for (item, restrictions) in type_restrictions.iter() {
 		// 	for (restriction, pos) in restrictions {
@@ -597,87 +686,12 @@ impl FunctionType {
 
 		let mut type_arguments = FunctionTypeArguments {
 			structure_arguments: parent_type_arguments,
-			local_arguments: type_arguments,
+			local_arguments: result_type_arguments,
 			closure_id: None,
 		};
 
-		// TODO only check
 		if E::CHECK_PARAMETERS {
-			// Check free variables from inference
-			// for (reference, restriction) in self.free_variables.clone().into_iter() {
-			// 	match reference {
-			// 		RootReference::Variable(ref variable) => {
-			// 			let current_value = get_value_of_variable(
-			// 				environment.facts_chain(),
-			// 				*variable,
-			// 				Some(&type_arguments),
-			// 			)
-			// 			.expect("reference not assigned");
-
-			// 			let mut basic_subtyping = BasicEquality {
-			// 				add_property_restrictions: false,
-			// 				// TODO temp position
-			// 				position: SpanWithSource::NULL_SPAN,
-			// 			};
-			// 			if let SubTypeResult::IsNotSubType(reasons) = type_is_subtype(
-			// 				restriction,
-			// 				current_value,
-			// 				&mut basic_subtyping,
-			// 				environment,
-			// 				types,
-			// 			) {
-			// 				errors.push(FunctionCallingError::ReferenceRestrictionDoesNotMatch {
-			// 					reference,
-			// 					requirement: TypeStringRepresentation::from_type_id(
-			// 						restriction,
-			// 						&environment.as_general_context(),
-			// 						types,
-			// 						false,
-			// 					),
-			// 					found: TypeStringRepresentation::from_type_id(
-			// 						current_value,
-			// 						&environment.as_general_context(),
-			// 						types,
-			// 						false,
-			// 					),
-			// 				});
-			// 			}
-			// 		}
-			// 		RootReference::This if matches!(called_with_new, CalledWithNew::None) => {}
-			// 		RootReference::This => {
-			// 			let value_of_this = this_value.get(environment, types);
-
-			// 			let mut basic_subtyping = BasicEquality {
-			// 				add_property_restrictions: false,
-			// 				// TODO temp position
-			// 				position: SpanWithSource::NULL_SPAN,
-			// 			};
-			// 			if let SubTypeResult::IsNotSubType(reasons) = type_is_subtype(
-			// 				restriction,
-			// 				value_of_this,
-			// 				&mut basic_subtyping,
-			// 				environment,
-			// 				types,
-			// 			) {
-			// 				errors.push(FunctionCallingError::ReferenceRestrictionDoesNotMatch {
-			// 					reference,
-			// 					requirement: TypeStringRepresentation::from_type_id(
-			// 						restriction,
-			// 						&environment.as_general_context(),
-			// 						types,
-			// 						false,
-			// 					),
-			// 					found: TypeStringRepresentation::from_type_id(
-			// 						value_of_this,
-			// 						&environment.as_general_context(),
-			// 						types,
-			// 						false,
-			// 					),
-			// 				});
-			// 			}
-			// 		}
-			// 	}
-			// }
+			// TODO check free variables from inference
 		}
 
 		if !errors.is_empty() {
@@ -721,54 +735,49 @@ impl FunctionType {
 			return_result
 		});
 
-		if let Some(returned_type) = early_return {
-			if let CalledWithNew::New { .. } = called_with_new {
-				// TODO skip returns if new, need a warning or something.
-				crate::utils::notify!("Returned despite being called with new...");
-				// todo!("warning")
-			}
+		if let CalledWithNew::New { .. } = called_with_new {
+			// TODO ridiculous early return primitive rule
+			match self.behavior {
+				FunctionBehavior::ArrowFunction { is_async } => todo!(),
+				FunctionBehavior::Method { is_async, is_generator, .. } => todo!(),
+				FunctionBehavior::Function { is_async, is_generator, free_this_id } => {
+					let new_instance_type = type_arguments
+						.local_arguments
+						.remove(&free_this_id)
+						.expect("no this argument7")
+						.0;
 
-			return Ok(FunctionCallResult {
-				returned_type,
-				warnings: Default::default(),
-				called: Some(self.id),
-				special: None,
-			});
+					return Ok(FunctionCallResult {
+						returned_type: new_instance_type,
+						warnings: Default::default(),
+						called: Some(self.id),
+						special: None,
+					});
+				}
+				FunctionBehavior::Constructor { non_super_prototype, this_object_type } => {
+					crate::utils::notify!("Registered this {:?}", this_object_type);
+					let new_instance_type = type_arguments
+						.local_arguments
+						.remove(&this_object_type)
+						.expect("no this argument7")
+						.0;
+
+					return Ok(FunctionCallResult {
+						returned_type: new_instance_type,
+						warnings: Default::default(),
+						called: Some(self.id),
+						special: None,
+					});
+				}
+			}
 		}
 
 		// set events should cover property specialization here:
-		// let returned_type = if let CalledWithNew::New { ..} = called_with_new {
-		// 	// TODO substitute under the primitive conditional rules
-		// 	let new_instance_type = type_arguments
-		// 		.local_arguments
-		// 		.get_mut(&TypeId::THIS_ARG)
-		// 		.unwrap()
-		// 		.value
-		// 		.take()
-		// 		.unwrap();
-		// 	new_instance_type
-		// } else {
-		// };
-
-		// TODO
-		// {
-		// 	let restriction = self.type_arguments.get_restriction_for_id(type_id);
-
-		// 	// Check restriction from call site type argument
-		// 	if let Some((pos, restriction)) = restriction {
-		// 		if let SubTypeResult::IsNotSubType(reason) =
-		// 			type_is_subtype(restriction, value, None, None, self, environment, types)
-		// 		{
-		// 			return Err(NonEqualityReason::GenericRestrictionMismatch {
-		// 				restriction,
-		// 				reason: Box::new(reason),
-		// 				pos,
-		// 			});
-		// 		}
-		// 	}
-		// }
-
-		let returned_type = substitute(self.return_type, &mut type_arguments, environment, types);
+		let returned_type = if let Some(returned_type) = early_return {
+			returned_type
+		} else {
+			substitute(self.return_type, &mut type_arguments, environment, types)
+		};
 
 		Ok(FunctionCallResult {
 			returned_type,
@@ -778,7 +787,7 @@ impl FunctionType {
 		})
 	}
 
-	fn synthesise_parameters<E: CallCheckingBehavior>(
+	fn synthesise_arguments<E: CallCheckingBehavior>(
 		&self,
 		arguments: &[SynthesisedArgument],
 		mut seeding_context: SeedingContext,

--- a/checker/src/types/classes.rs
+++ b/checker/src/types/classes.rs
@@ -1,0 +1,127 @@
+use crate::{
+	context::facts::PublicityKind, events::Event, synthesis::interfaces::GetterSetter,
+	CheckingData, Environment, PropertyValue, TypeId,
+};
+
+use super::properties::PropertyKey;
+
+// TODO better place
+pub enum PropertyFunctionProperty {
+	Get,
+	Set,
+	Standard { is_async: bool, is_generator: bool },
+}
+
+/// CreateProperty = get setter etc
+pub enum PropertyOnClass<'a, M: crate::ASTImplementation> {
+	Function { method: &'a M::ClassMethod, property: PropertyFunctionProperty },
+	Expression(Option<&'a M::Expression>),
+}
+
+// Needed to because of enum
+#[allow(type_alias_bounds)]
+pub type ClassProperties<'a, M: crate::ASTImplementation> =
+	Vec<(PublicityKind, PropertyKey<'static>, PropertyOnClass<'a, M>)>;
+
+pub enum ClassProperty {
+	Value {
+		publicity: PublicityKind,
+		/// Created eagerly, don't specialise
+		key: PropertyKey<'static>,
+		effects: Vec<Event>,
+		end_value: PropertyFunctionProperty,
+	},
+	Method {
+		publicity: PublicityKind,
+		/// Created eagerly, don't specialise
+		key: PropertyKey<'static>,
+		value: PropertyFunctionProperty,
+	},
+}
+
+/// TODO i really hate this setup. Can it be simpler & faster?
+///
+/// What about storing it as just set_events...?
+pub struct RegisterClassPropertiesEvent {
+	pub properties: Vec<ClassProperty>,
+	pub class_prototype: TypeId,
+}
+
+fn register_properties_into_store<T: crate::ReadFromFS, M: crate::ASTImplementation>(
+	environment: &mut Environment,
+	class_prototype: TypeId,
+	properties: Vec<(PublicityKind, PropertyKey<'static>, PropertyOnClass<'_, M>)>,
+	checking_data: &mut CheckingData<T, M>,
+) {
+	let (_, result, _) = environment.new_lexical_environment_fold_into_parent(
+		crate::Scope::Function(crate::context::environment::FunctionScope::Constructor {
+			extends: false,
+			type_of_super: Some(TypeId::ERROR_TYPE),
+			// TODO get from above
+			this_object_type: TypeId::ERROR_TYPE,
+		}),
+		checking_data,
+		|environment, checking_data| {
+			register_properties_into_environment(
+				environment,
+				class_prototype,
+				checking_data,
+				properties,
+			);
+		},
+	);
+	let (events, free_variables) = result.unwrap();
+	// Store events ...
+	todo!()
+}
+
+pub(crate) fn register_properties_into_environment<
+	T: crate::ReadFromFS,
+	M: crate::ASTImplementation,
+>(
+	environment: &mut Environment,
+	on: TypeId,
+	checking_data: &mut CheckingData<T, M>,
+	properties: Vec<(PublicityKind, PropertyKey<'static>, PropertyOnClass<'_, M>)>,
+) {
+	for (publicity, property, value) in properties {
+		let value = match value {
+			PropertyOnClass::Function { method, property } => {
+				let is_async = if let PropertyFunctionProperty::Standard { is_async, .. } = property
+				{
+					is_async
+				} else {
+					false
+				};
+				let is_generator =
+					if let PropertyFunctionProperty::Standard { is_generator, .. } = property {
+						is_generator
+					} else {
+						false
+					};
+				let getter_setter = match property {
+					PropertyFunctionProperty::Get => GetterSetter::Getter,
+					PropertyFunctionProperty::Set => GetterSetter::Setter,
+					PropertyFunctionProperty::Standard { .. } => GetterSetter::None,
+				};
+				let behavior = crate::behavior::functions::FunctionRegisterBehavior::ClassMethod {
+					is_async,
+					is_generator,
+					// TODO
+					super_type: None,
+				};
+				let function = environment.new_function(checking_data, method, behavior);
+				crate::behavior::functions::function_to_property(
+					getter_setter,
+					function,
+					&mut checking_data.types,
+				)
+			}
+			PropertyOnClass::Expression(Some(expression)) => PropertyValue::Value(
+				M::synthesise_expression(expression, TypeId::ANY_TYPE, environment, checking_data),
+			),
+			PropertyOnClass::Expression(None) => PropertyValue::Value(TypeId::UNDEFINED_TYPE),
+		};
+		environment.facts.register_property(on, publicity, property, value, true, None);
+	}
+}

--- a/checker/src/types/classes.rs
+++ b/checker/src/types/classes.rs
@@ -1,6 +1,7 @@
 use crate::{
-	context::facts::PublicityKind, events::Event, synthesis::interfaces::GetterSetter,
-	CheckingData, Environment, PropertyValue, TypeId,
+	behavior::functions::ClassPropertiesToRegister, context::facts::Publicity, events::Event,
+	synthesis::interfaces::GetterSetter, ASTImplementation, CheckingData, Environment,
+	PropertyValue, TypeId,
 };
 
 use super::properties::PropertyKey;
@@ -12,54 +13,52 @@ pub enum PropertyFunctionProperty {
 	Standard { is_async: bool, is_generator: bool },
 }
 
-/// CreateProperty = get setter etc
-pub enum PropertyOnClass<'a, M: crate::ASTImplementation> {
-	Function { method: &'a M::ClassMethod, property: PropertyFunctionProperty },
-	Expression(Option<&'a M::Expression>),
+pub struct ClassValue<'a, M: ASTImplementation> {
+	pub publicity: Publicity,
+	/// Created eagerly, don't specialise
+	pub key: PropertyKey<'static>,
+	pub value: Option<&'a M::Expression>,
 }
 
-// Needed to because of enum
-#[allow(type_alias_bounds)]
-pub type ClassProperties<'a, M: crate::ASTImplementation> =
-	Vec<(PublicityKind, PropertyKey<'static>, PropertyOnClass<'a, M>)>;
-
-pub enum ClassProperty {
-	Value {
-		publicity: PublicityKind,
-		/// Created eagerly, don't specialise
-		key: PropertyKey<'static>,
-		effects: Vec<Event>,
-		end_value: PropertyFunctionProperty,
-	},
-	Method {
-		publicity: PublicityKind,
-		/// Created eagerly, don't specialise
-		key: PropertyKey<'static>,
-		value: PropertyFunctionProperty,
-	},
+pub struct SynthesisedClassValue {
+	pub publicity: Publicity,
+	/// Created eagerly, don't specialise
+	pub key: PropertyKey<'static>,
+	pub effects: Vec<Event>,
+	pub value: TypeId,
 }
+
+// TODO might use
+// pub struct ClassMethod {
+// 	publicity: Publicity,
+// 	/// Created eagerly, don't specialise
+// 	key: PropertyKey<'static>,
+// 	value: PropertyFunctionProperty,
+// }
 
 /// TODO i really hate this setup. Can it be simpler & faster?
 ///
 /// What about storing it as just set_events...?
 pub struct RegisterClassPropertiesEvent {
-	pub properties: Vec<ClassProperty>,
+	pub properties: Vec<SynthesisedClassValue>,
 	pub class_prototype: TypeId,
 }
 
 fn register_properties_into_store<T: crate::ReadFromFS, M: crate::ASTImplementation>(
 	environment: &mut Environment,
 	class_prototype: TypeId,
-	properties: Vec<(PublicityKind, PropertyKey<'static>, PropertyOnClass<'_, M>)>,
+	properties: ClassPropertiesToRegister<'_, M>,
 	checking_data: &mut CheckingData<T, M>,
 ) {
+	let scope = crate::Scope::Function(crate::context::environment::FunctionScope::Constructor {
+		extends: false,
+		type_of_super: Some(TypeId::ERROR_TYPE),
+		// TODO get from above
+		this_object_type: TypeId::ERROR_TYPE,
+	});
+
 	let (_, result, _) = environment.new_lexical_environment_fold_into_parent(
-		crate::Scope::Function(crate::context::environment::FunctionScope::Constructor {
-			extends: false,
-			type_of_super: Some(TypeId::ERROR_TYPE),
-			// TODO get from above
-			this_object_type: TypeId::ERROR_TYPE,
-		}),
+		scope,
 		checking_data,
 		|environment, checking_data| {
 			register_properties_into_environment(
@@ -71,6 +70,7 @@ fn register_properties_into_store<T: crate::ReadFromFS, M: crate::ASTImplementat
 		},
 	);
 	let (events, free_variables) = result.unwrap();
+
 	// Store events ...
 	todo!()
 }
@@ -82,46 +82,19 @@ pub(crate) fn register_properties_into_environment<
 	environment: &mut Environment,
 	on: TypeId,
 	checking_data: &mut CheckingData<T, M>,
-	properties: Vec<(PublicityKind, PropertyKey<'static>, PropertyOnClass<'_, M>)>,
+	properties: ClassPropertiesToRegister<M>,
 ) {
-	for (publicity, property, value) in properties {
-		let value = match value {
-			PropertyOnClass::Function { method, property } => {
-				let is_async = if let PropertyFunctionProperty::Standard { is_async, .. } = property
-				{
-					is_async
-				} else {
-					false
-				};
-				let is_generator =
-					if let PropertyFunctionProperty::Standard { is_generator, .. } = property {
-						is_generator
-					} else {
-						false
-					};
-				let getter_setter = match property {
-					PropertyFunctionProperty::Get => GetterSetter::Getter,
-					PropertyFunctionProperty::Set => GetterSetter::Setter,
-					PropertyFunctionProperty::Standard { .. } => GetterSetter::None,
-				};
-				let behavior = crate::behavior::functions::FunctionRegisterBehavior::ClassMethod {
-					is_async,
-					is_generator,
-					// TODO
-					super_type: None,
-				};
-				let function = environment.new_function(checking_data, method, behavior);
-				crate::behavior::functions::function_to_property(
-					getter_setter,
-					function,
-					&mut checking_data.types,
-				)
-			}
-			PropertyOnClass::Expression(Some(expression)) => PropertyValue::Value(
-				M::synthesise_expression(expression, TypeId::ANY_TYPE, environment, checking_data),
-			),
-			PropertyOnClass::Expression(None) => PropertyValue::Value(TypeId::UNDEFINED_TYPE),
+	for ClassValue { publicity, key, value } in properties.0 {
+		let value = if let Some(expression) = value {
+			PropertyValue::Value(M::synthesise_expression(
+				expression,
+				TypeId::ANY_TYPE,
+				environment,
+				checking_data,
+			))
+		} else {
+			PropertyValue::Value(TypeId::UNDEFINED_TYPE)
 		};
-		environment.facts.register_property(on, publicity, property, value, true, None);
+		environment.facts.register_property(on, publicity, key, value, true, None);
 	}
 }

--- a/checker/src/types/functions.rs
+++ b/checker/src/types/functions.rs
@@ -2,19 +2,42 @@ use std::collections::HashMap;
 
 use source_map::{Span, SpanWithSource};
 
-use crate::{events::RootReference, FunctionId, GenericTypeParameters, TypeId};
+use crate::{
+	behavior::functions::FunctionBehavior,
+	context::{
+		environment::{self, FunctionScope},
+		facts::PublicityKind,
+		Context, ContextType,
+	},
+	events::{Event, RootReference},
+	CheckingData, Environment, Facts, FunctionId, GenericTypeParameters, PropertyValue, Scope,
+	Type, TypeId,
+};
 
+use super::{
+	classes::{register_properties_into_environment, ClassProperties},
+	TypeStore,
+};
+
+/// This is a mesh of annotation and actually defined functions
 #[derive(Clone, Debug, binary_serialize_derive::BinarySerializable)]
 pub struct FunctionType {
 	/// Syntax defined pointer
 	pub id: FunctionId,
 
+	pub constant_function: Option<String>,
+
+	/// If async, generator and what to do with `this`
+	pub behavior: FunctionBehavior,
+
 	/// TODO not sure about this field and how it tails with Pi Types
 	pub type_parameters: Option<GenericTypeParameters>,
 	pub parameters: SynthesisedParameters,
+	/// This is just aesthetic TODO also throw
 	pub return_type: TypeId,
+
 	/// Side effects of the function
-	pub effects: Vec<crate::events::Event>,
+	pub effects: Vec<Event>,
 
 	/// Things that this function pulls in. Converse of closed over which is where results below use
 	/// variables in this scope.
@@ -24,12 +47,84 @@ pub struct FunctionType {
 	///
 	/// The type is the initial value of the closure variable when this is called
 	pub closed_over_variables: HashMap<RootReference, TypeId>,
+}
 
-	/// Can be called for constant result
-	pub constant_id: Option<String>,
+impl FunctionType {
+	pub(crate) fn new_auto_constructor<
+		T: crate::ReadFromFS,
+		M: crate::ASTImplementation,
+		S: ContextType,
+	>(
+		_class_prototype: TypeId,
+		properties: ClassProperties<M>,
+		// TODO S overkill
+		context: &mut crate::context::Context<S>,
+		checking_data: &mut CheckingData<T, M>,
+	) -> Self {
+		let scope = Scope::Function(FunctionScope::Constructor {
+			extends: false,
+			type_of_super: None,
+			this_object_type: TypeId::ERROR_TYPE,
+		});
 
-	/// TODO temp
-	pub kind: FunctionKind,
+		let (on, env_data, _) = context.new_lexical_environment_fold_into_parent(
+			scope,
+			checking_data,
+			|environment, checking_data| {
+				let on = create_this_before_function_synthesis(
+					&mut checking_data.types,
+					&mut environment.facts,
+				);
+				if let Scope::Function(FunctionScope::Constructor {
+					ref mut this_object_type,
+					..
+				}) = environment.context_type.scope
+				{
+					*this_object_type = on
+				}
+
+				register_properties_into_environment(environment, on, checking_data, properties);
+				on
+			},
+		);
+		// TODO think Some fine
+		// TODO
+		let behavior =
+			FunctionBehavior::Constructor { non_super_prototype: None, this_object_type: on };
+
+		let (events, free_variables) = env_data.unwrap();
+		Self {
+			id: crate::FunctionId::AUTO_CONSTRUCTOR,
+			constant_function: None,
+			type_parameters: None,
+			parameters: SynthesisedParameters::default(),
+			// Only needed for printing
+			return_type: on,
+			effects: events,
+			behavior,
+			// TODO ???
+			free_variables: Default::default(),
+			closed_over_variables: Default::default(),
+		}
+	}
+}
+
+/// For inside the function
+pub(crate) fn create_this_before_function_synthesis(
+	types: &mut TypeStore,
+	facts: &mut Facts,
+) -> TypeId {
+	let ty = types.register_type(Type::Object(crate::types::ObjectNature::RealDeal));
+
+	crate::utils::notify!("Registered 'this' type as {:?}", ty);
+	let value = Event::CreateObject {
+		referenced_in_scope_as: ty,
+		prototype: crate::events::PrototypeArgument::None,
+		position: None,
+	};
+	facts.events.push(value);
+
+	ty
 }
 
 /// TODO temp
@@ -38,47 +133,6 @@ pub enum GetSet {
 	Get,
 	Set,
 }
-
-/// TODO as generics
-#[derive(Clone, Copy, Debug, binary_serialize_derive::BinarySerializable)]
-pub enum FunctionKind {
-	Arrow,
-	Function {
-		function_prototype: TypeId,
-	},
-	ClassConstructor {
-		// TODO constructor event
-	},
-	Method {
-		/// TODO this should be generically rather than at runtime
-		get_set: Option<GetSet>,
-	},
-}
-
-// /// TODO needs improvement
-// #[derive(Clone, Debug, binary_serialize_derive::BinarySerializable)]
-// pub enum FunctionNature {
-// 	BehindPoly {
-// 		/// TODO function id?
-// 		function_id_if_open_poly: Option<FunctionId>,
-// 		state: FunctionState,
-// 	},
-// 	/// Last is 'this' type,
-// 	Source {
-// 		state: FunctionState,
-// 	},
-// 	Reference,
-// }
-
-// impl FunctionNature {
-// 	pub fn get_this_and_closed_variables(self) -> (Option<TypeId>, ClosedOverVariables) {
-// 		match self {
-// 			FunctionNature::BehindPoly { function_id_if_open_poly: _ , state }
-// 			| FunctionNature::Source { state } => (state.value_of_this, state.closed_over_variables),
-// 			FunctionNature::Reference => (None, Default::default()),
-// 		}
-// 	}
-// }
 
 /// Optionality is indicated by what vector it is in [SynthesisedParameters]
 #[derive(Clone, Debug, binary_serialize_derive::BinarySerializable)]
@@ -109,54 +163,6 @@ pub struct SynthesisedParameters {
 	pub parameters: Vec<SynthesisedParameter>,
 	pub rest_parameter: Option<SynthesisedRestParameter>,
 }
-
-// impl TypeDisplay for SynthesisedParameters {
-// 	fn fmt(
-// 		&self,
-// 		buf: &mut String,
-// 		indent: usize,
-// 		cycles: &mut std::collections::HashSet<usize>,
-// 		environment: &GeneralContext,
-// 		store: &TypeStore,
-// 	) {
-// 		buf.push('(');
-
-// 		for (at_end, SynthesisedParameter { name, ty: constraint, .. }) in
-// 			self.parameters.iter().endiate()
-// 		{
-// 			buf.push_str(name);
-// 			buf.push_str(": ");
-// 			let constraint_ty = get_on_ctx!(environment.get_type_by_id(*constraint));
-// 			TypeDisplay::fmt(constraint, buf, indent, cycles, environment, store);
-// 			if !at_end || !self.optional_parameters.is_empty() || self.rest_parameter.is_some() {
-// 				buf.push_str(", ");
-// 			}
-// 		}
-
-// 		for (at_end, SynthesisedParameter { name, ty: constraint, .. }) in
-// 			self.optional_parameters.iter().endiate()
-// 		{
-// 			buf.push_str(name);
-// 			buf.push_str("?: ");
-// 			let constraint_ty = get_on_ctx!(environment.get_type_by_id(*constraint));
-// 			TypeDisplay::fmt(constraint, buf, indent, cycles, environment);
-// 			if !at_end || self.rest_parameter.is_some() {
-// 				buf.push_str(", ");
-// 			}
-// 		}
-
-// 		if let Some(synthesisedRestParameter { name, item_type, .. }) = self.rest_parameter.as_ref()
-// 		{
-// 			buf.push_str("...");
-// 			buf.push_str(&name);
-// 			buf.push_str(": ");
-// 			let item_type_ty = get_on_ctx!(environment.get_type_by_id(*item_type));
-// 			TypeDisplay::fmt(item_type, buf, indent, cycles, environment);
-// 		}
-
-// 		buf.push(')')
-// 	}
-// }
 
 impl SynthesisedParameters {
 	// TODO should be aware of undefined in optionals possibly

--- a/checker/src/types/inference.rs
+++ b/checker/src/types/inference.rs
@@ -1,0 +1,1 @@
+pub enum Root {}

--- a/checker/src/types/mod.rs
+++ b/checker/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod calling;
-mod casts;
+pub mod casts;
+pub mod classes;
 pub mod functions;
 pub mod others;
 pub mod poly_types;
@@ -31,13 +32,12 @@ use crate::{
 pub use self::functions::*;
 use self::{
 	poly_types::{generic_type_arguments::StructureGenericArguments, SeedingContext},
+	properties::PropertyKey,
 	subtyping::type_is_subtype,
 };
 use crate::FunctionId;
 
 /// References [Type]
-///
-/// Not to be confused with [parser::TypeId]
 ///
 /// TODO maybe u32 or u64
 /// TODO maybe on environment rather than here
@@ -78,17 +78,15 @@ impl TypeId {
 	pub const ZERO: Self = Self(16);
 	pub const ONE: Self = Self(17);
 	pub const NAN_TYPE: Self = Self(18);
-	/// For arrays
-	pub const LENGTH_AS_STRING: Self = Self(19);
 
-	/// For this_arg for type constraints only
-	pub const THIS_ARG: Self = Self(20);
+	/// TODO remove. Shortcut for inferred this
+	pub const ANY_INFERRED_FREE_THIS: Self = Self(19);
 	/// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target
-	pub const NEW_TARGET_ARG: Self = Self(21);
+	pub const NEW_TARGET_ARG: Self = Self(20);
 
-	pub const SYMBOL_TO_PRIMITIVE: Self = Self(22);
+	pub const SYMBOL_TO_PRIMITIVE: Self = Self(21);
 
-	pub(crate) const INTERNAL_TYPE_COUNT: usize = 23;
+	pub(crate) const INTERNAL_TYPE_COUNT: usize = 22;
 }
 
 #[derive(Clone, Debug, binary_serialize_derive::BinarySerializable)]
@@ -125,7 +123,6 @@ pub enum Type {
 	FunctionReference(FunctionId, ThisValue),
 
 	/// Technically could be just a function but...
-	Class(FunctionId),
 	Object(ObjectNature),
 	SpecialObject(SpecialObjects),
 }
@@ -193,7 +190,6 @@ impl Type {
 			Type::Constant(_)
 			| Type::Function(..)
 			| Type::FunctionReference(..)
-			| Type::Class(..)
 			| Type::Object(_) => false,
 			Type::SpecialObject(_) => todo!(),
 		}
@@ -237,7 +233,8 @@ pub enum Constructor {
 	},
 	Property {
 		on: TypeId,
-		under: TypeId,
+		under: PropertyKey<'static>,
+		result: TypeId,
 	},
 	/// Might not be best place but okay.
 	StructureGenerics(StructureGenerics),
@@ -283,8 +280,11 @@ pub(crate) fn new_logical_or_type(lhs: TypeId, rhs: TypeId, types: &mut TypeStor
 }
 
 pub fn is_type_truthy_falsy(ty: TypeId, types: &TypeStore) -> TruthyFalsy {
+	// These first two branches are just shortcuts.
 	if ty == TypeId::TRUE || ty == TypeId::FALSE {
 		TruthyFalsy::Decidable(ty == TypeId::TRUE)
+	} else if ty == TypeId::NULL_TYPE || ty == TypeId::UNDEFINED_TYPE {
+		TruthyFalsy::Decidable(false)
 	} else {
 		let ty = types.get_type_by_id(ty);
 		match ty {
@@ -299,7 +299,6 @@ pub fn is_type_truthy_falsy(ty: TypeId, types: &TypeStore) -> TruthyFalsy {
 			}
 			Type::Function(..)
 			| Type::FunctionReference(..)
-			| Type::Class(..)
 			| Type::SpecialObject(_)
 			| Type::Object(_) => TruthyFalsy::Decidable(true),
 			Type::Constant(cst) => {
@@ -422,7 +421,7 @@ pub enum SubTypeResult {
 pub enum NonEqualityReason {
 	Mismatch,
 	PropertiesInvalid {
-		errors: Vec<(TypeId, PropertyError)>,
+		errors: Vec<(PropertyKey<'static>, PropertyError)>,
 	},
 	TooStrict,
 	/// TODO more information

--- a/checker/src/types/others.rs
+++ b/checker/src/types/others.rs
@@ -1,7 +1,7 @@
 // Types to runtime behavior
 
 use crate::{
-	behavior::objects::ObjectBuilder, context::facts::PublicityKind, Constant, Environment, Type,
+	behavior::objects::ObjectBuilder, context::facts::Publicity, Constant, Environment, Type,
 	TypeId,
 };
 
@@ -23,7 +23,7 @@ pub(crate) fn create_object_for_type(
 			// TODO: Do we need positions for the following appends?
 			obj.append(
 				environment,
-				PublicityKind::Public,
+				Publicity::Public,
 				PropertyKey::String("kind".into()),
 				crate::PropertyValue::Value(types.new_constant_type(Constant::String(kind.into()))),
 				None,
@@ -32,14 +32,14 @@ pub(crate) fn create_object_for_type(
 			let right = create_object_for_type(right, environment, types);
 			obj.append(
 				environment,
-				PublicityKind::Public,
+				Publicity::Public,
 				PropertyKey::String("left".into()),
 				crate::PropertyValue::Value(left),
 				None,
 			);
 			obj.append(
 				environment,
-				PublicityKind::Public,
+				Publicity::Public,
 				PropertyKey::String("right".into()),
 				crate::PropertyValue::Value(right),
 				None,
@@ -53,7 +53,7 @@ pub(crate) fn create_object_for_type(
 			// TODO: Do we need positions for the following appends?
 			obj.append(
 				environment,
-				PublicityKind::Public,
+				Publicity::Public,
 				PropertyKey::String("name".into()),
 				crate::PropertyValue::Value(types.new_constant_type(Constant::String(name))),
 				None,
@@ -68,7 +68,7 @@ pub(crate) fn create_object_for_type(
 					let value = create_object_for_type(property, environment, types);
 					inner_object.append(
 						environment,
-						PublicityKind::Public,
+						Publicity::Public,
 						key,
 						crate::PropertyValue::Value(value),
 						None,
@@ -77,7 +77,7 @@ pub(crate) fn create_object_for_type(
 
 				obj.append(
 					environment,
-					PublicityKind::Public,
+					Publicity::Public,
 					PropertyKey::String("properties".into()),
 					crate::PropertyValue::Value(inner_object.build_object()),
 					None,
@@ -87,7 +87,7 @@ pub(crate) fn create_object_for_type(
 		Type::Constant(_) => {
 			obj.append(
 				environment,
-				PublicityKind::Public,
+				Publicity::Public,
 				PropertyKey::String("constant".into()),
 				crate::PropertyValue::Value(ty),
 				None,
@@ -101,7 +101,7 @@ pub(crate) fn create_object_for_type(
 			);
 			obj.append(
 				environment,
-				PublicityKind::Public,
+				Publicity::Public,
 				PropertyKey::String("kind".into()),
 				value,
 				None,
@@ -115,7 +115,7 @@ pub(crate) fn create_object_for_type(
 				let value = create_object_for_type(property, environment, types);
 				inner_object.append(
 					environment,
-					PublicityKind::Public,
+					Publicity::Public,
 					key,
 					crate::PropertyValue::Value(value),
 					None,
@@ -124,7 +124,7 @@ pub(crate) fn create_object_for_type(
 
 			obj.append(
 				environment,
-				PublicityKind::Public,
+				Publicity::Public,
 				PropertyKey::String("properties".into()),
 				crate::PropertyValue::Value(inner_object.build_object()),
 				None,

--- a/checker/src/types/others.rs
+++ b/checker/src/types/others.rs
@@ -5,7 +5,7 @@ use crate::{
 	TypeId,
 };
 
-use super::TypeStore;
+use super::{properties::PropertyKey, TypeStore};
 
 pub(crate) fn create_object_for_type(
 	ty: TypeId,
@@ -23,25 +23,25 @@ pub(crate) fn create_object_for_type(
 			// TODO: Do we need positions for the following appends?
 			obj.append(
 				environment,
-				types.new_constant_type(Constant::String("kind".into())),
-				crate::Property::Value(types.new_constant_type(Constant::String(kind.into()))),
 				PublicityKind::Public,
+				PropertyKey::String("kind".into()),
+				crate::PropertyValue::Value(types.new_constant_type(Constant::String(kind.into()))),
 				None,
 			);
 			let left = create_object_for_type(left, environment, types);
 			let right = create_object_for_type(right, environment, types);
 			obj.append(
 				environment,
-				types.new_constant_type(Constant::String("left".into())),
-				crate::Property::Value(left),
 				PublicityKind::Public,
+				PropertyKey::String("left".into()),
+				crate::PropertyValue::Value(left),
 				None,
 			);
 			obj.append(
 				environment,
-				types.new_constant_type(Constant::String("right".into())),
-				crate::Property::Value(right),
 				PublicityKind::Public,
+				PropertyKey::String("right".into()),
+				crate::PropertyValue::Value(right),
 				None,
 			);
 		}
@@ -53,9 +53,9 @@ pub(crate) fn create_object_for_type(
 			// TODO: Do we need positions for the following appends?
 			obj.append(
 				environment,
-				types.new_constant_type(Constant::String("name".into())),
-				crate::Property::Value(types.new_constant_type(Constant::String(name))),
 				PublicityKind::Public,
+				PropertyKey::String("name".into()),
+				crate::PropertyValue::Value(types.new_constant_type(Constant::String(name))),
 				None,
 			);
 
@@ -64,22 +64,22 @@ pub(crate) fn create_object_for_type(
 				let mut inner_object = ObjectBuilder::new(None, types, &mut environment.facts);
 
 				// let properties = env.create_array();
-				for (key, _, property) in environment.get_properties_on_type(ty) {
+				for (_, key, property) in environment.get_properties_on_type(ty) {
 					let value = create_object_for_type(property, environment, types);
 					inner_object.append(
 						environment,
-						key,
-						crate::Property::Value(value),
 						PublicityKind::Public,
+						key,
+						crate::PropertyValue::Value(value),
 						None,
 					);
 				}
 
 				obj.append(
 					environment,
-					types.new_constant_type(Constant::String("properties".into())),
-					crate::Property::Value(inner_object.build_object()),
 					PublicityKind::Public,
+					PropertyKey::String("properties".into()),
+					crate::PropertyValue::Value(inner_object.build_object()),
 					None,
 				);
 			}
@@ -87,24 +87,23 @@ pub(crate) fn create_object_for_type(
 		Type::Constant(_) => {
 			obj.append(
 				environment,
-				types.new_constant_type(Constant::String("constant".into())),
-				crate::Property::Value(ty),
 				PublicityKind::Public,
+				PropertyKey::String("constant".into()),
+				crate::PropertyValue::Value(ty),
 				None,
 			);
 		}
 		Type::Function(_, _) => todo!(),
 		Type::FunctionReference(_, _) => todo!(),
-		Type::Class(_) => todo!(),
 		Type::Object(_) => {
-			let value = crate::Property::Value(
+			let value = crate::PropertyValue::Value(
 				types.new_constant_type(Constant::String("anonymous object".into())),
 			);
 			obj.append(
 				environment,
-				types.new_constant_type(Constant::String("kind".into())),
-				value,
 				PublicityKind::Public,
+				PropertyKey::String("kind".into()),
+				value,
 				None,
 			);
 
@@ -112,22 +111,22 @@ pub(crate) fn create_object_for_type(
 			let mut inner_object = ObjectBuilder::new(None, types, &mut environment.facts);
 
 			// let properties = env.create_array();
-			for (key, _, property) in environment.get_properties_on_type(ty) {
+			for (_, key, property) in environment.get_properties_on_type(ty) {
 				let value = create_object_for_type(property, environment, types);
 				inner_object.append(
 					environment,
-					key,
-					crate::Property::Value(value),
 					PublicityKind::Public,
+					key,
+					crate::PropertyValue::Value(value),
 					None,
 				);
 			}
 
 			obj.append(
 				environment,
-				types.new_constant_type(Constant::String("properties".into())),
-				crate::Property::Value(inner_object.build_object()),
 				PublicityKind::Public,
+				PropertyKey::String("properties".into()),
+				crate::PropertyValue::Value(inner_object.build_object()),
 				None,
 			);
 		}

--- a/checker/src/types/poly_types/generics/generic_type_arguments.rs
+++ b/checker/src/types/poly_types/generics/generic_type_arguments.rs
@@ -65,6 +65,7 @@ pub(crate) struct FunctionTypeArguments {
 	pub local_arguments: SmallMap<TypeId, (TypeId, SpanWithSource)>,
 	pub closure_id: Option<ClosureId>,
 }
+
 impl FunctionTypeArguments {
 	pub(crate) fn set_id_from_reference(
 		&mut self,
@@ -151,6 +152,30 @@ impl TypeArgumentStore for FunctionTypeArguments {
 
 	fn is_empty(&self) -> bool {
 		self.closure_id.is_none() && self.local_arguments.len() == 0
+	}
+}
+
+// TODO temp: for type alias specialisation
+impl TypeArgumentStore for SmallMap<TypeId, (TypeId, SpanWithSource)> {
+	fn get_structure_argument(&self, id: TypeId) -> Option<TypeId> {
+		self.get(&id).map(|(value, pos)| *value)
+	}
+
+	fn get_local_argument(&self, id: TypeId) -> Option<TypeId> {
+		// ???
+		self.get_structure_argument(id)
+	}
+
+	fn get_structural_closures(&self) -> Option<Vec<ClosureId>> {
+		None
+	}
+
+	fn into_structural_generic_arguments(&self) -> StructureGenericArguments {
+		todo!("This shouldn't be needed");
+	}
+
+	fn is_empty(&self) -> bool {
+		false
 	}
 }
 

--- a/checker/src/types/poly_types/generics/mod.rs
+++ b/checker/src/types/poly_types/generics/mod.rs
@@ -17,7 +17,7 @@ pub(crate) struct UnmatchedGenericsError;
 
 /// When comparing parameters to arguments this sets type arguments
 pub(crate) struct SeedingContext {
-	/// usize = parameter position
+	/// usize = argument position
 	pub type_arguments: map_vec::Map<TypeId, Vec<(TypeId, SpanWithSource, usize)>>,
 	/// Produced by explicit call site type arguments (TODO explain) and function parameters (TODO explain)
 	pub type_restrictions: map_vec::Map<TypeId, Vec<(TypeId, SpanWithSource)>>,
@@ -60,6 +60,7 @@ impl SeedingContext {
 
 	/// TODO remove
 	pub(crate) fn set_this(&mut self, arg: TypeId) {
-		self.type_arguments.insert(TypeId::THIS_ARG, vec![(arg, SpanWithSource::NULL_SPAN, 0)]);
+		self.type_arguments
+			.insert(TypeId::ANY_INFERRED_FREE_THIS, vec![(arg, SpanWithSource::NULL_SPAN, 0)]);
 	}
 }

--- a/checker/src/types/poly_types/substitution.rs
+++ b/checker/src/types/poly_types/substitution.rs
@@ -6,7 +6,7 @@ use crate::{
 		operations::{evaluate_equality_inequality_operation, evaluate_mathematical_operation},
 	},
 	types::{is_type_truthy_falsy, Constructor, PolyNature, StructureGenerics, Type, TypeStore},
-	Environment, TruthyFalsy, TypeId,
+	Decidable, Environment, TypeId,
 };
 
 use super::generic_type_arguments::{StructureGenericArguments, TypeArgumentStore};
@@ -65,7 +65,7 @@ pub(crate) fn substitute(
 				let lhs = substitute(lhs, arguments, environment, types);
 				let rhs = substitute(rhs, arguments, environment, types);
 
-				evaluate_mathematical_operation(lhs, operator, rhs, types)
+				evaluate_mathematical_operation(lhs, operator, rhs, types, false)
 					.expect("restriction about binary operator failed")
 			}
 			Constructor::UnaryOperator { operand, operator, .. } => {
@@ -110,7 +110,7 @@ pub(crate) fn substitute(
 				// 	)
 				// );
 
-				if let TruthyFalsy::Decidable(result) = is_type_truthy_falsy(condition, types) {
+				if let Decidable::Known(result) = is_type_truthy_falsy(condition, types) {
 					if result {
 						substitute(truthy_result, arguments, environment, types)
 					} else {
@@ -132,7 +132,7 @@ pub(crate) fn substitute(
 				}
 			}
 			Constructor::Property { .. } | Constructor::FunctionResult { .. } => {
-				unreachable!("this should have covered by event specialization");
+				unreachable!("this should have covered by event specialisation");
 
 				// let on = substitute(on, arguments, environment);
 
@@ -188,7 +188,7 @@ pub(crate) fn substitute(
 			// 	let prototype = substitute(prototype, arguments, environment, types);
 			// 	if let Type::AliasTo { to, .. } = types.get_type_by_id(prototype) {
 			// 		crate::utils::notify!(
-			// 			"TODO temp might have to do more here when specializing a prototype"
+			// 			"TODO temp might have to do more here when specialising a prototype"
 			// 		);
 			// 		*to
 			// 	} else {
@@ -207,7 +207,7 @@ pub(crate) fn substitute(
 				let lhs = substitute(lhs, arguments, environment, types);
 				let rhs = substitute(rhs, arguments, environment, types);
 
-				evaluate_equality_inequality_operation(lhs, operator, rhs, types)
+				evaluate_equality_inequality_operation(lhs, operator, rhs, types, false)
 					.expect("restriction about binary operator failed")
 			}
 			Constructor::TypeOperator(..) => todo!(),

--- a/checker/src/types/printing.rs
+++ b/checker/src/types/printing.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use super::{properties::PropertyKey, PolyNature, Type, TypeId, TypeStore};
 use crate::{
-	context::{facts::PublicityKind, get_on_ctx},
+	context::{facts::Publicity, get_on_ctx},
 	types::{Constructor, StructureGenerics},
 	Constant, GeneralContext,
 };
@@ -267,7 +267,7 @@ fn print_type_into_buf(
 			buf.push_str("{ ");
 			let properties = get_on_ctx!(ctx.get_properties_on_type(id));
 			for (not_at_end, (publicity, key, value)) in properties.into_iter().nendiate() {
-				if let PublicityKind::Private = publicity {
+				if let Publicity::Private = publicity {
 					buf.push('#');
 				}
 				print_property_key_into_buf(buf, &key, cycles, types, ctx, debug);

--- a/checker/src/types/printing.rs
+++ b/checker/src/types/printing.rs
@@ -1,10 +1,11 @@
+use iterator_endiate::EndiateIteratorExt;
 use std::collections::HashSet;
 
-use super::{PolyNature, Type, TypeId, TypeStore};
+use super::{properties::PropertyKey, PolyNature, Type, TypeId, TypeStore};
 use crate::{
 	context::{facts::PublicityKind, get_on_ctx},
 	types::{Constructor, StructureGenerics},
-	GeneralContext,
+	Constant, GeneralContext,
 };
 
 /// TODO temp, needs recursion safe, reuse buffer
@@ -13,125 +14,134 @@ pub fn print_type(id: TypeId, types: &TypeStore, ctx: &GeneralContext, debug: bo
 	print_type_into_buf(id, &mut buf, &mut HashSet::new(), types, ctx, debug);
 
 	return buf;
+}
 
-	fn print_type_into_buf(
-		id: TypeId,
-		buf: &mut String,
-		cycles: &mut HashSet<TypeId>,
-		types: &TypeStore,
-		ctx: &GeneralContext,
-		debug: bool,
-	) {
-		use std::fmt::Write;
+fn print_type_into_buf(
+	id: TypeId,
+	buf: &mut String,
+	cycles: &mut HashSet<TypeId>,
+	types: &TypeStore,
+	ctx: &GeneralContext,
+	debug: bool,
+) {
+	use std::fmt::Write;
 
-		let not_in_cycle = cycles.insert(id);
-		if !not_in_cycle {
-			buf.push_str("cyclic");
-			return;
+	let not_in_cycle = cycles.insert(id);
+	if !not_in_cycle {
+		buf.push_str("cyclic");
+		return;
+	}
+
+	let ty = types.get_type_by_id(id);
+	match ty {
+		Type::AliasTo { to, name, parameters } => {
+			buf.push_str(name);
 		}
-
-		let ty = types.get_type_by_id(id);
-		match ty {
-			Type::AliasTo { to, name, parameters } => {
-				buf.push_str(name);
+		Type::And(a, b) => {
+			print_type_into_buf(*a, buf, cycles, types, ctx, debug);
+			buf.push_str(" & ");
+			print_type_into_buf(*b, buf, cycles, types, ctx, debug);
+		}
+		Type::Or(a, b) => {
+			print_type_into_buf(*a, buf, cycles, types, ctx, debug);
+			buf.push_str(" | ");
+			print_type_into_buf(*b, buf, cycles, types, ctx, debug);
+		}
+		Type::RootPolyType(nature) => match nature {
+			PolyNature::Generic { name, eager_fixed } => {
+				if debug {
+					// TODO restriction
+					write!(buf, "[generic {} {}, fixed to ", name, id.0).unwrap();
+					print_type_into_buf(*eager_fixed, buf, cycles, types, ctx, debug);
+					buf.push(']');
+				} else {
+					buf.push_str(name);
+				}
 			}
-			Type::And(a, b) => {
-				print_type_into_buf(*a, buf, cycles, types, ctx, debug);
-				buf.push_str(" & ");
-				print_type_into_buf(*b, buf, cycles, types, ctx, debug);
+			PolyNature::FreeVariable { based_on: to, reference, .. } => {
+				if debug {
+					let name = reference.get_name(ctx);
+					// FV = free variable
+					write!(buf, "[FV {} {}]", name, id.0).unwrap();
+				}
+				print_type_into_buf(*to, buf, cycles, types, ctx, debug);
 			}
-			Type::Or(a, b) => {
-				print_type_into_buf(*a, buf, cycles, types, ctx, debug);
-				buf.push_str(" | ");
-				print_type_into_buf(*b, buf, cycles, types, ctx, debug);
+			PolyNature::Parameter { fixed_to: to } => {
+				if debug {
+					write!(buf, "[param {}]", id.0).unwrap();
+				}
+				print_type_into_buf(*to, buf, cycles, types, ctx, debug);
 			}
-			Type::RootPolyType(nature) => match nature {
-				PolyNature::Generic { name, eager_fixed } => {
-					if debug {
-						// TODO restriction
-						write!(buf, "[generic {} {}, fixed to ", name, id.0).unwrap();
-						print_type_into_buf(*eager_fixed, buf, cycles, types, ctx, debug);
-						buf.push(']');
-					} else {
-						buf.push_str(name);
-					}
+			PolyNature::Open(to) => {
+				if debug {
+					write!(buf, "[open {}]", id.0).unwrap();
 				}
-				PolyNature::FreeVariable { based_on: to, reference, .. } => {
-					if debug {
-						let name = reference.get_name(ctx);
-						// FV = free variable
-						write!(buf, "[FV {} {}]", name, id.0).unwrap();
-					}
-					print_type_into_buf(*to, buf, cycles, types, ctx, debug);
+				print_type_into_buf(*to, buf, cycles, types, ctx, debug);
+			}
+			nature => {
+				todo!()
+				// let modified_base = match env {
+				// 	GeneralContext::Syntax(syn) => {
+				// 		syn.parents_iter().find_map(|env| get_on_ctx!(env.bases.get(&id)).copied())
+				// 	}
+				// 	GeneralContext::Root(root) => root.bases.get(&id).copied(),
+				// };
+			}
+		},
+		// TODO these can vary
+		Type::Constructor(constructor) => match constructor {
+			Constructor::ConditionalResult {
+				condition,
+				truthy_result,
+				else_result,
+				result_union,
+			} => {
+				if debug {
+					write!(buf, "[? {:? }", id).unwrap();
+					print_type_into_buf(*condition, buf, cycles, types, ctx, debug);
+					buf.push(']');
 				}
-				PolyNature::Parameter { fixed_to: to } => {
-					if debug {
-						write!(buf, "[param {}]", id.0).unwrap();
-					}
-					print_type_into_buf(*to, buf, cycles, types, ctx, debug);
+				print_type_into_buf(*truthy_result, buf, cycles, types, ctx, debug);
+				buf.push_str(if debug { " : " } else { " | " });
+				print_type_into_buf(*else_result, buf, cycles, types, ctx, debug);
+			}
+			Constructor::StructureGenerics(StructureGenerics { on, arguments }) => {
+				if debug {
+					buf.push_str("SG (");
+					print_type_into_buf(*on, buf, cycles, types, ctx, debug);
+					buf.push(')');
+				} else {
+					print_type_into_buf(*on, buf, cycles, types, ctx, debug);
 				}
-				PolyNature::Open(to) => {
-					if debug {
-						write!(buf, "[open {}]", id.0).unwrap();
-					}
-					print_type_into_buf(*to, buf, cycles, types, ctx, debug);
+				if debug && !arguments.closures.is_empty() {
+					write!(buf, " [closures {:?}]", arguments.closures).unwrap();
 				}
-				nature => {
-					todo!()
-					// let modified_base = match env {
-					// 	GeneralContext::Syntax(syn) => {
-					// 		syn.parents_iter().find_map(|env| get_on_ctx!(env.bases.get(&id)).copied())
-					// 	}
-					// 	GeneralContext::Root(root) => root.bases.get(&id).copied(),
-					// };
-				}
-			},
-			// TODO these can vary
-			Type::Constructor(constructor) => match constructor {
-				Constructor::ConditionalResult {
-					condition: on,
-					truthy_result: true_result,
-					else_result: false_result,
-					result_union,
-				} => {
-					if debug {
-						print_type_into_buf(*on, buf, cycles, types, ctx, debug);
-						buf.push_str(" ? ");
-					}
-					print_type_into_buf(*true_result, buf, cycles, types, ctx, debug);
-					buf.push_str(if debug { " : " } else { " | " });
-					print_type_into_buf(*false_result, buf, cycles, types, ctx, debug);
-				}
-				Constructor::StructureGenerics(StructureGenerics { on, arguments }) => {
-					if debug {
-						buf.push('(');
-						print_type_into_buf(*on, buf, cycles, types, ctx, debug);
-						buf.push(')');
-					} else {
-						print_type_into_buf(*on, buf, cycles, types, ctx, debug);
-					}
-					if debug && !arguments.closures.is_empty() {
-						write!(buf, " [closures {:?}]", arguments.closures).unwrap();
-					}
+				if matches!(
+					types.get_type_by_id(*on),
+					Type::NamedRooted { .. } | Type::Function { .. }
+				) {
 					if !arguments.type_arguments.is_empty() {
 						// TODO might be out of order ...
 						buf.push('<');
-						for (arg, _) in arguments.type_arguments.values() {
+						for (not_at_end, (arg, _)) in arguments.type_arguments.values().nendiate() {
 							print_type_into_buf(*arg, buf, cycles, types, ctx, debug);
-							buf.push_str(", ");
+							if not_at_end {
+								buf.push_str(", ")
+							}
 						}
 						buf.push('>');
 					}
 				}
-				constructor if debug => match constructor {
-					Constructor::BinaryOperator { lhs, operator, rhs } => {
-						print_type_into_buf(*lhs, buf, cycles, types, ctx, debug);
-						buf.push_str(" + ");
-						print_type_into_buf(*rhs, buf, cycles, types, ctx, debug);
-					}
-					Constructor::CanonicalRelationOperator { lhs, operator, rhs } => {
-						print_type_into_buf(*lhs, buf, cycles, types, ctx, debug);
-						match operator {
+			}
+			constructor if debug => match constructor {
+				Constructor::BinaryOperator { lhs, operator, rhs } => {
+					print_type_into_buf(*lhs, buf, cycles, types, ctx, debug);
+					buf.push_str(" + ");
+					print_type_into_buf(*rhs, buf, cycles, types, ctx, debug);
+				}
+				Constructor::CanonicalRelationOperator { lhs, operator, rhs } => {
+					print_type_into_buf(*lhs, buf, cycles, types, ctx, debug);
+					match operator {
 							crate::behavior::operations::CanonicalEqualityAndInequality::StrictEqual => {
 								buf.push_str(" === ");
 							}
@@ -139,147 +149,195 @@ pub fn print_type(id: TypeId, types: &TypeStore, ctx: &GeneralContext, debug: bo
 								buf.push_str(" > ");
 							}
 						}
-						print_type_into_buf(*rhs, buf, cycles, types, ctx, debug);
-					}
-					Constructor::UnaryOperator { operator, operand } => todo!(),
-					Constructor::TypeOperator(_) => todo!(),
-					Constructor::TypeRelationOperator(_) => todo!(),
-					Constructor::FunctionResult { on, with, result } => {
-						// TODO arguments and stuff
-						buf.push_str("[func result] ");
-						print_type_into_buf(*result, buf, cycles, types, ctx, debug);
-					}
-					Constructor::Property { on, under } => {
-						print_type_into_buf(*on, buf, cycles, types, ctx, debug);
-						buf.push('[');
-						print_type_into_buf(*under, buf, cycles, types, ctx, debug);
-						buf.push(']');
-					}
-					Constructor::StructureGenerics { .. }
-					| Constructor::ConditionalResult { .. } => {
-						unreachable!()
-					}
-				},
-				constructor => {
-					let base = get_on_ctx!(ctx.get_poly_base(id, types)).unwrap();
-					print_type_into_buf(base, buf, cycles, types, ctx, debug)
+					print_type_into_buf(*rhs, buf, cycles, types, ctx, debug);
+				}
+				Constructor::UnaryOperator { operator, operand } => todo!(),
+				Constructor::TypeOperator(_) => todo!(),
+				Constructor::TypeRelationOperator(_) => todo!(),
+				Constructor::FunctionResult { on, with, result } => {
+					// TODO arguments and stuff
+					buf.push_str("[func result] ");
+					print_type_into_buf(*result, buf, cycles, types, ctx, debug);
+				}
+				Constructor::Property { on, under, result: _ } => {
+					print_type_into_buf(*on, buf, cycles, types, ctx, debug);
+					buf.push('[');
+					print_property_key_into_buf(buf, under, cycles, types, ctx, debug);
+					buf.push(']');
+				}
+				Constructor::StructureGenerics { .. } | Constructor::ConditionalResult { .. } => {
+					unreachable!()
 				}
 			},
-			Type::NamedRooted { name, parameters, nominal } => {
-				if debug {
-					write!(buf, "(r{} nom={:?}) {name}", id.0, nominal).unwrap();
-				} else {
-					buf.push_str(name)
+			constructor => {
+				let base = get_on_ctx!(ctx.get_poly_base(id, types)).unwrap();
+				print_type_into_buf(base, buf, cycles, types, ctx, debug)
+			}
+		},
+		Type::NamedRooted { name, parameters, nominal } => {
+			if debug {
+				write!(buf, "(r{} nom={:?}) {name}", id.0, nominal).unwrap();
+			// buf.push_str("{ ");
+			// let properties = get_on_ctx!(ctx.get_properties_on_type(id));
+			// for (not_at_end, (publicity, key, value)) in properties.into_iter().nendiate() {
+			// 	if let PublicityKind::Private = publicity {
+			// 		buf.push('#');
+			// 	}
+			// 	print_property_key_into_buf(buf, &key, cycles, types, ctx, debug);
+			// 	buf.push_str(": ");
+			// 	print_type_into_buf(value, buf, cycles, types, ctx, debug);
+			// 	if not_at_end {
+			// 		buf.push_str(", ");
+			// 	}
+			// }
+			// buf.push_str(" }")
+			} else {
+				buf.push_str(name)
+			}
+			if let (true, Some(parameters)) = (debug, parameters) {
+				buf.push('<');
+				for param in parameters {
+					print_type_into_buf(*param, buf, cycles, types, ctx, debug);
+					buf.push_str(", ");
 				}
-				if let (true, Some(parameters)) = (debug, parameters) {
-					buf.push('<');
-					for param in parameters {
-						print_type_into_buf(*param, buf, cycles, types, ctx, debug);
-						buf.push_str(", ");
+				buf.push('>')
+			}
+		}
+		Type::Constant(cst) => {
+			if debug {
+				write!(buf, "({}) {}", id.0, cst.as_type_name()).unwrap();
+			} else {
+				buf.push_str(&cst.as_type_name());
+			}
+		}
+		Type::FunctionReference(func_id, this_ty) | Type::Function(func_id, this_ty) => {
+			let func = types.functions.get(func_id).unwrap();
+			if debug {
+				write!(
+					buf,
+					"[func {}, fvs {:?}, co {:?}, this {:?}, const {:?}] ",
+					id.0,
+					func.free_variables,
+					func.closed_over_variables,
+					this_ty,
+					func.constant_function.as_deref().unwrap_or("-")
+				)
+				.unwrap();
+			}
+			if let Some(ref parameters) = func.type_parameters {
+				buf.push('<');
+				for (not_at_end, param) in parameters.0.iter().nendiate() {
+					buf.push_str(&param.name);
+					// if param.constraint != TypeId::ANY_TYPE {
+					// 	// TODO `extends keyof` visual compat
+					// 	buf.push_str(" extends ");
+					// 	// let ty = memory.get_fixed_constraint(constraint);
+					// 	// TypeDisplay::fmt(ty, buf, indent, cycles, memory);
+					// }
+					if let Some(ref default) = param.default {
+						todo!()
 					}
-					buf.push('>')
-				}
-			}
-			Type::Constant(cst) => {
-				if debug {
-					write!(buf, "({}) {}", id.0, cst.as_type_name()).unwrap();
-				} else {
-					buf.push_str(&cst.as_type_name());
-				}
-			}
-			f @ Type::FunctionReference(func_id, this_ty)
-			| f @ Type::Function(func_id, this_ty) => {
-				let func = types.functions.get(func_id).unwrap();
-				if debug {
-					write!(
-						buf,
-						"[func {}/{:?}, uses {:?}, closes over {:?}, this {:?}, const {:?}]",
-						id.0,
-						func_id,
-						func.free_variables,
-						func.closed_over_variables,
-						this_ty,
-						func.constant_id
-					)
-					.unwrap();
-				}
-				if let Some(ref parameters) = func.type_parameters {
-					buf.push('<');
-					for param in parameters.0.iter() {
-						buf.push_str(&param.name);
-						// if param.constraint != TypeId::ANY_TYPE {
-						// 	// TODO `extends keyof` visual compat
-						// 	buf.push_str(" extends ");
-						// 	// let ty = memory.get_fixed_constraint(constraint);
-						// 	// TypeDisplay::fmt(ty, buf, indent, cycles, memory);
-						// }
-						if let Some(ref default) = param.default {
-							todo!()
-						}
+					if not_at_end {
 						buf.push_str(", ")
 					}
-					buf.push('>');
 				}
-				buf.push('(');
-				for param in func.parameters.parameters.iter() {
-					buf.push_str(&param.name);
-					buf.push_str(": ");
-					print_type_into_buf(param.ty, buf, cycles, types, ctx, debug);
+				buf.push('>');
+			}
+			buf.push('(');
+			for (not_at_end, param) in func.parameters.parameters.iter().nendiate() {
+				buf.push_str(&param.name);
+				buf.push_str(": ");
+				print_type_into_buf(param.ty, buf, cycles, types, ctx, debug);
+				if not_at_end {
+					buf.push_str(", ")
+				}
+			}
+			buf.push_str(") => ");
+			print_type_into_buf(func.return_type, buf, cycles, types, ctx, debug);
+		}
+		Type::Object(..) => {
+			if debug {
+				write!(buf, "[obj {}]", id.0).unwrap();
+			}
+			if let Some(prototype) = get_on_ctx!(ctx.facts.prototypes.get(&id)) {
+				buf.push('[');
+				print_type_into_buf(*prototype, buf, cycles, types, ctx, debug);
+				buf.push_str("] ");
+			}
+			buf.push_str("{ ");
+			let properties = get_on_ctx!(ctx.get_properties_on_type(id));
+			for (not_at_end, (publicity, key, value)) in properties.into_iter().nendiate() {
+				if let PublicityKind::Private = publicity {
+					buf.push('#');
+				}
+				print_property_key_into_buf(buf, &key, cycles, types, ctx, debug);
+				buf.push_str(": ");
+				print_type_into_buf(value, buf, cycles, types, ctx, debug);
+				if not_at_end {
 					buf.push_str(", ");
 				}
-				buf.push_str(") => ");
-				print_type_into_buf(func.return_type, buf, cycles, types, ctx, debug);
 			}
-			Type::Object(..) => {
-				if debug {
-					write!(buf, "[obj {}]", id.0).unwrap();
-				}
-				if let Some(prototype) = get_on_ctx!(ctx.facts.prototypes.get(&id)) {
-					buf.push('[');
-					print_type_into_buf(*prototype, buf, cycles, types, ctx, debug);
-					buf.push_str("] ");
-				}
-				buf.push('{');
-				for (key, publicity, value) in get_on_ctx!(ctx.get_properties_on_type(id)) {
-					if let PublicityKind::Private = publicity {
-						buf.push('#');
-					}
-					print_type_into_buf(key, buf, cycles, types, ctx, debug);
+			buf.push_str(" }");
+		}
+		Type::SpecialObject(special_object) => match special_object {
+			crate::behavior::objects::SpecialObjects::Promise { events } => todo!(),
+			crate::behavior::objects::SpecialObjects::Generator { position } => todo!(),
+			crate::behavior::objects::SpecialObjects::Proxy { handler, over } => {
+				// Copies from node behavior
+				buf.push_str("Proxy [ ");
+				print_type_into_buf(*over, buf, cycles, types, ctx, debug);
+				buf.push_str(", ");
+				print_type_into_buf(*handler, buf, cycles, types, ctx, debug);
+				buf.push_str(" ]");
+			}
+			crate::behavior::objects::SpecialObjects::Import(exports) => {
+				buf.push_str("{ ");
+				for (not_at_end, (key, (variable, mutability))) in exports.named.iter().nendiate() {
+					buf.push_str(key);
 					buf.push_str(": ");
-					print_type_into_buf(value, buf, cycles, types, ctx, debug);
-					buf.push_str(", ");
-				}
-				buf.push('}');
-			}
-			Type::Class(..) => todo!("name"),
-			Type::SpecialObject(special_object) => match special_object {
-				crate::behavior::objects::SpecialObjects::Promise { events } => todo!(),
-				crate::behavior::objects::SpecialObjects::Generator { position } => todo!(),
-				crate::behavior::objects::SpecialObjects::Proxy { handler, over } => todo!(),
-				crate::behavior::objects::SpecialObjects::Import(exports) => {
-					buf.push('{');
-					for (key, (variable, mutability)) in exports.named.iter() {
-						buf.push('"');
-						buf.push_str(key);
-						buf.push_str("\": ");
-						match mutability {
-							crate::behavior::variables::VariableMutability::Constant => {
-								let value = get_on_ctx!(
-									ctx.get_value_of_constant_import_variable(*variable)
-								);
-								print_type_into_buf(value, buf, cycles, types, ctx, debug);
-							}
-							crate::behavior::variables::VariableMutability::Mutable {
-								reassignment_constraint,
-							} => todo!(),
-						};
+					match mutability {
+						crate::behavior::variables::VariableMutability::Constant => {
+							let value =
+								get_on_ctx!(ctx.get_value_of_constant_import_variable(*variable));
+							print_type_into_buf(value, buf, cycles, types, ctx, debug);
+						}
+						crate::behavior::variables::VariableMutability::Mutable {
+							reassignment_constraint,
+						} => todo!(),
+					};
+					if not_at_end {
 						buf.push_str(", ");
 					}
-					buf.push('}');
 				}
-			},
-		}
+				buf.push_str(" }");
+			}
+		},
+	}
 
-		cycles.remove(&id);
+	cycles.remove(&id);
+}
+
+pub fn print_property_key(
+	key: &PropertyKey,
+	types: &TypeStore,
+	ctx: &GeneralContext,
+	debug: bool,
+) -> String {
+	let mut string = String::new();
+	print_property_key_into_buf(&mut string, key, &mut HashSet::new(), types, ctx, debug);
+	string
+}
+
+pub(crate) fn print_property_key_into_buf(
+	buf: &mut String,
+	key: &PropertyKey,
+	cycles: &mut HashSet<TypeId>,
+	types: &TypeStore,
+	ctx: &GeneralContext,
+	debug: bool,
+) {
+	match key {
+		PropertyKey::String(s) => buf.push_str(s),
+		PropertyKey::Type(t) => print_type_into_buf(*t, buf, cycles, types, ctx, debug),
 	}
 }

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::{
 	behavior::functions::ThisValue,
-	context::{facts::PublicityKind, CallCheckingBehavior, Logical, SetPropertyError},
+	context::{facts::Publicity, CallCheckingBehavior, Logical, SetPropertyError},
 	events::Event,
 	subtyping::{type_is_subtype, SubTypeResult},
 	types::{printing::print_type, substitute, FunctionType, StructureGenerics},
@@ -122,7 +122,7 @@ impl PropertyValue {
 /// types at some point*
 pub(crate) fn get_property<'a, E: CallCheckingBehavior>(
 	on: TypeId,
-	publicity: PublicityKind,
+	publicity: Publicity,
 	under: PropertyKey,
 	with: Option<TypeId>,
 	environment: &mut Environment,
@@ -189,7 +189,7 @@ pub(crate) fn get_property<'a, E: CallCheckingBehavior>(
 
 fn get_from_an_object<'a, E: CallCheckingBehavior>(
 	on: TypeId,
-	publicity: PublicityKind,
+	publicity: Publicity,
 	under: PropertyKey,
 	environment: &mut Environment,
 	behavior: &mut E,
@@ -308,7 +308,7 @@ fn get_from_an_object<'a, E: CallCheckingBehavior>(
 fn evaluate_get_on_poly<'a, E: CallCheckingBehavior>(
 	constraint: TypeId,
 	on: TypeId,
-	publicity: PublicityKind,
+	publicity: Publicity,
 	under: PropertyKey,
 	with: Option<TypeId>,
 	environment: &mut Environment,
@@ -394,9 +394,11 @@ fn evaluate_get_on_poly<'a, E: CallCheckingBehavior>(
 					None
 				}
 			}
-			Logical::Implies { on, antecedent } => {
+			Logical::Implies { on: a, antecedent } => {
 				todo!()
-				// Some(substitute(*on, &mut antecedent.type_arguments, environment, types))
+				// TODO pass down argument instead ...
+				// let a = get_property_from_logical(*a, types, on, under.clone())?;
+				// Some(substitute(*a, &mut antecedent.type_arguments, environment, types))
 			}
 		}
 	}
@@ -409,7 +411,7 @@ fn evaluate_get_on_poly<'a, E: CallCheckingBehavior>(
 /// Evaluates setters
 pub(crate) fn set_property<'a, E: CallCheckingBehavior>(
 	on: TypeId,
-	publicity: PublicityKind,
+	publicity: Publicity,
 	under: PropertyKey,
 	new: PropertyValue,
 	environment: &mut Environment,

--- a/checker/src/types/store.rs
+++ b/checker/src/types/store.rs
@@ -22,7 +22,7 @@ pub struct TypeStore {
 	// TODO merge into type
 	// pub(crate) functions_on_type: HashMap<TypeId, FunctionType>,
 	// pub(crate) proxies: HashMap<TypeId, Proxy>,
-	pub(crate) specializations: HashMap<TypeId, Vec<TypeId>>,
+	pub(crate) specialisations: HashMap<TypeId, Vec<TypeId>>,
 
 	/// TODO not best place	but is passed through everything so
 	pub(crate) closure_counter: u32,
@@ -89,7 +89,7 @@ impl Default for TypeStore {
 			types: types.to_vec(),
 			functions: HashMap::new(),
 			dependent_dependencies: Default::default(),
-			specializations: Default::default(),
+			specialisations: Default::default(),
 			closure_counter: 0,
 		}
 	}

--- a/checker/src/types/store.rs
+++ b/checker/src/types/store.rs
@@ -130,19 +130,6 @@ impl TypeStore {
 		&self.types[id.0 as usize]
 	}
 
-	pub fn new_any_parameter<S: ContextType>(&mut self, environment: &mut Context<S>) -> TypeId {
-		// if let GeneralContext::Syntax(env) = environment.into_general_context() {
-		// 	// TODO not sure about this:
-		// 	if environment.context_type.is_dynamic_boundary() {
-		// 		crate::utils::notify!("TODO is context different in the param synthesis?");
-
-		// 		environment.bases.mutable_bases.insert(id, (inference_boundary, TypeId::ANY_TYPE));
-		// 		return id;
-		// 	}
-		// }
-		TypeId::ANY_TYPE
-	}
-
 	pub fn new_or_type(&mut self, lhs: TypeId, rhs: TypeId) -> TypeId {
 		let ty = Type::Or(lhs, rhs);
 		self.register_type(ty)

--- a/src/js-cli-and-library/README.md
+++ b/src/js-cli-and-library/README.md
@@ -21,7 +21,7 @@ import { build } from "ezno/initialised";
 
 // Just use a local string. Could use readFileSync for FS access
 const fs_handler = (_path) => "const x = !t ? 4 : 5;";
-console.dir(build(fs_handler, "input.js"), { depth: 5 })
+console.dir(build("input.js", fs_handler), { depth: 5 })
 ```
 
 For the web, `init()` is needed to load the WASM before calling any functions.
@@ -31,7 +31,7 @@ import { init, build } from "ezno";
 
 await init();
 
-const res = build(() => "const x = 2 + 5;", "input.js");
+const res = build("input.js", () => "const x = 2 + 5;");
 
 document.querySelector('#app').innerHTML = `<pre>${JSON.stringify(res)}</pre>`;
 ```

--- a/src/js-cli-and-library/test.mjs
+++ b/src/js-cli-and-library/test.mjs
@@ -9,7 +9,7 @@ buildTest()
 
 function checkTest() {
 	const example = "const x: 4 = 2;"
-	const output = check((_path) => example, "input.js");
+	const output = check("input.js", (_path) => example);
 	deepStrictEqual(output, [
 		{
 			type: "PositionWithAdditionLabels",

--- a/src/wasm_bindings.rs
+++ b/src/wasm_bindings.rs
@@ -8,7 +8,7 @@ extern "C" {
 }
 
 #[wasm_bindgen(js_name = build)]
-pub fn build_wasm(fs_resolver_js: &js_sys::Function, entry_path: String, minify: bool) -> JsValue {
+pub fn build_wasm(entry_path: String, fs_resolver_js: &js_sys::Function, minify: bool) -> JsValue {
 	std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
 	let fs_resolver = |path: &std::path::Path| {
@@ -28,7 +28,7 @@ pub fn build_wasm(fs_resolver_js: &js_sys::Function, entry_path: String, minify:
 }
 
 #[wasm_bindgen(js_name = check)]
-pub fn check_wasm(fs_resolver_js: &js_sys::Function, entry_path: String) -> JsValue {
+pub fn check_wasm(entry_path: String, fs_resolver_js: &js_sys::Function) -> JsValue {
 	std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
 	let fs_resolver = |path: &std::path::Path| {


### PR DESCRIPTION
- Adds support for classes (some of it ATM)
- Adds expected_value (not hooked up to anything yet)
- Adds function behavior and function scopes (improves the handling of `this`)
- Property keys are no longer always `TypeId`. New `Cow<str> | TypeId` produces less types, improves property handling and overall less overhead (🏇)
- `Object.getPrototypeOf` and `Object.setPrototypeOf`
- `in` and `delete` property additions
- `Array.prototype.pop()`
- Improved structure of calling (not fully)

Overall takes passing specification tests from 85 to 105!!!!