### PR TITLE
[Feat] Adding `export type { ... } from '...'` support

### DIFF
--- a/checker/src/synthesis/block.rs
+++ b/checker/src/synthesis/block.rs
@@ -150,6 +150,7 @@ pub(crate) fn synthesize_declaration<T: crate::ReadFromFS>(
 					);
 				}
 			}
+			parser::declarations::ExportDeclaration::Type { .. } => {}
 		},
 	}
 }

--- a/checker/src/synthesis/block.rs
+++ b/checker/src/synthesis/block.rs
@@ -150,7 +150,6 @@ pub(crate) fn synthesize_declaration<T: crate::ReadFromFS>(
 					);
 				}
 			}
-			parser::declarations::ExportDeclaration::Type { .. } => {}
 		},
 	}
 }

--- a/checker/src/synthesis/hoisting.rs
+++ b/checker/src/synthesis/hoisting.rs
@@ -337,7 +337,8 @@ pub(crate) fn hoist_statements<T: crate::ReadFromFS>(
 							| Exportable::ImportParts { .. } => {}
 						}
 					}
-					parser::declarations::ExportDeclaration::Default { .. } => {}
+					parser::declarations::ExportDeclaration::Type { .. }
+					| parser::declarations::ExportDeclaration::Default { .. } => {}
 				},
 			},
 		}

--- a/checker/src/synthesis/hoisting.rs
+++ b/checker/src/synthesis/hoisting.rs
@@ -143,7 +143,7 @@ pub(crate) fn hoist_statements<T: crate::ReadFromFS>(
 									);
 								}
 							}
-							Exportable::ImportParts { parts, from } => {
+							Exportable::ImportParts { parts, from, .. } => {
 								let parts =
 									parts.iter().filter_map(|item| export_part_to_name_pair(item));
 
@@ -337,8 +337,7 @@ pub(crate) fn hoist_statements<T: crate::ReadFromFS>(
 							| Exportable::ImportParts { .. } => {}
 						}
 					}
-					parser::declarations::ExportDeclaration::Type { .. }
-					| parser::declarations::ExportDeclaration::Default { .. } => {}
+					parser::declarations::ExportDeclaration::Default { .. } => {}
 				},
 			},
 		}

--- a/parser/tests/statements.rs
+++ b/parser/tests/statements.rs
@@ -188,7 +188,8 @@ export * as name1 from "module-name";
 export { name1, /* …, */ nameN } from "module-name";
 export { import1 as name1, import2 as name2, /* …, */ nameN } from "module-name";
 export { default, /* …, */ } from "module-name";
-export { default as name1 } from "module-name""#
+export { default as name1 } from "module-name";
+export type { name1 } from "module-name";"#
 		.trim_start();
 
 	let _module =

--- a/parser/tests/statements.rs
+++ b/parser/tests/statements.rs
@@ -189,7 +189,7 @@ export { name1, /* …, */ nameN } from "module-name";
 export { import1 as name1, import2 as name2, /* …, */ nameN } from "module-name";
 export { default, /* …, */ } from "module-name";
 export { default as name1 } from "module-name";
-export type { name1 } from "module-name";"#
+export type { name1, /* …, */ nameN } from "module-name";"#
 		.trim_start();
 
 	let _module =


### PR DESCRIPTION
# Description

Hey! Following my issue #83 here is a PR to support this feature!

I would need 2 advices:
- I couldn't return `UnexpectedToken` error as I can't clone a Token, so I'm not sure how I can return it
- There's a `println!("Not supposed to happen");` in the code, what would the intended error in that case?

