### PR TITLE
[WIP] [Refactor] Defining clippy rules 

### DIFF
--- a/checker/src/behavior/template_literal.rs
+++ b/checker/src/behavior/template_literal.rs
@@ -4,7 +4,7 @@ use source_map::{Span, SpanWithSource};
 
 use crate::{
 	behavior::objects::ObjectBuilder,
-	types::{cast_as_string, SynthesisedArgument},
+	types::{calling::CallingInput, cast_as_string, SynthesisedArgument},
 	CheckingData, Constant, Environment, Instance, Type, TypeId,
 };
 
@@ -101,12 +101,14 @@ where
 		let call_site = position.clone().with_source(environment.get_source());
 		crate::types::calling::call_type_handle_errors(
 			tag,
-			crate::types::calling::CalledWithNew::None,
-			crate::behavior::functions::ThisValue::UseParent,
-			None,
-			arguments,
-			call_site,
+			CallingInput {
+				called_with_new: crate::types::calling::CalledWithNew::None,
+				this_value: crate::behavior::functions::ThisValue::UseParent,
+				call_site,
+				call_site_type_arguments: None,
+			},
 			environment,
+			arguments,
 			checking_data,
 		)
 		.0

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -175,12 +175,14 @@ pub(crate) fn apply_event(
 				CallingTiming::Synchronous => {
 					let result = crate::types::calling::call_type(
 						on,
-						called_with_new,
-						Default::default(),
-						None,
+						crate::types::calling::CallingInput {
+							called_with_new,
+							this_value: Default::default(),
+							call_site_type_arguments: None,
+							// TODO:
+							call_site: source_map::SpanWithSource::NULL_SPAN,
+						},
 						with,
-						// TODO
-						source_map::SpanWithSource::NULL_SPAN,
 						environment,
 						target,
 						types,

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![deny(clippy::all)]
 #![allow(
 	unreachable_code,
 	unused_variables,
@@ -6,7 +7,9 @@
 	unused_mut,
 	dead_code,
 	irrefutable_let_patterns,
-	deprecated
+	deprecated,
+    // TODO: Remove when fixed
+	clippy::result_unit_err
 )]
 
 pub mod behavior;

--- a/checker/src/synthesis/expressions.rs
+++ b/checker/src/synthesis/expressions.rs
@@ -19,7 +19,7 @@ use crate::{
 		variables::VariableWithValue,
 	},
 	synthesis::parser_property_key_to_checker_property_key,
-	types::properties::PropertyKey,
+	types::{calling::CallingInput, properties::PropertyKey},
 	Decidable,
 };
 
@@ -837,12 +837,14 @@ fn call_function<T: crate::ReadFromFS>(
 
 	crate::types::calling::call_type_handle_errors(
 		function_type_id,
-		called_with_new,
-		Default::default(),
-		generic_type_arguments,
-		synthesised_arguments,
-		call_site.clone().with_source(environment.get_source()),
+		CallingInput {
+			called_with_new,
+			this_value: Default::default(),
+			call_site: call_site.clone().with_source(environment.get_source()),
+			call_site_type_arguments: generic_type_arguments,
+		},
 		environment,
+		synthesised_arguments,
 		checking_data,
 	)
 }

--- a/checker/src/synthesis/extensions/jsx.rs
+++ b/checker/src/synthesis/extensions/jsx.rs
@@ -14,6 +14,7 @@ use crate::{
 	diagnostics::{TypeCheckError, TypeStringRepresentation},
 	synthesis::expressions::synthesise_expression,
 	types::{
+		calling::CallingInput,
 		properties::PropertyKey,
 		subtyping::{type_is_subtype, BasicEquality, SubTypeResult},
 		SynthesisedArgument,
@@ -191,12 +192,14 @@ pub(crate) fn synthesise_jsx_element<T: crate::ReadFromFS>(
 
 	call_type_handle_errors(
 		jsx_function,
-		crate::types::calling::CalledWithNew::None,
-		environment.facts.value_of_this,
-		None,
-		args,
-		position.clone(),
+		CallingInput {
+			called_with_new: crate::types::calling::CalledWithNew::None,
+			this_value: environment.facts.value_of_this,
+			call_site: position.clone(),
+			call_site_type_arguments: None,
+		},
 		environment,
+		args,
 		checking_data,
 	)
 	.0

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -5,7 +5,9 @@ use crate::{
 	context::{facts::Publicity, CallCheckingBehavior, Logical, SetPropertyError},
 	events::Event,
 	subtyping::{type_is_subtype, SubTypeResult},
-	types::{printing::print_type, substitute, FunctionType, StructureGenerics},
+	types::{
+		calling::CallingInput, printing::print_type, substitute, FunctionType, StructureGenerics,
+	},
 	Constant, Environment, TypeId,
 };
 
@@ -271,13 +273,15 @@ fn get_from_an_object<E: CallCheckingBehavior>(
 					PropertyValue::Getter(getter) => {
 						let state = ThisValue::Passed(on);
 						let call = getter.call(
-							CalledWithNew::None,
-							state,
-							None,
+							CallingInput {
+								called_with_new: CalledWithNew::None,
+								this_value: state,
+								call_site_type_arguments: None,
+								call_site: SpanWithSource::NULL_SPAN,
+							},
 							// TODO
 							None,
 							&[],
-							SpanWithSource::NULL_SPAN,
 							environment,
 							behavior,
 							types,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![deny(clippy::all)]
 #![allow(clippy::new_without_default)]
 
 mod block;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 mod ast_explorer;
 mod commands;
 mod error_handling;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::all)]
 use ezno_lib::cli::run_cli;
 use std::io;
 


### PR DESCRIPTION
# Description
This PR aims to define standards for clippy, and fixes the `too_many_arugment` error as well.

## About clippy
Imo the best strategy is to use `#![deny(clippy::all)]` which is covering the most important linting rules, and to cherry pick some of `clippy::pedantic` as using everything can be painful, and raise false positives.

[List of all the pedantic lintings](https://rust-lang.github.io/rust-clippy/master/index.html#/?groups=pedantic)

Example of some pendantic linting I think may be nice to have:
- [Cast lostless](https://rust-lang.github.io/rust-clippy/master/index.html#/cast_lossless?groups=pedantic)
- [From iter instead of collect](https://rust-lang.github.io/rust-clippy/master/index.html#/from_iter_instead_of_collect?groups=pedantic)
- [Inneficient to string](https://rust-lang.github.io/rust-clippy/master/index.html#/inefficient_to_string?groups=pedantic)