### PR TITLE
[Refactor] Removing most of clippy warnings

### DIFF
--- a/checker/examples/check.rs
+++ b/checker/examples/check.rs
@@ -14,7 +14,7 @@ fn main() {
 		path.to_path_buf(),
 		HashSet::from_iter(std::iter::once(ezno_checker::INTERNAL_DEFINITION_FILE_PATH.into())),
 		|path: &std::path::Path| {
-			if path == &PathBuf::from(ezno_checker::INTERNAL_DEFINITION_FILE_PATH) {
+			if path == PathBuf::from(ezno_checker::INTERNAL_DEFINITION_FILE_PATH) {
 				Some(ezno_checker::INTERNAL_DEFINITION_FILE.to_owned())
 			} else {
 				fs::read_to_string(path).ok()

--- a/checker/src/behavior/constant_functions.rs
+++ b/checker/src/behavior/constant_functions.rs
@@ -45,7 +45,7 @@ pub(crate) fn call_constant_function(
 				arguments
 					.last()
 					.ok_or(ConstantFunctionError::BadCall)?
-					.into_type()
+					.to_type()
 					.map_err(|_| ConstantFunctionError::BadCall)?,
 			);
 
@@ -114,7 +114,7 @@ pub(crate) fn call_constant_function(
 			let ty = arguments
 				.first()
 				.ok_or(ConstantFunctionError::BadCall)?
-				.into_type()
+				.to_type()
 				.map_err(|_| ConstantFunctionError::BadCall)?;
 			let ty_as_string = print_type(ty, types, &environment.as_general_context(), debug);
 			Ok(ConstantOutput::Diagnostic(format!("Type is: {ty_as_string}")))
@@ -123,7 +123,7 @@ pub(crate) fn call_constant_function(
 			let ty = arguments
 				.first()
 				.ok_or(ConstantFunctionError::BadCall)?
-				.into_type()
+				.to_type()
 				.map_err(|_| ConstantFunctionError::BadCall)?;
 			if let Type::Function(func, _) | Type::FunctionReference(func, _) =
 				types.get_type_by_id(ty)
@@ -145,7 +145,7 @@ pub(crate) fn call_constant_function(
 				Some(this_ty),
 			) = (on, first_argument)
 			{
-				let type_id = this_ty.into_type().map_err(|_| ConstantFunctionError::BadCall)?;
+				let type_id = this_ty.to_type().map_err(|_| ConstantFunctionError::BadCall)?;
 				let value = types.register_type(Type::Function(*func, ThisValue::Passed(type_id)));
 				Ok(ConstantOutput::Value(value))
 			} else {
@@ -157,7 +157,7 @@ pub(crate) fn call_constant_function(
 				let prototype = environment
 					.facts
 					.prototypes
-					.insert(first.into_type().unwrap(), second.into_type().unwrap());
+					.insert(first.to_type().unwrap(), second.to_type().unwrap());
 				// TODO
 				Ok(ConstantOutput::Value(TypeId::UNDEFINED_TYPE))
 			} else {
@@ -170,7 +170,7 @@ pub(crate) fn call_constant_function(
 				let prototype = environment
 					.facts
 					.prototypes
-					.get(&first.into_type().unwrap())
+					.get(&first.to_type().unwrap())
 					.cloned()
 					.unwrap_or(TypeId::NULL_TYPE);
 				Ok(ConstantOutput::Value(prototype))
@@ -183,8 +183,8 @@ pub(crate) fn call_constant_function(
 				// TODO checking for both, what about spreading
 				let value = types.register_type(Type::SpecialObject(
 					crate::behavior::objects::SpecialObjects::Proxy {
-						handler: trap.into_type().expect("single type"),
-						over: object.into_type().expect("single type"),
+						handler: trap.to_type().expect("single type"),
+						over: object.to_type().expect("single type"),
 					},
 				));
 				Ok(ConstantOutput::Value(value))
@@ -196,7 +196,7 @@ pub(crate) fn call_constant_function(
 			let ty = arguments
 				.first()
 				.ok_or(ConstantFunctionError::BadCall)?
-				.into_type()
+				.to_type()
 				.map_err(|_| ConstantFunctionError::BadCall)?;
 			// TODO temp!!!
 			let arg = call_site_type_args
@@ -234,7 +234,7 @@ pub(crate) fn call_constant_function(
 					arguments
 						.first()
 						.ok_or(ConstantFunctionError::BadCall)?
-						.into_type()
+						.to_type()
 						.map_err(|_| ConstantFunctionError::BadCall)?
 				)
 				.is_dependent()

--- a/checker/src/behavior/functions.rs
+++ b/checker/src/behavior/functions.rs
@@ -30,7 +30,7 @@ impl ThisValue {
 	pub(crate) fn get(
 		&self,
 		environment: &mut Environment,
-		types: &mut TypeStore,
+		types: &TypeStore,
 		position: SpanWithSource,
 	) -> TypeId {
 		match self {

--- a/checker/src/behavior/modules.rs
+++ b/checker/src/behavior/modules.rs
@@ -48,8 +48,7 @@ impl Exported {
 		self.named
 			.iter()
 			.find_map(|(export, value)| {
-				(export == want)
-					.then_some(TypeOrVariable::ExportedVariable((value.0, value.1.clone())))
+				(export == want).then_some(TypeOrVariable::ExportedVariable((value.0, value.1)))
 			})
 			.or_else(|| {
 				self.named_types.iter().find_map(|(export, value)| {

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -211,7 +211,7 @@ impl<'a> Environment<'a> {
 								publicity,
 								with,
 								new,
-								&mut checking_data.types,
+								&checking_data.types,
 								Some(span),
 							)?
 							.unwrap_or(new)),
@@ -434,7 +434,7 @@ impl<'a> Environment<'a> {
 						VariableMutability::Mutable { reassignment_constraint } => {
 							let variable = variable.clone();
 
-							if let Some(reassignment_constraint) = reassignment_constraint.clone() {
+							if let Some(reassignment_constraint) = *reassignment_constraint {
 								// TODO tuple with position:
 								let mut basic_subtyping = BasicEquality {
 									add_property_restrictions: false,
@@ -900,7 +900,7 @@ impl<'a> Environment<'a> {
 		publicity: Publicity,
 		under: PropertyKey,
 		new: TypeId,
-		types: &mut TypeStore,
+		types: &TypeStore,
 		setter_position: Option<SpanWithSource>,
 	) -> Result<Option<TypeId>, SetPropertyError> {
 		crate::types::properties::set_property(
@@ -937,7 +937,7 @@ impl<'a> Environment<'a> {
 			return;
 		}
 
-		let exports = checking_data.import_file(current_source, &partial_import_path, self);
+		let exports = checking_data.import_file(current_source, partial_import_path, self);
 
 		if let Err(ref err) = exports {
 			checking_data.diagnostics_container.add_error(TypeCheckError::CannotOpenFile {
@@ -1020,7 +1020,7 @@ impl<'a> Environment<'a> {
 										{
 											exported.named.push((
 												part.r#as.to_owned(),
-												(variable, mutability.clone()),
+												(variable, mutability),
 											));
 										}
 									}
@@ -1097,7 +1097,7 @@ impl<'a> Environment<'a> {
 					for (name, (variable, mutability)) in exports.named.iter() {
 						// TODO are variables put into scope?
 						if let Scope::Module { ref mut exported, .. } = self.context_type.scope {
-							exported.named.push((name.clone(), (*variable, mutability.clone())));
+							exported.named.push((name.clone(), (*variable, *mutability)));
 						}
 					}
 				} else {

--- a/checker/src/context/facts.rs
+++ b/checker/src/context/facts.rs
@@ -134,9 +134,9 @@ impl Facts {
 		self.variable_current_value.extend(other.variable_current_value.iter().to_owned());
 		self.prototypes.extend(other.prototypes.iter().to_owned());
 		self.current_properties
-			.extend(other.current_properties.iter().map(|(l, r)| (l.clone(), r.clone())));
+			.extend(other.current_properties.iter().map(|(l, r)| (*l, r.clone())));
 		self.closure_current_values
-			.extend(other.closure_current_values.iter().map(|(l, r)| (l.clone(), r.clone())));
+			.extend(other.closure_current_values.iter().map(|(l, r)| (l.clone(), *r)));
 		self.configurable.extend(other.configurable.iter().to_owned());
 		self.enumerable.extend(other.enumerable.iter().to_owned());
 		self.writable.extend(other.writable.iter().to_owned());

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -106,10 +106,6 @@ impl DiagnosticsContainer {
 		self.diagnostics.iter().flat_map(|item| item.sources())
 	}
 
-	pub fn into_iter(self) -> impl DoubleEndedIterator<Item = Diagnostic> {
-		self.diagnostics.into_iter()
-	}
-
 	#[doc(hidden)]
 	pub fn get_diagnostics(self) -> Vec<Diagnostic> {
 		self.diagnostics
@@ -121,6 +117,16 @@ impl DiagnosticsContainer {
 		} else {
 			Ok(self)
 		}
+	}
+}
+
+impl IntoIterator for DiagnosticsContainer {
+	type Item = Diagnostic;
+
+	type IntoIter = std::vec::IntoIter<Diagnostic>;
+
+	fn into_iter(self) -> Self::IntoIter {
+		self.diagnostics.into_iter()
 	}
 }
 
@@ -284,7 +290,7 @@ mod defined_errors_and_warnings {
 	impl From<TypeCheckError<'_>> for Diagnostic {
 		fn from(error: TypeCheckError<'_>) -> Self {
 			let kind = super::DiagnosticKind::Error;
-			let diagnostic = match error {
+			match error {
 				TypeCheckError::CouldNotFindVariable { variable, possibles, position } => {
 					Diagnostic::Position {
 						reason: format!(
@@ -590,8 +596,7 @@ mod defined_errors_and_warnings {
 					position,
 					kind,
 				}
-			};
-			diagnostic
+			}
 		}
 	}
 

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -69,7 +69,7 @@ pub(crate) fn apply_event(
 			let under = match under {
 				crate::types::properties::PropertyKey::Type(under) => {
 					let ty = substitute(under, type_arguments, environment, types);
-					crate::types::properties::PropertyKey::from_type(ty, &types)
+					crate::types::properties::PropertyKey::from_type(ty, types)
 				}
 				under => under,
 			};
@@ -97,7 +97,7 @@ pub(crate) fn apply_event(
 			let under = match under {
 				crate::types::properties::PropertyKey::Type(under) => {
 					let ty = substitute(under, type_arguments, environment, types);
-					crate::types::properties::PropertyKey::from_type(ty, &types)
+					crate::types::properties::PropertyKey::from_type(ty, types)
 				}
 				under => under,
 			};

--- a/checker/src/events/mod.rs
+++ b/checker/src/events/mod.rs
@@ -103,13 +103,13 @@ pub enum Event {
 	/// *lil bit magic*, handles:
 	/// - Creating objects `{}`
 	/// - Creating objects with prototypes:
-	/// 	- Arrays
-	/// 	- Map & Sets
-	/// 	- HTMLElement and derivatives
+	///     - Arrays
+	///     - Map & Sets
+	///     - HTMLElement and derivatives
 	///
 	/// ```typescript
 	/// function x() {
-	/// 	return {}
+	///     return {}
 	/// }
 	/// ```
 	///

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -519,12 +519,9 @@ impl TypeCombinable for () {
 		_else_result: Self,
 		_types: &mut TypeStore,
 	) -> Self {
-		()
 	}
 
-	fn default() -> Self {
-		()
-	}
+	fn default() -> Self {}
 }
 
 // For ternary conditional operators

--- a/checker/src/serialization.rs
+++ b/checker/src/serialization.rs
@@ -33,9 +33,7 @@ impl BinarySerializable for String {
 impl BinarySerializable for () {
 	fn serialize(self, _buf: &mut Vec<u8>) {}
 
-	fn deserialize<I: Iterator<Item = u8>>(iter: &mut I, source: SourceId) -> Self {
-		()
-	}
+	fn deserialize<I: Iterator<Item = u8>>(iter: &mut I, source: SourceId) -> Self {}
 }
 
 impl<T: BinarySerializable> BinarySerializable for Option<T> {

--- a/checker/src/synthesis/assignments.rs
+++ b/checker/src/synthesis/assignments.rs
@@ -100,8 +100,8 @@ pub(super) fn synthesise_lhs_of_assignment_to_reference<T: crate::ReadFromFS>(
 
 fn synthesise_object_shorthand_assignable<T: crate::ReadFromFS>(
 	name: &parser::VariableIdentifier,
-	checking_data: &mut CheckingData<T, super::EznoParser>,
-	environment: &mut crate::context::Context<crate::context::Syntax<'_>>,
+	checking_data: &CheckingData<T, super::EznoParser>,
+	environment: &crate::context::Context<crate::context::Syntax<'_>>,
 ) -> Assignable {
 	match name {
 		parser::VariableIdentifier::Standard(name, pos) => Assignable::Reference(
@@ -123,7 +123,7 @@ pub(crate) fn synthesise_access_to_reference<T: crate::ReadFromFS>(
 		),
 		VariableOrPropertyAccess::PropertyAccess { parent, property, position } => {
 			let parent_ty =
-				synthesise_expression(&parent, environment, checking_data, TypeId::ANY_TYPE);
+				synthesise_expression(parent, environment, checking_data, TypeId::ANY_TYPE);
 			match property {
 				parser::PropertyReference::Standard { property, is_private } => {
 					let publicity =
@@ -142,9 +142,9 @@ pub(crate) fn synthesise_access_to_reference<T: crate::ReadFromFS>(
 		}
 		VariableOrPropertyAccess::Index { indexee, indexer, position } => {
 			let parent_ty =
-				synthesise_expression(&indexee, environment, checking_data, TypeId::ANY_TYPE);
+				synthesise_expression(indexee, environment, checking_data, TypeId::ANY_TYPE);
 			let key_ty = synthesise_multiple_expression(
-				&indexer,
+				indexer,
 				environment,
 				checking_data,
 				TypeId::ANY_TYPE,

--- a/checker/src/synthesis/block.rs
+++ b/checker/src/synthesis/block.rs
@@ -25,7 +25,7 @@ pub(super) fn synthesise_block<T: crate::ReadFromFS>(
 	for (idx, statement) in statements.iter().enumerate() {
 		match statement {
 			StatementOrDeclaration::Statement(statement) => {
-				let statement_result = synthesise_statement(statement, environment, checking_data);
+				synthesise_statement(statement, environment, checking_data);
 
 				// TODO Statement::is_control_flow ...?
 				if let Statement::Return(..) | Statement::Break(..) | Statement::Continue(..) =

--- a/checker/src/synthesis/classes.rs
+++ b/checker/src/synthesis/classes.rs
@@ -53,13 +53,9 @@ pub(super) fn synthesise_class_declaration<
 		// let class_type = checking_data.types.register_type(ty);
 	}
 
-	let extends = if let Some(ref extends) = class.extends {
-		// TODO temp
-		// let expecting = TypeId::ANY_TYPE;
-		Some(synthesise_expression(&**extends, environment, checking_data, TypeId::ANY_TYPE))
-	} else {
-		None
-	};
+	let extends = class.extends.as_ref().map(|extends| {
+		synthesise_expression(extends, environment, checking_data, TypeId::ANY_TYPE)
+	});
 
 	// TODO prototype of extends
 	let class_prototype =
@@ -214,7 +210,7 @@ pub(super) fn synthesise_class_declaration<
 				};
 				let value = if let Some(ref value) = property.value {
 					let expecting = TypeId::ANY_TYPE;
-					synthesise_expression(&**value, environment, checking_data, expecting)
+					synthesise_expression(value, environment, checking_data, expecting)
 				} else {
 					TypeId::UNDEFINED_TYPE
 				};

--- a/checker/src/synthesis/declarations.rs
+++ b/checker/src/synthesis/declarations.rs
@@ -14,7 +14,7 @@ pub(super) fn synthesise_variable_declaration<T: crate::ReadFromFS>(
 		VariableDeclaration::ConstDeclaration { declarations, .. } => {
 			for variable_declaration in declarations.iter() {
 				synthesise_variable_declaration_item(
-					&variable_declaration,
+					variable_declaration,
 					environment,
 					true,
 					checking_data,
@@ -37,7 +37,7 @@ pub(super) fn synthesise_variable_declaration<T: crate::ReadFromFS>(
 					VariableMutability::Mutable { reassignment_constraint: restriction }
 				});
 				synthesise_variable_declaration_item(
-					&variable_declaration,
+					variable_declaration,
 					environment,
 					false,
 					checking_data,

--- a/checker/src/synthesis/definitions.rs
+++ b/checker/src/synthesis/definitions.rs
@@ -154,6 +154,8 @@ pub(super) fn type_definition_file<T: crate::ReadFromFS>(
 			}) => {
 				let TypeDeclaration { name, type_parameters, .. } = &type_name;
 
+				// To remove when implementing
+				#[allow(clippy::redundant_pattern_matching)]
 				if let Some(_) = type_parameters {
 					todo!()
 				// let ty = if let Some(type_parameters) = type_parameters {
@@ -217,7 +219,7 @@ pub(super) fn type_definition_file<T: crate::ReadFromFS>(
 	(Names { named_types, variable_names, variables }, facts)
 }
 
-pub(crate) fn decorators_to_context(decorators: &Vec<parser::Decorator>) -> Option<String> {
+pub(crate) fn decorators_to_context(decorators: &[parser::Decorator]) -> Option<String> {
 	decorators.iter().find_map(|dec| {
 		if dec.name.first() == Some(&"server".to_owned()) {
 			Some("server".to_owned())

--- a/checker/src/synthesis/extensions/is_expression.rs
+++ b/checker/src/synthesis/extensions/is_expression.rs
@@ -22,12 +22,12 @@ pub(crate) fn synthesise_is_expression<T: crate::ReadFromFS>(
 
 	let mut returned = TypeId::UNDEFINED_TYPE;
 	for (condition, code) in is_expression.branches.iter() {
-		let requirement = synthesise_type_annotation(&condition, environment, checking_data);
+		let requirement = synthesise_type_annotation(condition, environment, checking_data);
 
 		// TODO need to test subtyping and subtype here
 		// TODO move proofs here
 
-		let result = code.synthesise_function_body(environment, checking_data);
+		code.synthesise_function_body(environment, checking_data);
 
 		// let code_returns = code.synthesise_function_body(environment, checking_data);
 

--- a/checker/src/synthesis/functions.rs
+++ b/checker/src/synthesis/functions.rs
@@ -135,7 +135,7 @@ where
 	) -> Option<GenericTypeParameters> {
 		self.type_parameters
 			.as_ref()
-			.map(|ty_params| synthesise_type_parameters(&ty_params, environment, checking_data))
+			.map(|ty_params| synthesise_type_parameters(ty_params, environment, checking_data))
 	}
 
 	fn this_constraint<T: crate::ReadFromFS>(
@@ -495,15 +495,9 @@ pub(super) fn synthesise_function_annotation<T: crate::ReadFromFS, S: ContextTyp
 							environment.new_lexical_environment(Scope::Function(new_scope));
 
 						let type_parameters: Option<GenericTypeParameters> =
-							if let Some(type_parameters) = type_parameters {
-								Some(synthesise_type_parameters(
-									type_parameters,
-									&mut env,
-									checking_data,
-								))
-							} else {
-								None
-							};
+							type_parameters.as_ref().map(|type_parameters| {
+								synthesise_type_parameters(type_parameters, &mut env, checking_data)
+							});
 
 						let parameters = synthesise_type_annotation_function_parameters(
 							parameters,
@@ -538,15 +532,13 @@ pub(super) fn synthesise_function_annotation<T: crate::ReadFromFS, S: ContextTyp
 					}
 					other => {
 						let type_parameters: Option<GenericTypeParameters> =
-							if let Some(type_parameters) = type_parameters {
-								Some(synthesise_type_parameters(
+							type_parameters.as_ref().map(|type_parameters| {
+								synthesise_type_parameters(
 									type_parameters,
 									environment,
 									checking_data,
-								))
-							} else {
-								None
-							};
+								)
+							});
 
 						let parameters = synthesise_type_annotation_function_parameters(
 							parameters,

--- a/checker/src/synthesis/mod.rs
+++ b/checker/src/synthesis/mod.rs
@@ -110,7 +110,7 @@ impl crate::ASTImplementation for EznoParser {
 		string: String,
 		options: &Self::ParseOptions,
 	) -> Result<Self::Module, Self::ParseError> {
-		<parser::Module as parser::ASTNode>::from_string(string, options.clone(), source_id, None)
+		<parser::Module as parser::ASTNode>::from_string(string, *options, source_id, None)
 			.map_err(|err| (err, source_id))
 	}
 

--- a/checker/src/synthesis/statements.rs
+++ b/checker/src/synthesis/statements.rs
@@ -107,7 +107,7 @@ pub(super) fn synthesise_statement<T: crate::ReadFromFS>(
 				environment.new_conditional_context(
 					condition,
 					|env: &mut Environment, data: &mut CheckingData<T, EznoParser>| {
-						synthesise_block_or_single_statement(&current.1, env, data)
+						synthesise_block_or_single_statement(current.1, env, data)
 					},
 					if !others.is_empty() || last.is_some() {
 						Some(|env: &mut Environment, data: &mut CheckingData<T, EznoParser>| {

--- a/checker/src/synthesis/type_annotations.rs
+++ b/checker/src/synthesis/type_annotations.rs
@@ -70,7 +70,7 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 			checking_data.types.new_constant_type(constant)
 		}
 		TypeAnnotation::BooleanLiteral(value, _) => {
-			checking_data.types.new_constant_type(Constant::Boolean(value.clone()))
+			checking_data.types.new_constant_type(Constant::Boolean(*value))
 		}
 		TypeAnnotation::Name(name, pos) => match name.as_str() {
 			"any" => TypeId::ANY_TYPE,
@@ -249,7 +249,7 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 			let function_type = synthesise_function_annotation(
 				type_parameters,
 				parameters,
-				Some(&*return_type),
+				Some(return_type),
 				environment,
 				checking_data,
 				super::Performs::None,
@@ -270,7 +270,7 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 		}
 		TypeAnnotation::Readonly(type_annotation, _) => {
 			let underlying_type =
-				synthesise_type_annotation(&*type_annotation, environment, checking_data);
+				synthesise_type_annotation(type_annotation, environment, checking_data);
 
 			todo!();
 
@@ -287,8 +287,7 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 		}
 		TypeAnnotation::NamespacedName(_, _, _) => unimplemented!(),
 		TypeAnnotation::ArrayLiteral(item_annotation, _) => {
-			let item_type =
-				synthesise_type_annotation(&*item_annotation, environment, checking_data);
+			let item_type = synthesise_type_annotation(item_annotation, environment, checking_data);
 			let with_source =
 				item_annotation.get_position().clone().with_source(environment.get_source());
 			let ty = Type::Constructor(Constructor::StructureGenerics(StructureGenerics {
@@ -320,7 +319,7 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 
 			super::interfaces::synthesise_signatures(
 				None,
-				&members,
+				members,
 				super::interfaces::OnToType(onto),
 				environment,
 				checking_data,
@@ -443,7 +442,7 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 		// TODO these are all work in progress
 		TypeAnnotation::Decorated(decorator, inner, _) => {
 			crate::utils::notify!("Unknown decorator skipping {:#?}", decorator.name);
-			synthesise_type_annotation(&inner, environment, checking_data)
+			synthesise_type_annotation(inner, environment, checking_data)
 		}
 		TypeAnnotation::TemplateLiteral(_, _) => todo!(),
 	};

--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -36,7 +36,7 @@ pub(crate) fn register_variable<T: crate::ReadFromFS, U: parser::VariableFieldKi
 		match name {
 			parser::VariableIdentifier::Standard(name, pos) => {
 				let ty = environment.register_variable_handle_error(
-					&name,
+					name,
 					pos.clone().with_source(environment.get_source()),
 					behavior,
 					checking_data,
@@ -283,8 +283,7 @@ fn assign_to_fields<T: crate::ReadFromFS>(
 				if let crate::Scope::Module { ref mut exported, .. } =
 					environment.context_type.scope
 				{
-					let existing =
-						exported.named.push((name.as_str().to_owned(), (id, mutability)));
+					exported.named.push((name.as_str().to_owned(), (id, mutability)));
 				} else {
 					todo!("emit error here")
 				}

--- a/checker/src/types/functions.rs
+++ b/checker/src/types/functions.rs
@@ -192,7 +192,7 @@ impl SynthesisedArgument {
 		}
 	}
 
-	pub(crate) fn into_type(&self) -> Result<TypeId, ()> {
+	pub(crate) fn to_type(&self) -> Result<TypeId, ()> {
 		match self {
 			SynthesisedArgument::NonSpread { ty, position: _ } => Ok(*ty),
 		}

--- a/checker/src/types/poly_types/generics/generic_type_arguments.rs
+++ b/checker/src/types/poly_types/generics/generic_type_arguments.rs
@@ -67,12 +67,7 @@ pub(crate) struct FunctionTypeArguments {
 }
 
 impl FunctionTypeArguments {
-	pub(crate) fn set_id_from_reference(
-		&mut self,
-		id: TypeId,
-		value: TypeId,
-		types: &mut TypeStore,
-	) {
+	pub(crate) fn set_id_from_reference(&mut self, id: TypeId, value: TypeId, types: &TypeStore) {
 		self.local_arguments.insert(id, (value, SpanWithSource::NULL_SPAN));
 	}
 }
@@ -89,7 +84,7 @@ pub(crate) trait TypeArgumentStore {
 
 	fn get_structural_closures(&self) -> Option<Vec<ClosureId>>;
 
-	fn into_structural_generic_arguments(&self) -> StructureGenericArguments;
+	fn to_structural_generic_arguments(&self) -> StructureGenericArguments;
 
 	fn is_empty(&self) -> bool;
 }
@@ -130,7 +125,7 @@ impl TypeArgumentStore for FunctionTypeArguments {
 		None
 	}
 
-	fn into_structural_generic_arguments(&self) -> StructureGenericArguments {
+	fn to_structural_generic_arguments(&self) -> StructureGenericArguments {
 		// self.structure_arguments.clone()
 		match self.structure_arguments {
 			Some(ref parent) => {
@@ -145,7 +140,7 @@ impl TypeArgumentStore for FunctionTypeArguments {
 			}
 			None => StructureGenericArguments {
 				type_arguments: self.local_arguments.clone(),
-				closures: self.closure_id.clone().into_iter().collect(),
+				closures: self.closure_id.into_iter().collect(),
 			},
 		}
 	}
@@ -170,7 +165,7 @@ impl TypeArgumentStore for SmallMap<TypeId, (TypeId, SpanWithSource)> {
 		None
 	}
 
-	fn into_structural_generic_arguments(&self) -> StructureGenericArguments {
+	fn to_structural_generic_arguments(&self) -> StructureGenericArguments {
 		todo!("This shouldn't be needed");
 	}
 
@@ -199,7 +194,7 @@ impl TypeArgumentStore for StructureGenericArguments {
 		Some(self.closures.clone())
 	}
 
-	fn into_structural_generic_arguments(&self) -> StructureGenericArguments {
+	fn to_structural_generic_arguments(&self) -> StructureGenericArguments {
 		self.clone()
 	}
 

--- a/checker/src/types/poly_types/generics/mod.rs
+++ b/checker/src/types/poly_types/generics/mod.rs
@@ -49,12 +49,10 @@ impl SeedingContext {
 			} else {
 				self.type_restrictions.insert(on, vec![(arg, pos)]);
 			}
+		} else if let Some(args) = self.type_arguments.get_mut(&on) {
+			args.push(arg);
 		} else {
-			if let Some(args) = self.type_arguments.get_mut(&on) {
-				args.push(arg);
-			} else {
-				self.type_arguments.insert(on, vec![arg]);
-			}
+			self.type_arguments.insert(on, vec![arg]);
 		};
 	}
 

--- a/checker/src/types/poly_types/substitution.rs
+++ b/checker/src/types/poly_types/substitution.rs
@@ -254,14 +254,14 @@ pub(crate) fn substitute(
 }
 
 pub(crate) fn curry_arguments(
-	arguments: &mut impl TypeArgumentStore,
+	arguments: &impl TypeArgumentStore,
 	types: &mut TypeStore,
 	id: TypeId,
 ) -> TypeId {
 	if !arguments.is_empty() {
 		crate::utils::notify!("Storing arguments onto object");
 		// TODO only carry arguments that are used
-		let arguments = arguments.into_structural_generic_arguments();
+		let arguments = arguments.to_structural_generic_arguments();
 
 		types.register_type(Type::Constructor(Constructor::StructureGenerics(
 			crate::types::StructureGenerics { on: id, arguments },

--- a/checker/src/types/printing.rs
+++ b/checker/src/types/printing.rs
@@ -13,7 +13,7 @@ pub fn print_type(id: TypeId, types: &TypeStore, ctx: &GeneralContext, debug: bo
 	let mut buf = String::new();
 	print_type_into_buf(id, &mut buf, &mut HashSet::new(), types, ctx, debug);
 
-	return buf;
+	buf
 }
 
 fn print_type_into_buf(
@@ -119,18 +119,17 @@ fn print_type_into_buf(
 				if matches!(
 					types.get_type_by_id(*on),
 					Type::NamedRooted { .. } | Type::Function { .. }
-				) {
-					if !arguments.type_arguments.is_empty() {
-						// TODO might be out of order ...
-						buf.push('<');
-						for (not_at_end, (arg, _)) in arguments.type_arguments.values().nendiate() {
-							print_type_into_buf(*arg, buf, cycles, types, ctx, debug);
-							if not_at_end {
-								buf.push_str(", ")
-							}
+				) && !arguments.type_arguments.is_empty()
+				{
+					// TODO might be out of order ...
+					buf.push('<');
+					for (not_at_end, (arg, _)) in arguments.type_arguments.values().nendiate() {
+						print_type_into_buf(*arg, buf, cycles, types, ctx, debug);
+						if not_at_end {
+							buf.push_str(", ")
 						}
-						buf.push('>');
 					}
+					buf.push('>');
 				}
 			}
 			constructor if debug => match constructor {

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -120,7 +120,7 @@ impl PropertyValue {
 ///
 /// *be aware this creates a new type every time, bc of this binding. could cache this bound
 /// types at some point*
-pub(crate) fn get_property<'a, E: CallCheckingBehavior>(
+pub(crate) fn get_property<E: CallCheckingBehavior>(
 	on: TypeId,
 	publicity: Publicity,
 	under: PropertyKey,
@@ -187,7 +187,7 @@ pub(crate) fn get_property<'a, E: CallCheckingBehavior>(
 	Some((PropertyKind::Direct, value))
 }
 
-fn get_from_an_object<'a, E: CallCheckingBehavior>(
+fn get_from_an_object<E: CallCheckingBehavior>(
 	on: TypeId,
 	publicity: Publicity,
 	under: PropertyKey,
@@ -305,14 +305,14 @@ fn get_from_an_object<'a, E: CallCheckingBehavior>(
 	}
 }
 
-fn evaluate_get_on_poly<'a, E: CallCheckingBehavior>(
+fn evaluate_get_on_poly<E: CallCheckingBehavior>(
 	constraint: TypeId,
 	on: TypeId,
 	publicity: Publicity,
 	under: PropertyKey,
 	with: Option<TypeId>,
 	environment: &mut Environment,
-	behavior: &mut E,
+	behavior: &E,
 	types: &mut TypeStore,
 ) -> Option<TypeId> {
 	// match constraint {
@@ -409,14 +409,14 @@ fn evaluate_get_on_poly<'a, E: CallCheckingBehavior>(
 /// Aka a assignment to a property, **INCLUDING initialization of a new one**
 ///
 /// Evaluates setters
-pub(crate) fn set_property<'a, E: CallCheckingBehavior>(
+pub(crate) fn set_property<E: CallCheckingBehavior>(
 	on: TypeId,
 	publicity: Publicity,
 	under: PropertyKey,
 	new: PropertyValue,
 	environment: &mut Environment,
 	behavior: &mut E,
-	types: &mut TypeStore,
+	types: &TypeStore,
 	setter_position: Option<SpanWithSource>,
 ) -> Result<Option<TypeId>, SetPropertyError> {
 	// TODO

--- a/checker/src/types/store.rs
+++ b/checker/src/types/store.rs
@@ -24,7 +24,7 @@ pub struct TypeStore {
 	// pub(crate) proxies: HashMap<TypeId, Proxy>,
 	pub(crate) specialisations: HashMap<TypeId, Vec<TypeId>>,
 
-	/// TODO not best place	but is passed through everything so
+	/// TODO not best place but is passed through everything so
 	pub(crate) closure_counter: u32,
 }
 

--- a/parser/generator/generator.rs
+++ b/parser/generator/generator.rs
@@ -33,10 +33,7 @@ fn token_stream_to_ast_node<T: ezno_parser::ASTNode + self_rust_tokenize::SelfRu
 		.iter()
 		.enumerate()
 		.map(|(idx, InterpolationPoint { position, expr_name: _ })| {
-			(
-				*position,
-				ezno_parser::CursorId(idx.try_into().unwrap(), std::marker::PhantomData::default()),
-			)
+			(*position, ezno_parser::CursorId(idx.try_into().unwrap(), std::marker::PhantomData))
 		})
 		.collect();
 

--- a/parser/src/declarations/export.rs
+++ b/parser/src/declarations/export.rs
@@ -196,10 +196,10 @@ impl ASTNode for ExportDeclaration {
 						})
 					}
 				} else {
-					return Err(ParseError::new(
+					Err(ParseError::new(
 						crate::ParseErrors::UnmatchedBrackets,
 						start.with_length(1),
-					));
+					))
 				}
 			}
 			Token(TSXToken::Keyword(kw), _) if kw.is_in_function_header() => {
@@ -388,7 +388,7 @@ impl ASTNode for ExportPart {
 			ExportPart::PrefixComment(comment, inner, _) => {
 				if options.include_comments {
 					buf.push_str("/*");
-					buf.push_str(&comment);
+					buf.push_str(comment);
 					buf.push_str("*/");
 					if inner.is_some() {
 						buf.push(' ');
@@ -402,7 +402,7 @@ impl ASTNode for ExportPart {
 				inner.to_string_from_buffer(buf, options, depth);
 				if options.include_comments {
 					buf.push_str("/*");
-					buf.push_str(&comment);
+					buf.push_str(comment);
 					buf.push_str("*/ ");
 				}
 			}

--- a/parser/src/declarations/import.rs
+++ b/parser/src/declarations/import.rs
@@ -383,7 +383,7 @@ impl ASTNode for ImportPart {
 			ImportPart::PrefixComment(comment, inner, _) => {
 				if options.include_comments {
 					buf.push_str("/*");
-					buf.push_str(&comment);
+					buf.push_str(comment);
 					buf.push_str("*/");
 					if inner.is_some() {
 						buf.push(' ');
@@ -397,7 +397,7 @@ impl ASTNode for ImportPart {
 				inner.to_string_from_buffer(buf, options, depth);
 				if options.include_comments {
 					buf.push_str("/*");
-					buf.push_str(&comment);
+					buf.push_str(comment);
 					buf.push_str("*/ ");
 				}
 			}

--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -273,12 +273,12 @@ pub fn lex_script(
 								&& !(*fractional || script[..idx].ends_with('_'))
 							{
 								*literal_type = NumberLiteralType::Exponent;
-							} else if !matches!(chr, '0'..='9') {
+							} else if !chr.is_ascii_digit() {
 								return_err!(LexingErrors::InvalidNumeralItemBecauseOfLiteralKind)
 							}
 						}
 						NumberLiteralType::Exponent => {
-							if !matches!(chr, '0'..='9') {
+							if !chr.is_ascii_digit() {
 								return_err!(LexingErrors::InvalidNumeralItemBecauseOfLiteralKind)
 							}
 						}

--- a/parser/src/modules.rs
+++ b/parser/src/modules.rs
@@ -114,7 +114,7 @@ impl Module {
 		let mut chain = temporary_annex::Annex::new(&mut chain);
 
 		{
-			visitors.visit_block(&mut crate::block::BlockLike { items: &self.items }, data, &chain);
+			visitors.visit_block(&crate::block::BlockLike { items: &self.items }, data, &chain);
 		}
 
 		let iter = self.items.iter();

--- a/parser/src/parameters.rs
+++ b/parser/src/parameters.rs
@@ -150,14 +150,14 @@ impl FunctionParameters {
 				}));
 				break;
 			} else if let Some(Token(_, start)) = reader.conditional_next(|tok| {
-				parameters.len() == 0 && matches!(tok, TSXToken::Keyword(TSXKeyword::This))
+				parameters.is_empty() && matches!(tok, TSXToken::Keyword(TSXKeyword::This))
 			}) {
 				reader.expect_next(TSXToken::Colon)?;
 				let type_annotation = TypeAnnotation::from_reader(reader, state, options)?;
 				let position = start.union(type_annotation.get_position());
 				this_type = Some((type_annotation, position));
 			} else if let Some(Token(_, start)) = reader.conditional_next(|tok| {
-				parameters.len() == 0 && matches!(tok, TSXToken::Keyword(TSXKeyword::Super))
+				parameters.is_empty() && matches!(tok, TSXToken::Keyword(TSXKeyword::Super))
 			}) {
 				reader.expect_next(TSXToken::Colon)?;
 				let type_annotation = TypeAnnotation::from_reader(reader, state, options)?;

--- a/parser/src/visiting.rs
+++ b/parser/src/visiting.rs
@@ -282,6 +282,10 @@ mod structures {
 			self.0.len()
 		}
 
+		pub fn is_empty(&self) -> bool {
+			self.0.is_empty()
+		}
+
 		pub fn truncate(&mut self, to_size: usize) {
 			self.0.truncate(to_size)
 		}

--- a/parser/src/visiting.rs
+++ b/parser/src/visiting.rs
@@ -536,14 +536,17 @@ mod visitors {
 		}
 	}
 
+	type ExpressionVisitor<T> = Box<dyn Visitor<Expression, T>>;
+	type StatementVisitor<T> = Box<dyn for<'a> Visitor<StatementOrDeclarationRef<'a>, T>>;
+	type VariableVisitor<T> = Box<dyn for<'a> Visitor<ImmutableVariableOrPropertyPart<'a>, T>>;
+	type BlockVisitor<T> = Box<dyn for<'a> Visitor<BlockLike<'a>, T>>;
 	#[derive(Default)]
 	pub struct Visitors<T> {
-		pub expression_visitors: Vec<Box<dyn Visitor<Expression, T>>>,
-		pub statement_visitors: Vec<Box<dyn for<'a> Visitor<StatementOrDeclarationRef<'a>, T>>>,
+		pub expression_visitors: Vec<ExpressionVisitor<T>>,
+		pub statement_visitors: Vec<StatementVisitor<T>>,
 		pub jsx_element_visitors: Vec<Box<dyn Visitor<JSXElement, T>>>,
-		pub variable_visitors:
-			Vec<Box<dyn for<'a> Visitor<ImmutableVariableOrPropertyPart<'a>, T>>>,
-		pub block_visitors: Vec<Box<dyn for<'a> Visitor<BlockLike<'a>, T>>>,
+		pub variable_visitors: Vec<VariableVisitor<T>>,
+		pub block_visitors: Vec<BlockVisitor<T>>,
 	}
 
 	// impl<T, U> Visitor<Expression, T> for U
@@ -622,13 +625,16 @@ mod visitors_mut {
 		fn visit_block_mut(&mut self, block: &mut BlockLikeMut, data: &mut T, chain: &Chain) {}
 	}
 
+	type StatementVisitor<T> = Box<dyn for<'a> VisitorMut<StatementOrDeclarationMut<'a>, T>>;
+	type VariableVisitor<T> = Box<dyn for<'a> VisitorMut<MutableVariablePart<'a>, T>>;
+	type BlockVisitor<T> = Box<dyn for<'a> VisitorMut<BlockLikeMut<'a>, T>>;
+
 	pub struct VisitorsMut<T> {
 		pub expression_visitors_mut: Vec<Box<dyn VisitorMut<Expression, T>>>,
-		pub statement_visitors_mut:
-			Vec<Box<dyn for<'a> VisitorMut<StatementOrDeclarationMut<'a>, T>>>,
+		pub statement_visitors_mut: Vec<StatementVisitor<T>>,
 		pub jsx_element_visitors_mut: Vec<Box<dyn VisitorMut<JSXElement, T>>>,
-		pub variable_visitors_mut: Vec<Box<dyn for<'a> VisitorMut<MutableVariablePart<'a>, T>>>,
-		pub block_visitors_mut: Vec<Box<dyn for<'a> VisitorMut<BlockLikeMut<'a>, T>>>,
+		pub variable_visitors_mut: Vec<VariableVisitor<T>>,
+		pub block_visitors_mut: Vec<BlockVisitor<T>>,
 	}
 
 	impl<T> Default for VisitorsMut<T> {

--- a/src/ast_explorer.rs
+++ b/src/ast_explorer.rs
@@ -75,8 +75,8 @@ impl ExplorerArguments {
 #[derive(FromArgs, Debug, EnumVariantsStrings)]
 #[argh(subcommand)]
 #[enum_variants_strings_transform(transform = "kebab_case")]
+#[allow(clippy::upper_case_acronyms)]
 pub(crate) enum ExplorerSubCommand {
-	#[allow(clippy::upper_case_acronyms)]
 	AST(ASTArgs),
 	FullAST(FullASTArgs),
 	Prettifier(PrettyArgs),

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -57,7 +57,7 @@ pub(crate) fn run_deno_repl<U: crate::CLIInputResolver>(
 	};
 
 	let definitions = if let Some(tdm) = type_definition_module {
-		HashSet::from_iter(std::iter::once(tdm.into()))
+		HashSet::from_iter(std::iter::once(tdm))
 	} else {
 		HashSet::from_iter(std::iter::once(checker::INTERNAL_DEFINITION_FILE_PATH.into()))
 	};
@@ -79,7 +79,7 @@ pub(crate) fn run_deno_repl<U: crate::CLIInputResolver>(
 	loop {
 		let input = cli_input_resolver("");
 		let input = if let Some(input) = input {
-			if input.len() == 0 {
+			if input.is_empty() {
 				continue;
 			} else if input.trim() == "close()" {
 				if let Some((_process, stdin, _child_buf)) = items.as_mut() {
@@ -157,10 +157,8 @@ pub(crate) fn run_deno_repl<U: crate::CLIInputResolver>(
 							}
 						}
 					}
-				} else {
-					if let Some(last_ty) = last_ty {
-						println!("{last_ty}");
-					}
+				} else if let Some(last_ty) = last_ty {
+					println!("{last_ty}");
 				}
 			}
 			Err(diagnostics) => {


### PR DESCRIPTION
# Description

This PR applies most of the suggestions made by clippy.
There's still some warnings that I didn't take care of:
- [`Result<_, ()>`](https://rust-lang.github.io/rust-clippy/master/index.html#/result_unit_err) -> I think it may needs to define how to do the error reporting, or if this warning can be disabled
- [Function with too much arguments](https://rust-lang.github.io/rust-clippy/master/index.html#/too_many_arguments) -> Again, either "a big" refactor is needed, or to disable the warnings

Also, I think this PR could be a good timing to choose a lint level and explicitly add it everywhere