### PR TITLE
Ast typegen

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -95,7 +95,7 @@ jobs:
       - uses: brndnmtthws/rust-action-cargo-binstall@v1
         if: ${{ inputs.ezno-version != 'none' }}
         with:
-          packages: wasm-bindgen-cli@0.2.89
+          packages: wasm-pack@0.12.1
 
       - name: Set NPM package version & build
         id: set-npm-version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -139,7 +139,7 @@ jobs:
       - uses: brndnmtthws/rust-action-cargo-binstall@v1
         if: steps.changes.outputs.src == 'true'
         with:
-          packages: wasm-bindgen-cli@0.2.89
+          packages: wasm-pack@0.12.1
       - uses: denoland/setup-deno@v1
         if: steps.changes.outputs.src == 'true'
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,11 +158,13 @@ jobs:
           rustup target add wasm32-unknown-unknown
           npm ci
           npm run build
-          npm run test
+          npm run run-tests
+
           node ./dist/cli.cjs info
           deno run -A ./dist/cli.mjs info
+
           # typegen exhibits debug/release divergent quirks
-          npm run build-release
+          # npm run build-release
           npx -p typescript tsc --strict ./build/ezno_lib.d.ts
         working-directory: src/js-cli-and-library
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,9 +163,14 @@ jobs:
           node ./dist/cli.cjs info
           deno run -A ./dist/cli.mjs info
 
-          # typegen exhibits debug/release divergent quirks
-          # npm run build-release
           npx -p typescript tsc --strict --pretty ./build/ezno_lib.d.ts
+          
+          # TODO temp as the types generated can be a bit unpredicatible
+          echo "::debug::On branch '${{ github.ref_name }}'"
+          if ${{ contains(fromJSON('["main", "ast-typegen-direct"]'), github.ref_name ) }}; then
+            npm run build-release
+            npx -p typescript tsc --strict --pretty ./build/ezno_lib.d.ts
+          fi
         working-directory: src/js-cli-and-library
         shell: bash
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,7 +163,7 @@ jobs:
           deno run -A ./dist/cli.mjs info
           # typegen exhibits debug/release divergent quirks
           npm run build-release
-          npx -p typescript tsc --strict ./dist/shared/ezno_lib*.d.ts
+          npx -p typescript tsc --strict ./build/ezno_lib.d.ts
         working-directory: src/js-cli-and-library
         shell: bash
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -165,7 +165,7 @@ jobs:
 
           # typegen exhibits debug/release divergent quirks
           # npm run build-release
-          npx -p typescript tsc --strict ./build/ezno_lib.d.ts
+          npx -p typescript tsc --strict --pretty ./build/ezno_lib.d.ts
         working-directory: src/js-cli-and-library
         shell: bash
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -161,6 +161,9 @@ jobs:
           npm run test
           node ./dist/cli.cjs info
           deno run -A ./dist/cli.mjs info
+          # typegen exhibits debug/release divergent quirks
+          npm run build-release
+          npx -p typescript tsc --strict ./dist/shared/ezno_lib*.d.ts
         working-directory: src/js-cli-and-library
         shell: bash
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "tsify",
  "wasm-bindgen",
  "wasm-bindgen-derive",
 ]
@@ -297,6 +298,8 @@ dependencies = [
  "serde",
  "source-map",
  "temporary-annex",
+ "tsify",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -327,6 +330,8 @@ dependencies = [
  "source-map",
  "temporary-annex",
  "tokenizer-lib",
+ "tsify",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -374,6 +379,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c1777fe05ec14229f7eede7ecb245051776a405a90501139aa6967a9eba7feb"
 dependencies = [
  "syn-helpers",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -693,6 +711,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.46",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +805,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedcdc3b4760676e1ed01c749e219c98f8da59ef08c62547c19a74bea228c5d8"
 dependencies = [
  "source-map",
+]
+
+[[package]]
+name = "tsify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde_json",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -881,6 +935,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "ezno-parser-visitable-derive",
  "get-field-by-type",
  "iterator-endiate",
+ "macro_rules_attribute",
  "match_deref",
  "pretty_assertions",
  "self-rust-tokenize",
@@ -496,6 +497,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a82271f7bc033d84bbca59a3ce3e4159938cb08a9c3aebbe54d215131518a13"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dd856d451cc0da70e2ef2ce95a18e39a93b7558bedf10201ad28503f918568"
+
+[[package]]
 name = "map_vec"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +595,12 @@ checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "path-absolutize"
@@ -734,13 +757,15 @@ dependencies = [
 
 [[package]]
 name = "source-map"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c87aed86fe881b9427c79b2278f2e70b81dac06996dc789de58f2c1d79f7ec"
+checksum = "562cbf03968c48809f6bd48115b894b6b3bb5af0437f6077c19cb1bd0fb51080"
 dependencies = [
  "codespan-reporting",
  "self-rust-tokenize",
  "serde",
+ "tsify",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,15 @@ wasm-bindgen-derive = "0.2.1"
 serde-wasm-bindgen = "0.6.3"
 console_error_panic_hook = "0.1.7"
 js-sys = "0.3"
+tsify = "0.4.5"
+
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 multiline-term-input = "0.1.0"
 notify = "6.1.0"
+
+# [profile.release]
+# lto = true
+
+# [patch.crates-io]
+# source-map = { path = "../source-map"}

--- a/checker/Cargo.toml
+++ b/checker/Cargo.toml
@@ -21,7 +21,7 @@ ezno-parser = ["dep:parser"]
 serde-serialize = ["dep:serde"]
 
 [dependencies]
-source-map = { version = "0.14.9", features = [
+source-map = { version = "0.14.10", features = [
   "serde-serialize",
   "self-rust-tokenize",
 ] }

--- a/checker/Cargo.toml
+++ b/checker/Cargo.toml
@@ -47,6 +47,11 @@ map_vec = "0.3.0"
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+tsify = "0.4.5"
+wasm-bindgen = "=0.2.89"
+
+
 [dependencies.parser]
 path = "../parser"
 optional = true

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -19,6 +19,7 @@ use std::{
 
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize), serde(rename_all = "lowercase"))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum DiagnosticKind {
 	Error,
 	Warning,
@@ -28,6 +29,7 @@ pub enum DiagnosticKind {
 /// Contains information
 #[derive(Debug)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize), serde(untagged))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Diagnostic {
 	/// Does not have positional information
 	Global {
@@ -103,6 +105,7 @@ impl Diagnostic {
 /// TODO this is one variant, others should pipe strait to stdout or put it on a channel etc
 #[derive(Default)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize), serde(transparent))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct DiagnosticsContainer {
 	diagnostics: Vec<Diagnostic>,
 	// Quick way to check whether a error was added

--- a/checker/src/options.rs
+++ b/checker/src/options.rs
@@ -1,6 +1,7 @@
 /// Options for type checking
 /// TODO figure out compat with tsc
 #[cfg_attr(feature = "serde-serialize", derive(serde::Deserialize), serde(default))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[allow(clippy::struct_excessive_bools)]
 pub struct TypeCheckOptions {
 	/// Parameters cannot be reassigned

--- a/checker/src/synthesis/classes.rs
+++ b/checker/src/synthesis/classes.rs
@@ -64,7 +64,11 @@ pub(super) fn synthesise_class_declaration<
 		match &member.on {
 			ClassMember::Method(false, method) => {
 				let publicity = match method.name.get_ast_ref() {
-					ParserPropertyKey::Ident(_, _, true) => Publicity::Private,
+					ParserPropertyKey::Ident(
+						_,
+						_,
+						parser::property_key::PublicOrPrivate::Private,
+					) => Publicity::Private,
 					_ => Publicity::Public,
 				};
 				let property_key = parser_property_key_to_checker_property_key(
@@ -109,7 +113,11 @@ pub(super) fn synthesise_class_declaration<
 			}
 			ClassMember::Property(false, property) => {
 				let publicity = match property.key.get_ast_ref() {
-					ParserPropertyKey::Ident(_, _, true) => Publicity::Private,
+					ParserPropertyKey::Ident(
+						_,
+						_,
+						parser::property_key::PublicOrPrivate::Private,
+					) => Publicity::Private,
 					_ => Publicity::Public,
 				};
 				let key = parser_property_key_to_checker_property_key(
@@ -160,7 +168,11 @@ pub(super) fn synthesise_class_declaration<
 		match &member.on {
 			ClassMember::Method(true, method) => {
 				let publicity_kind = match method.name.get_ast_ref() {
-					ParserPropertyKey::Ident(_, _, true) => Publicity::Private,
+					ParserPropertyKey::Ident(
+						_,
+						_,
+						parser::property_key::PublicOrPrivate::Private,
+					) => Publicity::Private,
 					_ => Publicity::Public,
 				};
 				let behavior = FunctionRegisterBehavior::ClassMethod {
@@ -193,7 +205,11 @@ pub(super) fn synthesise_class_declaration<
 			}
 			ClassMember::Property(true, property) => {
 				let publicity_kind = match property.key.get_ast_ref() {
-					ParserPropertyKey::Ident(_, _, true) => Publicity::Private,
+					ParserPropertyKey::Ident(
+						_,
+						_,
+						parser::property_key::PublicOrPrivate::Private,
+					) => Publicity::Private,
 					_ => Publicity::Public,
 				};
 				let value = if let Some(ref value) = property.value {

--- a/checker/src/synthesis/functions.rs
+++ b/checker/src/synthesis/functions.rs
@@ -507,7 +507,7 @@ fn param_name_to_string(param: &VariableField<parser::VariableFieldInSourceCode>
 					}
 					parser::ObjectDestructuringField::Map { from, name, .. } => {
 						match from {
-							parser::PropertyKey::Ident(ident, _, ()) => {
+							parser::PropertyKey::Ident(ident, _, _) => {
 								buf.push_str(ident);
 							}
 							parser::PropertyKey::StringLiteral(_, _, _) => todo!(),

--- a/checker/src/synthesis/interfaces.rs
+++ b/checker/src/synthesis/interfaces.rs
@@ -70,7 +70,14 @@ impl SynthesiseInterfaceBehavior for OnToType {
 	) {
 		let (publicity, under) = match key {
 			ParserPropertyKeyType::ClassProperty(key) => (
-				if matches!(key, parser::PropertyKey::Ident(_, _, true)) {
+				if matches!(
+					key,
+					parser::PropertyKey::Ident(
+						_,
+						_,
+						parser::property_key::PublicOrPrivate::Private
+					)
+				) {
 					Publicity::Private
 				} else {
 					Publicity::Public

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -59,6 +59,8 @@ tokenizer-lib = { version = "1.5.1", features = [
   "buffered",
   "sized-tokens",
 ], default_features = false }
+tsify = "0.4.5"
+wasm-bindgen = "=0.2.89"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokenizer-lib = { version = "1.5.1", features = [

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -50,7 +50,7 @@ macro_rules_attribute = { version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 self-rust-tokenize = { version = "0.3.3", optional = true }
 
-source-map = { version = "0.14.9", features = [
+source-map = { version = "0.14.10", features = [
   "serde-serialize",
   "self-rust-tokenize",
 ] }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -45,6 +45,8 @@ enum-variants-strings = "0.2"
 
 get-field-by-type = "0.0.3"
 
+macro_rules_attribute = { version = "0.2.0" }
+
 serde = { version = "1.0", features = ["derive"], optional = true }
 self-rust-tokenize = { version = "0.3.3", optional = true }
 

--- a/parser/src/block.rs
+++ b/parser/src/block.rs
@@ -6,7 +6,7 @@ use visitable_derive::Visitable;
 use super::{ASTNode, Span, TSXToken, TokenReader};
 use crate::{
 	declarations::{export::Exportable, ExportDeclaration},
-	expect_semi_colon,
+	default_derive_bundle, expect_semi_colon,
 	marker::MARKER,
 	Declaration, Decorated, Marker, ParseOptions, ParseResult, Statement, TSXKeyword, VisitOptions,
 	Visitable,
@@ -243,9 +243,7 @@ impl Visitable for Block {
 
 /// For ifs and other statements
 #[derive(Debug, Clone, PartialEq, Eq, EnumFrom)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle!)]
 pub enum BlockOrSingleStatement {
 	Braced(Block),
 	SingleStatement(Box<Statement>),

--- a/parser/src/block.rs
+++ b/parser/src/block.rs
@@ -6,7 +6,7 @@ use visitable_derive::Visitable;
 use super::{ASTNode, Span, TSXToken, TokenReader};
 use crate::{
 	declarations::{export::Exportable, ExportDeclaration},
-	default_derive_bundle, expect_semi_colon,
+	derive_ASTNode, expect_semi_colon,
 	marker::MARKER,
 	Declaration, Decorated, Marker, ParseOptions, ParseResult, Statement, TSXKeyword, VisitOptions,
 	Visitable,
@@ -243,7 +243,7 @@ impl Visitable for Block {
 
 /// For ifs and other statements
 #[derive(Debug, Clone, PartialEq, Eq, EnumFrom)]
-#[apply(default_derive_bundle!)]
+#[apply(derive_ASTNode!)]
 pub enum BlockOrSingleStatement {
 	Braced(Block),
 	SingleStatement(Box<Statement>),

--- a/parser/src/block.rs
+++ b/parser/src/block.rs
@@ -12,11 +12,9 @@ use crate::{
 	Visitable,
 };
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Visitable, get_field_by_type::GetFieldByType, EnumFrom)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[visit_self(under statement)]
 pub enum StatementOrDeclaration {
 	Statement(Statement),
@@ -111,11 +109,9 @@ impl ASTNode for StatementOrDeclaration {
 }
 
 /// A "block" of braced statements and declarations
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct Block(pub Vec<StatementOrDeclaration>, pub Span);
 
 impl Eq for Block {}

--- a/parser/src/block.rs
+++ b/parser/src/block.rs
@@ -16,6 +16,7 @@ use crate::{
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[visit_self(under statement)]
 pub enum StatementOrDeclaration {
 	Statement(Statement),
@@ -114,6 +115,7 @@ impl ASTNode for StatementOrDeclaration {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct Block(pub Vec<StatementOrDeclaration>, pub Span);
 
 impl Eq for Block {}
@@ -243,6 +245,7 @@ impl Visitable for Block {
 #[derive(Debug, Clone, PartialEq, Eq, EnumFrom)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum BlockOrSingleStatement {
 	Braced(Block),
 	SingleStatement(Box<Statement>),

--- a/parser/src/comments.rs
+++ b/parser/src/comments.rs
@@ -6,8 +6,9 @@ use crate::ParseOptions;
 use tokenizer_lib::Token;
 use visitable_derive::Visitable;
 
+// #[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+
 #[derive(Debug, Clone, Eq, Visitable)]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum WithComment<T> {
 	None(T),
 	PrefixComment(String, T, Span),

--- a/parser/src/comments.rs
+++ b/parser/src/comments.rs
@@ -7,6 +7,7 @@ use tokenizer_lib::Token;
 use visitable_derive::Visitable;
 
 #[derive(Debug, Clone, Eq, Visitable)]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum WithComment<T> {
 	None(T),
 	PrefixComment(String, T, Span),

--- a/parser/src/comments.rs
+++ b/parser/src/comments.rs
@@ -6,8 +6,7 @@ use crate::ParseOptions;
 use tokenizer_lib::Token;
 use visitable_derive::Visitable;
 
-// #[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
-
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[derive(Debug, Clone, Eq, Visitable)]
 pub enum WithComment<T> {
 	None(T),

--- a/parser/src/declarations/classes/class_member.rs
+++ b/parser/src/declarations/classes/class_member.rs
@@ -30,22 +30,22 @@ pub enum ClassMember {
 pub struct ClassConstructorBase;
 pub type ClassConstructor = FunctionBase<ClassConstructorBase>;
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const CLASS_CONSTRUCTOR_TYPES: &str = r###"
+const CLASS_CONSTRUCTOR_TYPES: &str = r"
 	export interface ClassConstructor extends Omit<FunctionBase, 'header' | 'name'> {
 		body: Block
 	}
-"###;
+";
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ClassFunctionBase;
 pub type ClassFunction = FunctionBase<ClassFunctionBase>;
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const CLASS_FUNCTION_TYPES: &str = r###"
+const CLASS_FUNCTION_TYPES: &str = r"
 	export interface ClassFunction extends FunctionBase {
 		header: MethodHeader,
 		body: Block,
 		name: WithComment<PropertyKey<PublicOrPrivate>>
 	}
-"###;
+";
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[apply(default_derive_bundle)]

--- a/parser/src/declarations/classes/class_member.rs
+++ b/parser/src/declarations/classes/class_member.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use crate::{
-	default_derive_bundle, errors::parse_lexing_error, functions::HeadingAndPosition,
+	derive_ASTNode, errors::parse_lexing_error, functions::HeadingAndPosition,
 	property_key::PublicOrPrivate, visiting::Visitable,
 };
 use source_map::Span;
@@ -17,7 +17,7 @@ use crate::{
 pub type IsStatic = bool;
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum ClassMember {
 	Constructor(ClassConstructor),
 	Method(IsStatic, ClassFunction),
@@ -48,7 +48,7 @@ const CLASS_FUNCTION_TYPES: &str = r"
 ";
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct ClassProperty {
 	pub is_readonly: bool,
 	pub key: WithComment<PropertyKey<PublicOrPrivate>>,

--- a/parser/src/declarations/classes/class_member.rs
+++ b/parser/src/declarations/classes/class_member.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
 use crate::{
-	errors::parse_lexing_error, functions::HeadingAndPosition, property_key::PublicOrPrivate,
-	visiting::Visitable,
+	default_derive_bundle, errors::parse_lexing_error, functions::HeadingAndPosition,
+	property_key::PublicOrPrivate, visiting::Visitable,
 };
 use source_map::Span;
 use tokenizer_lib::{sized_tokens::TokenStart, Token, TokenReader};
@@ -17,9 +17,7 @@ use crate::{
 pub type IsStatic = bool;
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum ClassMember {
 	Constructor(ClassConstructor),
 	Method(IsStatic, ClassFunction),
@@ -50,9 +48,7 @@ const CLASS_FUNCTION_TYPES: &str = r###"
 "###;
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct ClassProperty {
 	pub is_readonly: bool,
 	pub key: WithComment<PropertyKey<PublicOrPrivate>>,

--- a/parser/src/declarations/classes/mod.rs
+++ b/parser/src/declarations/classes/mod.rs
@@ -2,7 +2,7 @@ mod class_member;
 
 use std::fmt::Debug;
 
-use crate::{throw_unexpected_token_with_token, to_string_bracketed, Expression};
+use crate::{derive_ASTNode, throw_unexpected_token_with_token, to_string_bracketed, Expression};
 pub use class_member::*;
 use iterator_endiate::EndiateIteratorExt;
 
@@ -16,11 +16,9 @@ use tokenizer_lib::{
 	Token, TokenReader,
 };
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ClassDeclaration<T: ExpressionOrStatementPosition> {
 	pub name: T,
 	pub type_parameters: Option<Vec<GenericTypeConstraint>>,

--- a/parser/src/declarations/classes/mod.rs
+++ b/parser/src/declarations/classes/mod.rs
@@ -20,6 +20,7 @@ use tokenizer_lib::{
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ClassDeclaration<T: ExpressionOrStatementPosition> {
 	pub name: T,
 	pub type_parameters: Option<Vec<GenericTypeConstraint>>,

--- a/parser/src/declarations/export.rs
+++ b/parser/src/declarations/export.rs
@@ -315,9 +315,21 @@ impl ASTNode for ExportDeclaration {
 #[get_field_by_type_target(Span)]
 pub enum ExportPart {
 	Name(VariableIdentifier),
-	NameWithAlias { name: String, alias: ImportExportName, position: Span },
-	PrefixComment(String, Option<Box<Self>>, Span),
-	PostfixComment(Box<Self>, String, Span),
+	NameWithAlias {
+		name: String,
+		alias: ImportExportName,
+		position: Span,
+	},
+	PrefixComment(
+		String,
+		#[cfg_attr(target_family = "wasm", tsify(type = "ExportPart | null"))] Option<Box<Self>>,
+		Span,
+	),
+	PostfixComment(
+		#[cfg_attr(target_family = "wasm", tsify(type = "ExportPart"))] Box<Self>,
+		String,
+		Span,
+	),
 }
 
 impl ListItem for ExportPart {}

--- a/parser/src/declarations/export.rs
+++ b/parser/src/declarations/export.rs
@@ -21,6 +21,7 @@ use visitable_derive::Visitable;
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ExportDeclaration {
 	// TODO listed object thing
 	// TODO export *
@@ -33,6 +34,7 @@ pub enum ExportDeclaration {
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Exportable {
 	Class(ClassDeclaration<StatementPosition>),
 	Function(StatementFunction),
@@ -309,6 +311,7 @@ impl ASTNode for ExportDeclaration {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, GetFieldByType)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[get_field_by_type_target(Span)]
 pub enum ExportPart {
 	Name(VariableIdentifier),

--- a/parser/src/declarations/export.rs
+++ b/parser/src/declarations/export.rs
@@ -1,5 +1,5 @@
 use crate::{
-	default_derive_bundle, errors::parse_lexing_error, throw_unexpected_token, ASTNode, Expression,
+	derive_ASTNode, errors::parse_lexing_error, throw_unexpected_token, ASTNode, Expression,
 	ListItem, ParseError, ParseOptions, ParseResult, Span, StatementPosition, TSXKeyword, TSXToken,
 	Token, VariableIdentifier,
 };
@@ -32,7 +32,7 @@ pub enum ExportDeclaration {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum Exportable {
 	Class(ClassDeclaration<StatementPosition>),
 	Function(StatementFunction),

--- a/parser/src/declarations/export.rs
+++ b/parser/src/declarations/export.rs
@@ -17,11 +17,9 @@ use visitable_derive::Visitable;
 /// TODO tidy up into struct
 ///
 /// [See](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export)
+#[apply(derive_ASTNode)]
 #[derive(Debug, PartialEq, Eq, Clone, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ExportDeclaration {
 	// TODO listed object thing
 	// TODO export *
@@ -306,10 +304,8 @@ impl ASTNode for ExportDeclaration {
 /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#syntax>
 ///
 /// Similar to [`ImportPart`] but reversed
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, GetFieldByType)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[get_field_by_type_target(Span)]
 pub enum ExportPart {
 	Name(VariableIdentifier),

--- a/parser/src/declarations/export.rs
+++ b/parser/src/declarations/export.rs
@@ -1,7 +1,7 @@
 use crate::{
-	errors::parse_lexing_error, throw_unexpected_token, ASTNode, Expression, ListItem, ParseError,
-	ParseOptions, ParseResult, Span, StatementPosition, TSXKeyword, TSXToken, Token,
-	VariableIdentifier,
+	default_derive_bundle, errors::parse_lexing_error, throw_unexpected_token, ASTNode, Expression,
+	ListItem, ParseError, ParseOptions, ParseResult, Span, StatementPosition, TSXKeyword, TSXToken,
+	Token, VariableIdentifier,
 };
 
 use super::{
@@ -32,9 +32,7 @@ pub enum ExportDeclaration {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum Exportable {
 	Class(ClassDeclaration<StatementPosition>),
 	Function(StatementFunction),

--- a/parser/src/declarations/import.rs
+++ b/parser/src/declarations/import.rs
@@ -16,6 +16,7 @@ use super::ImportLocation;
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ImportedItems {
 	Parts(Option<Vec<ImportPart>>),
 	All { under: VariableIdentifier },
@@ -26,6 +27,7 @@ pub enum ImportedItems {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ImportDeclaration {
 	#[cfg(feature = "extras")]
 	pub is_deferred: bool,
@@ -42,6 +44,7 @@ pub struct ImportDeclaration {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ImportExportName {
 	Reference(String),
 	Quoted(String, Quoted),
@@ -284,6 +287,7 @@ pub(crate) fn parse_import_specifier_and_parts(
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, GetFieldByType)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[get_field_by_type_target(Span)]
 pub enum ImportPart {
 	Name(VariableIdentifier),

--- a/parser/src/declarations/import.rs
+++ b/parser/src/declarations/import.rs
@@ -21,11 +21,9 @@ pub enum ImportedItems {
 }
 
 /// TODO a few more thing needed here
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ImportDeclaration {
 	#[cfg(feature = "extras")]
 	pub is_deferred: bool,
@@ -282,10 +280,8 @@ pub(crate) fn parse_import_specifier_and_parts(
 }
 
 /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#syntax>
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, GetFieldByType)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[get_field_by_type_target(Span)]
 pub enum ImportPart {
 	Name(VariableIdentifier),

--- a/parser/src/declarations/import.rs
+++ b/parser/src/declarations/import.rs
@@ -4,7 +4,7 @@ use source_map::Span;
 use tokenizer_lib::{sized_tokens::TokenStart, Token, TokenReader};
 
 use crate::{
-	default_derive_bundle, errors::parse_lexing_error, parse_bracketed, throw_unexpected_token,
+	derive_ASTNode, errors::parse_lexing_error, parse_bracketed, throw_unexpected_token,
 	tokens::token_as_identifier, ASTNode, ListItem, Marker, ParseOptions, ParseResult,
 	ParsingState, Quoted, TSXKeyword, TSXToken, VariableIdentifier,
 };
@@ -14,7 +14,7 @@ use super::ImportLocation;
 
 /// Side effects is represented under the Parts variant where the vector is empty
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum ImportedItems {
 	Parts(Option<Vec<ImportPart>>),
 	All { under: VariableIdentifier },
@@ -40,7 +40,7 @@ pub struct ImportDeclaration {
 
 /// TODO default
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum ImportExportName {
 	Reference(String),
 	Quoted(String, Quoted),

--- a/parser/src/declarations/import.rs
+++ b/parser/src/declarations/import.rs
@@ -49,7 +49,9 @@ pub enum ImportExportName {
 	Reference(String),
 	Quoted(String, Quoted),
 	#[cfg_attr(feature = "self-rust-tokenize", self_tokenize_field(0))]
-	Marker(Marker<Self>),
+	Marker(
+		#[cfg_attr(target_family = "wasm", tsify(type = "Marker<ImportExportName>"))] Marker<Self>,
+	),
 }
 
 impl ImportExportName {
@@ -291,9 +293,21 @@ pub(crate) fn parse_import_specifier_and_parts(
 #[get_field_by_type_target(Span)]
 pub enum ImportPart {
 	Name(VariableIdentifier),
-	NameWithAlias { name: String, alias: ImportExportName, position: Span },
-	PrefixComment(String, Option<Box<Self>>, Span),
-	PostfixComment(Box<Self>, String, Span),
+	NameWithAlias {
+		name: String,
+		alias: ImportExportName,
+		position: Span,
+	},
+	PrefixComment(
+		String,
+		#[cfg_attr(target_family = "wasm", tsify(type = "ImportPart | null"))] Option<Box<Self>>,
+		Span,
+	),
+	PostfixComment(
+		#[cfg_attr(target_family = "wasm", tsify(type = "ImportPart"))] Box<Self>,
+		String,
+		Span,
+	),
 }
 
 impl ListItem for ImportPart {}

--- a/parser/src/declarations/import.rs
+++ b/parser/src/declarations/import.rs
@@ -4,7 +4,7 @@ use source_map::Span;
 use tokenizer_lib::{sized_tokens::TokenStart, Token, TokenReader};
 
 use crate::{
-	errors::parse_lexing_error, parse_bracketed, throw_unexpected_token,
+	default_derive_bundle, errors::parse_lexing_error, parse_bracketed, throw_unexpected_token,
 	tokens::token_as_identifier, ASTNode, ListItem, Marker, ParseOptions, ParseResult,
 	ParsingState, Quoted, TSXKeyword, TSXToken, VariableIdentifier,
 };
@@ -14,9 +14,7 @@ use super::ImportLocation;
 
 /// Side effects is represented under the Parts variant where the vector is empty
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum ImportedItems {
 	Parts(Option<Vec<ImportPart>>),
 	All { under: VariableIdentifier },
@@ -42,9 +40,7 @@ pub struct ImportDeclaration {
 
 /// TODO default
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum ImportExportName {
 	Reference(String),
 	Quoted(String, Quoted),

--- a/parser/src/declarations/mod.rs
+++ b/parser/src/declarations/mod.rs
@@ -5,9 +5,9 @@ use tokenizer_lib::{sized_tokens::TokenStart, Token};
 use visitable_derive::Visitable;
 
 use crate::{
-	errors::parse_lexing_error, extensions::decorators, throw_unexpected_token_with_token,
-	Decorated, Marker, ParseError, ParseErrors, ParseOptions, Quoted, StatementPosition,
-	TSXKeyword, TSXToken, TypeDefinitionModuleDeclaration,
+	derive_ASTNode, errors::parse_lexing_error, extensions::decorators,
+	throw_unexpected_token_with_token, Decorated, Marker, ParseError, ParseErrors, ParseOptions,
+	Quoted, StatementPosition, TSXKeyword, TSXToken, TypeDefinitionModuleDeclaration,
 };
 
 pub use self::{
@@ -40,14 +40,12 @@ pub use super::types::{
 pub use classes::ClassDeclaration;
 pub use import::{ImportDeclaration, ImportExportName, ImportPart};
 
+#[apply(derive_ASTNode)]
 #[derive(
 	Debug, Clone, Visitable, EnumFrom, EnumTryInto, PartialEq, get_field_by_type::GetFieldByType,
 )]
 #[get_field_by_type_target(Span)]
 #[try_into_references(&, &mut)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Declaration {
 	Variable(VariableDeclaration),
 	Function(Decorated<StatementFunction>),
@@ -109,10 +107,8 @@ impl Declaration {
 	}
 }
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ImportLocation {
 	Quoted(String, Quoted),
 	#[cfg_attr(feature = "self-rust-tokenize", self_tokenize_field(0))]

--- a/parser/src/declarations/mod.rs
+++ b/parser/src/declarations/mod.rs
@@ -19,13 +19,13 @@ pub type StatementFunctionBase = crate::functions::GeneralFunctionBase<Statement
 pub type StatementFunction = crate::FunctionBase<StatementFunctionBase>;
 
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES_STATEMENT_FUNCTION: &str = r###"
+const TYPES_STATEMENT_FUNCTION: &str = r"
 	export interface StatementFunction extends FunctionBase {
 		header: FunctionHeader,
 		body: Block,
 		name: StatementPosition
 	}
-"###;
+";
 pub mod classes;
 pub mod export;
 pub mod import;

--- a/parser/src/declarations/mod.rs
+++ b/parser/src/declarations/mod.rs
@@ -116,7 +116,9 @@ impl Declaration {
 pub enum ImportLocation {
 	Quoted(String, Quoted),
 	#[cfg_attr(feature = "self-rust-tokenize", self_tokenize_field(0))]
-	Marker(Marker<Self>),
+	Marker(
+		#[cfg_attr(target_family = "wasm", tsify(type = "Marker<ImportLocation>"))] Marker<Self>,
+	),
 }
 
 impl ImportLocation {

--- a/parser/src/declarations/mod.rs
+++ b/parser/src/declarations/mod.rs
@@ -18,6 +18,14 @@ pub use self::{
 pub type StatementFunctionBase = crate::functions::GeneralFunctionBase<StatementPosition>;
 pub type StatementFunction = crate::FunctionBase<StatementFunctionBase>;
 
+#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+const TYPES_STATEMENT_FUNCTION: &str = r###"
+	export interface StatementFunction extends FunctionBase {
+		header: FunctionHeader,
+		body: Block,
+		name: StatementPosition
+	}
+"###;
 pub mod classes;
 pub mod export;
 pub mod import;
@@ -39,6 +47,7 @@ pub use import::{ImportDeclaration, ImportExportName, ImportPart};
 #[try_into_references(&, &mut)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Declaration {
 	Variable(VariableDeclaration),
 	Function(Decorated<StatementFunction>),
@@ -103,6 +112,7 @@ impl Declaration {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ImportLocation {
 	Quoted(String, Quoted),
 	#[cfg_attr(feature = "self-rust-tokenize", self_tokenize_field(0))]

--- a/parser/src/declarations/variable.rs
+++ b/parser/src/declarations/variable.rs
@@ -194,6 +194,7 @@ impl<TExpr: DeclarationExpression + 'static> ASTNode for VariableDeclarationItem
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum VariableDeclaration {
 	ConstDeclaration {
 		declarations: Vec<VariableDeclarationItem<Expression>>,
@@ -208,6 +209,7 @@ pub enum VariableDeclaration {
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum VariableDeclarationKeyword {
 	Const,
 	Let,

--- a/parser/src/declarations/variable.rs
+++ b/parser/src/declarations/variable.rs
@@ -124,6 +124,7 @@ impl DeclarationExpression for crate::Expression {
 #[partial_eq_ignore_types(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct VariableDeclarationItem<TExpr: DeclarationExpression> {
 	pub name: WithComment<VariableField<VariableFieldInSourceCode>>,
 	pub type_annotation: Option<TypeAnnotation>,

--- a/parser/src/declarations/variable.rs
+++ b/parser/src/declarations/variable.rs
@@ -3,9 +3,10 @@ use get_field_by_type::GetFieldByType;
 use iterator_endiate::EndiateIteratorExt;
 
 use crate::{
-	errors::parse_lexing_error, operators::COMMA_PRECEDENCE, throw_unexpected_token_with_token,
-	ASTNode, Expression, ParseOptions, ParseResult, Span, TSXKeyword, TSXToken, Token, TokenReader,
-	TypeAnnotation, VariableField, VariableFieldInSourceCode, WithComment,
+	default_derive_bundle, errors::parse_lexing_error, operators::COMMA_PRECEDENCE,
+	throw_unexpected_token_with_token, ASTNode, Expression, ParseOptions, ParseResult, Span,
+	TSXKeyword, TSXToken, Token, TokenReader, TypeAnnotation, VariableField,
+	VariableFieldInSourceCode, WithComment,
 };
 use visitable_derive::Visitable;
 
@@ -208,9 +209,7 @@ pub enum VariableDeclaration {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum VariableDeclarationKeyword {
 	Const,
 	Let,

--- a/parser/src/declarations/variable.rs
+++ b/parser/src/declarations/variable.rs
@@ -120,12 +120,10 @@ impl DeclarationExpression for crate::Expression {
 }
 
 /// Represents a name =
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEqExtras, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
 #[partial_eq_ignore_types(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct VariableDeclarationItem<TExpr: DeclarationExpression> {
 	pub name: WithComment<VariableField<VariableFieldInSourceCode>>,
 	pub type_annotation: Option<TypeAnnotation>,
@@ -191,12 +189,10 @@ impl<TExpr: DeclarationExpression + 'static> ASTNode for VariableDeclarationItem
 	}
 }
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEqExtras, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[partial_eq_ignore_types(Span)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum VariableDeclaration {
 	ConstDeclaration {
 		declarations: Vec<VariableDeclarationItem<Expression>>,

--- a/parser/src/declarations/variable.rs
+++ b/parser/src/declarations/variable.rs
@@ -3,7 +3,7 @@ use get_field_by_type::GetFieldByType;
 use iterator_endiate::EndiateIteratorExt;
 
 use crate::{
-	default_derive_bundle, errors::parse_lexing_error, operators::COMMA_PRECEDENCE,
+	derive_ASTNode, errors::parse_lexing_error, operators::COMMA_PRECEDENCE,
 	throw_unexpected_token_with_token, ASTNode, Expression, ParseOptions, ParseResult, Span,
 	TSXKeyword, TSXToken, Token, TokenReader, TypeAnnotation, VariableField,
 	VariableFieldInSourceCode, WithComment,
@@ -209,7 +209,7 @@ pub enum VariableDeclaration {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum VariableDeclarationKeyword {
 	Const,
 	Let,

--- a/parser/src/expressions/arrow_function.rs
+++ b/parser/src/expressions/arrow_function.rs
@@ -16,12 +16,12 @@ pub type ArrowFunction = FunctionBase<ArrowFunctionBase>;
 pub type IsAsync = bool;
 
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES: &str = r###"
+const TYPES: &str = r"
 	export interface ArrowFunction extends Omit<FunctionBase, 'name'> {
 		header: IsAsync,
 		body: ExpressionOrBlock
 	}
-"###;
+";
 
 impl FunctionBased for ArrowFunctionBase {
 	type Name = ();

--- a/parser/src/expressions/arrow_function.rs
+++ b/parser/src/expressions/arrow_function.rs
@@ -1,4 +1,4 @@
-use crate::{functions::HeadingAndPosition, VariableIdentifier};
+use crate::{default_derive_bundle, functions::HeadingAndPosition, VariableIdentifier};
 use tokenizer_lib::sized_tokens::TokenStart;
 use visitable_derive::Visitable;
 
@@ -204,9 +204,7 @@ impl ArrowFunction {
 
 /// For [`ArrowFunction`] and [`crate::MatchArm`] bodies
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum ExpressionOrBlock {
 	Expression(Box<Expression>),
 	Block(Block),

--- a/parser/src/expressions/arrow_function.rs
+++ b/parser/src/expressions/arrow_function.rs
@@ -12,7 +12,16 @@ use crate::{
 pub struct ArrowFunctionBase;
 
 pub type ArrowFunction = FunctionBase<ArrowFunctionBase>;
+#[cfg_attr(target_family = "wasm", tsify::declare)]
 pub type IsAsync = bool;
+
+#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+const TYPES: &str = r###"
+	export interface ArrowFunction extends Omit<FunctionBase, 'name'> {
+		header: IsAsync,
+		body: ExpressionOrBlock
+	}
+"###;
 
 impl FunctionBased for ArrowFunctionBase {
 	type Name = ();
@@ -197,6 +206,7 @@ impl ArrowFunction {
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ExpressionOrBlock {
 	Expression(Box<Expression>),
 	Block(Block),

--- a/parser/src/expressions/arrow_function.rs
+++ b/parser/src/expressions/arrow_function.rs
@@ -1,4 +1,4 @@
-use crate::{default_derive_bundle, functions::HeadingAndPosition, VariableIdentifier};
+use crate::{derive_ASTNode, functions::HeadingAndPosition, VariableIdentifier};
 use tokenizer_lib::sized_tokens::TokenStart;
 use visitable_derive::Visitable;
 
@@ -204,7 +204,7 @@ impl ArrowFunction {
 
 /// For [`ArrowFunction`] and [`crate::MatchArm`] bodies
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum ExpressionOrBlock {
 	Expression(Box<Expression>),
 	Block(Block),

--- a/parser/src/expressions/assignments.rs
+++ b/parser/src/expressions/assignments.rs
@@ -18,6 +18,7 @@ use super::MultipleExpression;
 #[partial_eq_ignore_types(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum VariableOrPropertyAccess {
 	Variable(String, Span),
 	PropertyAccess {
@@ -167,6 +168,7 @@ impl VariableOrPropertyAccess {
 #[derive(PartialEqExtras, Debug, Clone, Visitable, derive_enum_from_into::EnumFrom)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[partial_eq_ignore_types(Span)]
 pub enum LHSOfAssignment {
 	ObjectDestructuring(

--- a/parser/src/expressions/assignments.rs
+++ b/parser/src/expressions/assignments.rs
@@ -1,4 +1,4 @@
-use crate::{PropertyReference, TSXToken};
+use crate::{derive_ASTNode, PropertyReference, TSXToken};
 use derive_partial_eq_extras::PartialEqExtras;
 use get_field_by_type::GetFieldByType;
 use iterator_endiate::EndiateIteratorExt;
@@ -13,12 +13,11 @@ use crate::{
 
 use super::MultipleExpression;
 
+/// TODO marker
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEqExtras, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
 #[partial_eq_ignore_types(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum VariableOrPropertyAccess {
 	Variable(String, Span),
 	PropertyAccess {
@@ -164,11 +163,8 @@ impl VariableOrPropertyAccess {
 
 /// TODO should be different from `VariableFieldInSourceCode` here
 /// TODO visitable is current skipped...
-/// TODO marker
+#[apply(derive_ASTNode)]
 #[derive(PartialEqExtras, Debug, Clone, Visitable, derive_enum_from_into::EnumFrom)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[partial_eq_ignore_types(Span)]
 pub enum LHSOfAssignment {
 	ObjectDestructuring(

--- a/parser/src/expressions/mod.rs
+++ b/parser/src/expressions/mod.rs
@@ -55,6 +55,7 @@ use std::convert::{TryFrom, TryInto};
 #[visit_self]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Expression {
 	// Literals:
 	NumberLiteral(NumberRepresentation, Span),
@@ -183,6 +184,7 @@ impl Eq for Expression {}
 #[derive(PartialEq, Eq, Debug, Clone)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum PropertyReference {
 	Standard {
 		property: String,
@@ -1671,6 +1673,7 @@ fn function_header_ish(
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize), serde(untagged))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum MultipleExpression {
 	Multiple { lhs: Box<MultipleExpression>, rhs: Expression, position: Span },
 	Single(Expression),
@@ -1861,6 +1864,7 @@ pub(crate) fn arguments_to_string<T: source_map::ToString>(
 #[partial_eq_ignore_types(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum InExpressionLHS {
 	PrivateProperty(String),
 	Expression(Box<Expression>),
@@ -1871,6 +1875,7 @@ pub enum InExpressionLHS {
 #[partial_eq_ignore_types(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum SpecialOperators {
 	/// TS Only
 	AsExpression {
@@ -1900,6 +1905,7 @@ pub enum SpecialOperators {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum SpreadExpression {
 	Spread(Expression, Span),
 	NonSpread(Expression),
@@ -1986,6 +1992,7 @@ impl From<Expression> for SpreadExpression {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ArrayElement(pub Option<SpreadExpression>);
 
 impl ASTNode for ArrayElement {
@@ -2107,6 +2114,7 @@ impl Expression {
 #[partial_eq_ignore_types(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum SuperReference {
 	Call { arguments: Vec<SpreadExpression> },
 	PropertyAccess { property: String },

--- a/parser/src/expressions/mod.rs
+++ b/parser/src/expressions/mod.rs
@@ -1,7 +1,8 @@
 use crate::{
 	declarations::ClassDeclaration,
+	default_derive_bundle,
 	errors::parse_lexing_error,
-	functions::{self},
+	functions,
 	operators::{
 		AssociativityDirection, BinaryAssignmentOperator, UnaryPostfixAssignmentOperator,
 		UnaryPrefixAssignmentOperator, ASSIGNMENT_PRECEDENCE, FUNCTION_CALL_PRECEDENCE,
@@ -182,9 +183,7 @@ pub enum Expression {
 impl Eq for Expression {}
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum PropertyReference {
 	Standard {
 		property: String,
@@ -1903,9 +1902,7 @@ pub enum SpecialOperators {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum SpreadExpression {
 	Spread(Expression, Span),
 	NonSpread(Expression),
@@ -1990,9 +1987,7 @@ impl From<Expression> for SpreadExpression {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct ArrayElement(pub Option<SpreadExpression>);
 
 impl ASTNode for ArrayElement {

--- a/parser/src/expressions/mod.rs
+++ b/parser/src/expressions/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
 	declarations::ClassDeclaration,
-	default_derive_bundle,
+	derive_ASTNode,
 	errors::parse_lexing_error,
 	functions,
 	operators::{
@@ -183,7 +183,7 @@ pub enum Expression {
 impl Eq for Expression {}
 
 #[derive(PartialEq, Eq, Debug, Clone)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum PropertyReference {
 	Standard {
 		property: String,
@@ -1902,7 +1902,7 @@ pub enum SpecialOperators {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum SpreadExpression {
 	Spread(Expression, Span),
 	NonSpread(Expression),
@@ -1987,7 +1987,7 @@ impl From<Expression> for SpreadExpression {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct ArrayElement(pub Option<SpreadExpression>);
 
 impl ASTNode for ArrayElement {

--- a/parser/src/expressions/mod.rs
+++ b/parser/src/expressions/mod.rs
@@ -50,13 +50,11 @@ use std::convert::{TryFrom, TryInto};
 /// Expression structures
 ///
 /// Comma is implemented as a [`BinaryOperator`]
+#[apply(derive_ASTNode)]
 #[derive(PartialEqExtras, Debug, Clone, Visitable, GetFieldByType)]
 #[get_field_by_type_target(Span)]
 #[partial_eq_ignore_types(Span)]
 #[visit_self]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Expression {
 	// Literals:
 	NumberLiteral(NumberRepresentation, Span),
@@ -1668,11 +1666,9 @@ fn function_header_ish(
 }
 
 /// Represents expressions that can be `,`
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize), serde(untagged))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum MultipleExpression {
 	Multiple { lhs: Box<MultipleExpression>, rhs: Expression, position: Span },
 	Single(Expression),
@@ -1859,22 +1855,18 @@ pub(crate) fn arguments_to_string<T: source_map::ToString>(
 	buf.push(')');
 }
 
+#[apply(derive_ASTNode)]
 #[derive(PartialEqExtras, Debug, Clone, Visitable)]
 #[partial_eq_ignore_types(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum InExpressionLHS {
 	PrivateProperty(String),
 	Expression(Box<Expression>),
 }
 
 /// Binary operations whose RHS are types rather than [Expression]s
+#[apply(derive_ASTNode)]
 #[derive(PartialEqExtras, Debug, Clone, Visitable)]
 #[partial_eq_ignore_types(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum SpecialOperators {
 	/// TS Only
 	AsExpression {
@@ -2105,11 +2097,9 @@ impl Expression {
 }
 
 /// "super" cannot be used alone
+#[apply(derive_ASTNode)]
 #[derive(PartialEqExtras, Debug, Clone, Visitable)]
 #[partial_eq_ignore_types(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum SuperReference {
 	Call { arguments: Vec<SpreadExpression> },
 	PropertyAccess { property: String },

--- a/parser/src/expressions/object_literal.rs
+++ b/parser/src/expressions/object_literal.rs
@@ -5,6 +5,7 @@ use tokenizer_lib::sized_tokens::{TokenReaderWithTokenEnds, TokenStart};
 use visitable_derive::Visitable;
 
 use crate::{
+	derive_ASTNode,
 	errors::parse_lexing_error,
 	functions::{FunctionBased, HeadingAndPosition, MethodHeader},
 	property_key::AlwaysPublic,
@@ -14,21 +15,17 @@ use crate::{
 	TSXToken, Token, TokenReader, WithComment,
 };
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, Eq, PartialEq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ObjectLiteral {
 	pub members: Vec<ObjectLiteralMember>,
 	pub position: Span,
 }
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEqExtras)]
 #[partial_eq_ignore_types(Span, VariableId)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ObjectLiteralMember {
 	Spread(Expression, Span),
 	Shorthand(String, Span),
@@ -243,7 +240,7 @@ impl ASTNode for ObjectLiteralMember {
 					return crate::throw_unexpected_token(reader, &[TSXToken::OpenParentheses]);
 				}
 				if let Some(Token(TSXToken::Comma | TSXToken::CloseBrace, _)) = reader.peek() {
-					if let PropertyKey::Ident(name, position, ()) = key.get_ast() {
+					if let PropertyKey::Ident(name, position, _) = key.get_ast() {
 						Ok(Self::Shorthand(name, position))
 					} else {
 						let token = reader.next().ok_or_else(parse_lexing_error)?;

--- a/parser/src/expressions/object_literal.rs
+++ b/parser/src/expressions/object_literal.rs
@@ -73,13 +73,13 @@ pub struct ObjectLiteralMethodBase;
 pub type ObjectLiteralMethod = FunctionBase<ObjectLiteralMethodBase>;
 
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES: &str = r###"
+const TYPES: &str = r"
 	export interface ObjectLiteralMethod extends FunctionBase {
 		header: MethodHeader,
 		body: Block,
 		name: WithComment<PropertyKey<AlwaysPublic>>
 	}
-"###;
+";
 
 impl FunctionBased for ObjectLiteralMethodBase {
 	type Name = WithComment<PropertyKey<AlwaysPublic>>;

--- a/parser/src/expressions/object_literal.rs
+++ b/parser/src/expressions/object_literal.rs
@@ -18,6 +18,7 @@ use crate::{
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ObjectLiteral {
 	pub members: Vec<ObjectLiteralMember>,
 	pub position: Span,
@@ -27,6 +28,7 @@ pub struct ObjectLiteral {
 #[partial_eq_ignore_types(Span, VariableId)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ObjectLiteralMember {
 	Spread(Expression, Span),
 	Shorthand(String, Span),
@@ -69,6 +71,15 @@ impl crate::Visitable for ObjectLiteralMember {
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct ObjectLiteralMethodBase;
 pub type ObjectLiteralMethod = FunctionBase<ObjectLiteralMethodBase>;
+
+#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+const TYPES: &str = r###"
+	export interface ObjectLiteralMethod extends FunctionBase {
+		header: MethodHeader,
+		body: Block,
+		name: WithComment<PropertyKey<AlwaysPublic>>
+	}
+"###;
 
 impl FunctionBased for ObjectLiteralMethodBase {
 	type Name = WithComment<PropertyKey<AlwaysPublic>>;

--- a/parser/src/expressions/template_literal.rs
+++ b/parser/src/expressions/template_literal.rs
@@ -9,6 +9,7 @@ use visitable_derive::Visitable;
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TemplateLiteral {
 	pub tag: Option<Box<Expression>>,
 	pub parts: Vec<TemplateLiteralPart<Expression>>,
@@ -18,6 +19,7 @@ pub struct TemplateLiteral {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum TemplateLiteralPart<T: ASTNode> {
 	Static(String),
 	Dynamic(Box<T>),

--- a/parser/src/expressions/template_literal.rs
+++ b/parser/src/expressions/template_literal.rs
@@ -1,6 +1,6 @@
 use crate::{
-	errors::parse_lexing_error, ASTNode, Expression, ParseOptions, ParseResult, Span, TSXToken,
-	Token, TokenReader,
+	default_derive_bundle, errors::parse_lexing_error, ASTNode, Expression, ParseOptions,
+	ParseResult, Span, TSXToken, Token, TokenReader,
 };
 use tokenizer_lib::sized_tokens::TokenStart;
 use visitable_derive::Visitable;
@@ -17,9 +17,7 @@ pub struct TemplateLiteral {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum TemplateLiteralPart<T: ASTNode> {
 	Static(String),
 	Dynamic(Box<T>),

--- a/parser/src/expressions/template_literal.rs
+++ b/parser/src/expressions/template_literal.rs
@@ -5,11 +5,9 @@ use crate::{
 use tokenizer_lib::sized_tokens::TokenStart;
 use visitable_derive::Visitable;
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TemplateLiteral {
 	pub tag: Option<Box<Expression>>,
 	pub parts: Vec<TemplateLiteralPart<Expression>>,

--- a/parser/src/expressions/template_literal.rs
+++ b/parser/src/expressions/template_literal.rs
@@ -1,6 +1,6 @@
 use crate::{
-	default_derive_bundle, errors::parse_lexing_error, ASTNode, Expression, ParseOptions,
-	ParseResult, Span, TSXToken, Token, TokenReader,
+	derive_ASTNode, errors::parse_lexing_error, ASTNode, Expression, ParseOptions, ParseResult,
+	Span, TSXToken, Token, TokenReader,
 };
 use tokenizer_lib::sized_tokens::TokenStart;
 use visitable_derive::Visitable;
@@ -17,7 +17,7 @@ pub struct TemplateLiteral {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum TemplateLiteralPart<T: ASTNode> {
 	Static(String),
 	Dynamic(Box<T>),

--- a/parser/src/extensions/decorators.rs
+++ b/parser/src/extensions/decorators.rs
@@ -15,6 +15,7 @@ use crate::{
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct Decorator {
 	pub name: Vec<String>,
 	pub arguments: Option<Vec<Expression>>,
@@ -112,6 +113,7 @@ impl Decorator {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct Decorated<T> {
 	pub decorators: Vec<Decorator>,
 	pub on: T,

--- a/parser/src/extensions/decorators.rs
+++ b/parser/src/extensions/decorators.rs
@@ -107,11 +107,9 @@ impl Decorator {
 }
 
 /// TODO under cfg if don't want this could just be `type Decorated<T> = T;`
+#[apply(derive_ASTNode)]
 #[derive(Debug, PartialEq, Eq, Clone, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct Decorated<T> {
 	pub decorators: Vec<Decorator>,
 	pub on: T,

--- a/parser/src/extensions/decorators.rs
+++ b/parser/src/extensions/decorators.rs
@@ -8,14 +8,12 @@ use tokenizer_lib::{
 use visitable_derive::Visitable;
 
 use crate::{
-	tokens::token_as_identifier, ASTNode, Expression, ParseOptions, ParseResult, TSXToken,
-	Visitable,
+	default_derive_bundle, tokens::token_as_identifier, ASTNode, Expression, ParseOptions,
+	ParseResult, TSXToken, Visitable,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct Decorator {
 	pub name: Vec<String>,
 	pub arguments: Option<Vec<Expression>>,

--- a/parser/src/extensions/decorators.rs
+++ b/parser/src/extensions/decorators.rs
@@ -8,12 +8,12 @@ use tokenizer_lib::{
 use visitable_derive::Visitable;
 
 use crate::{
-	default_derive_bundle, tokens::token_as_identifier, ASTNode, Expression, ParseOptions,
-	ParseResult, TSXToken, Visitable,
+	derive_ASTNode, tokens::token_as_identifier, ASTNode, Expression, ParseOptions, ParseResult,
+	TSXToken, Visitable,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct Decorator {
 	pub name: Vec<String>,
 	pub arguments: Option<Vec<Expression>>,

--- a/parser/src/extensions/is_expression.rs
+++ b/parser/src/extensions/is_expression.rs
@@ -4,14 +4,13 @@ use tokenizer_lib::{sized_tokens::TokenStart, TokenReader};
 use visitable_derive::Visitable;
 
 use crate::{
+	derive_ASTNode,
 	expressions::{ExpressionOrBlock, MultipleExpression},
 	ASTNode, TSXToken, TypeAnnotation,
 };
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, PartialEq, Eq, Clone, Visitable, get_field_by_type::GetFieldByType)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[get_field_by_type_target(Span)]
 pub struct IsExpression {
 	pub matcher: Box<MultipleExpression>,

--- a/parser/src/extensions/is_expression.rs
+++ b/parser/src/extensions/is_expression.rs
@@ -11,6 +11,7 @@ use crate::{
 #[derive(Debug, PartialEq, Eq, Clone, Visitable, get_field_by_type::GetFieldByType)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 #[get_field_by_type_target(Span)]
 pub struct IsExpression {
 	pub matcher: Box<MultipleExpression>,

--- a/parser/src/extensions/jsx.rs
+++ b/parser/src/extensions/jsx.rs
@@ -5,21 +5,17 @@ use crate::{
 use tokenizer_lib::sized_tokens::{TokenEnd, TokenReaderWithTokenEnds, TokenStart};
 use visitable_derive::Visitable;
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum JSXRoot {
 	Element(JSXElement),
 	Fragment(JSXFragment),
 }
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct JSXElement {
 	/// Name of the element (TODO or reference to element)
 	pub tag_name: String,
@@ -84,11 +80,9 @@ impl ASTNode for JSXElement {
 	}
 }
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct JSXFragment {
 	pub children: Vec<JSXNode>,
 	pub position: Span,

--- a/parser/src/extensions/jsx.rs
+++ b/parser/src/extensions/jsx.rs
@@ -1,6 +1,6 @@
 use crate::{
-	default_derive_bundle, errors::parse_lexing_error, ASTNode, Expression, ParseError,
-	ParseOptions, ParseResult, Span, TSXToken, Token, TokenReader,
+	derive_ASTNode, errors::parse_lexing_error, ASTNode, Expression, ParseError, ParseOptions,
+	ParseResult, Span, TSXToken, Token, TokenReader,
 };
 use tokenizer_lib::sized_tokens::{TokenEnd, TokenReaderWithTokenEnds, TokenStart};
 use visitable_derive::Visitable;
@@ -29,7 +29,7 @@ pub struct JSXElement {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum JSXElementChildren {
 	Children(Vec<JSXNode>),
 	/// For img elements
@@ -222,7 +222,7 @@ impl JSXRoot {
 
 // TODO Fragment
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum JSXNode {
 	TextNode(String, Span),
 	InterpolatedExpression(Box<Expression>, Span),
@@ -295,7 +295,7 @@ impl ASTNode for JSXNode {
 
 /// TODO spread attributes and boolean attributes
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum JSXAttribute {
 	Static(String, String, Span),
 	Dynamic(String, Box<Expression>, Span),

--- a/parser/src/extensions/jsx.rs
+++ b/parser/src/extensions/jsx.rs
@@ -9,6 +9,7 @@ use visitable_derive::Visitable;
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum JSXRoot {
 	Element(JSXElement),
 	Fragment(JSXFragment),
@@ -18,6 +19,7 @@ pub enum JSXRoot {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct JSXElement {
 	/// Name of the element (TODO or reference to element)
 	pub tag_name: String,
@@ -29,6 +31,7 @@ pub struct JSXElement {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum JSXElementChildren {
 	Children(Vec<JSXNode>),
 	/// For img elements
@@ -87,6 +90,7 @@ impl ASTNode for JSXElement {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct JSXFragment {
 	pub children: Vec<JSXNode>,
 	pub position: Span,
@@ -222,6 +226,7 @@ impl JSXRoot {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum JSXNode {
 	TextNode(String, Span),
 	InterpolatedExpression(Box<Expression>, Span),
@@ -296,6 +301,7 @@ impl ASTNode for JSXNode {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum JSXAttribute {
 	Static(String, String, Span),
 	Dynamic(String, Box<Expression>, Span),

--- a/parser/src/extensions/jsx.rs
+++ b/parser/src/extensions/jsx.rs
@@ -1,6 +1,6 @@
 use crate::{
-	errors::parse_lexing_error, ASTNode, Expression, ParseError, ParseOptions, ParseResult, Span,
-	TSXToken, Token, TokenReader,
+	default_derive_bundle, errors::parse_lexing_error, ASTNode, Expression, ParseError,
+	ParseOptions, ParseResult, Span, TSXToken, Token, TokenReader,
 };
 use tokenizer_lib::sized_tokens::{TokenEnd, TokenReaderWithTokenEnds, TokenStart};
 use visitable_derive::Visitable;
@@ -29,9 +29,7 @@ pub struct JSXElement {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum JSXElementChildren {
 	Children(Vec<JSXNode>),
 	/// For img elements
@@ -224,9 +222,7 @@ impl JSXRoot {
 
 // TODO Fragment
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum JSXNode {
 	TextNode(String, Span),
 	InterpolatedExpression(Box<Expression>, Span),
@@ -299,9 +295,7 @@ impl ASTNode for JSXNode {
 
 /// TODO spread attributes and boolean attributes
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum JSXAttribute {
 	Static(String, String, Span),
 	Dynamic(String, Box<Expression>, Span),

--- a/parser/src/functions.rs
+++ b/parser/src/functions.rs
@@ -123,6 +123,16 @@ pub struct FunctionBase<T: FunctionBased> {
 	pub position: Span,
 }
 
+#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+const TYPES: &str = r###"
+	export interface FunctionBase {
+		type_parameters?: GenericTypeConstraint[],
+		parameters: FunctionParameters,
+		return_type?: TypeAnnotation,
+		position: Span
+	}
+"###;
+
 impl<T: FunctionBased> Eq for FunctionBase<T> {}
 
 impl<T: FunctionBased + 'static> ASTNode for FunctionBase<T> {
@@ -239,6 +249,14 @@ where
 pub struct GeneralFunctionBase<T: ExpressionOrStatementPosition>(PhantomData<T>);
 
 pub type ExpressionFunction = FunctionBase<GeneralFunctionBase<ExpressionPosition>>;
+#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+const TYPES_EXPRESSION_FUNCTION: &str = r###"
+	export interface ExpressionFunction extends FunctionBase {
+		header: FunctionHeader,
+		body: Block,
+		name: ExpressionPosition
+	}
+"###;
 
 #[allow(clippy::similar_names)]
 impl<T: ExpressionOrStatementPosition> FunctionBased for GeneralFunctionBase<T> {
@@ -306,6 +324,7 @@ impl<T: ExpressionOrStatementPosition> FunctionBased for GeneralFunctionBase<T> 
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum FunctionLocationModifier {
 	Server,
 	Worker,
@@ -314,6 +333,7 @@ pub enum FunctionLocationModifier {
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum FunctionHeader {
 	VirginFunctionHeader {
 		is_async: bool,
@@ -485,6 +505,7 @@ impl FunctionHeader {
 #[derive(Eq, PartialEq, Clone, Debug)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum MethodHeader {
 	Get,
 	Set,
@@ -553,6 +574,7 @@ impl MethodHeader {
 #[derive(Eq, PartialEq, Clone, Debug)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum GeneratorSpecifier {
 	Star(Span),
 	#[cfg(feature = "extras")]

--- a/parser/src/functions.rs
+++ b/parser/src/functions.rs
@@ -124,14 +124,14 @@ pub struct FunctionBase<T: FunctionBased> {
 }
 
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES: &str = r###"
+const TYPES: &str = r"
 	export interface FunctionBase {
 		type_parameters?: GenericTypeConstraint[],
 		parameters: FunctionParameters,
 		return_type?: TypeAnnotation,
 		position: Span
 	}
-"###;
+";
 
 impl<T: FunctionBased> Eq for FunctionBase<T> {}
 
@@ -250,13 +250,13 @@ pub struct GeneralFunctionBase<T: ExpressionOrStatementPosition>(PhantomData<T>)
 
 pub type ExpressionFunction = FunctionBase<GeneralFunctionBase<ExpressionPosition>>;
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES_EXPRESSION_FUNCTION: &str = r###"
+const TYPES_EXPRESSION_FUNCTION: &str = r"
 	export interface ExpressionFunction extends FunctionBase {
 		header: FunctionHeader,
 		body: Block,
 		name: ExpressionPosition
 	}
-"###;
+";
 
 #[allow(clippy::similar_names)]
 impl<T: ExpressionOrStatementPosition> FunctionBased for GeneralFunctionBase<T> {

--- a/parser/src/functions.rs
+++ b/parser/src/functions.rs
@@ -3,9 +3,9 @@ use std::{fmt::Debug, marker::PhantomData};
 use crate::property_key::PropertyKeyKind;
 use crate::visiting::{ImmutableVariableOrProperty, MutableVariableOrProperty};
 use crate::{
-	parse_bracketed, to_string_bracketed, ASTNode, Block, ExpressionOrStatementPosition,
-	ExpressionPosition, GenericTypeConstraint, ParseOptions, ParseResult, TSXToken, TypeAnnotation,
-	VisitOptions, Visitable, WithComment,
+	default_derive_bundle, parse_bracketed, to_string_bracketed, ASTNode, Block,
+	ExpressionOrStatementPosition, ExpressionPosition, GenericTypeConstraint, ParseOptions,
+	ParseResult, TSXToken, TypeAnnotation, VisitOptions, Visitable, WithComment,
 };
 use crate::{PropertyKey, TSXKeyword};
 use derive_partial_eq_extras::PartialEqExtras;
@@ -322,18 +322,14 @@ impl<T: ExpressionOrStatementPosition> FunctionBased for GeneralFunctionBase<T> 
 
 #[cfg(feature = "extras")]
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum FunctionLocationModifier {
 	Server,
 	Worker,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum FunctionHeader {
 	VirginFunctionHeader {
 		is_async: bool,
@@ -503,9 +499,7 @@ impl FunctionHeader {
 
 /// This structure removes possible invalid combinations with async
 #[derive(Eq, PartialEq, Clone, Debug)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum MethodHeader {
 	Get,
 	Set,
@@ -572,9 +566,7 @@ impl MethodHeader {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum GeneratorSpecifier {
 	Star(Span),
 	#[cfg(feature = "extras")]

--- a/parser/src/functions.rs
+++ b/parser/src/functions.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, marker::PhantomData};
 use crate::property_key::PropertyKeyKind;
 use crate::visiting::{ImmutableVariableOrProperty, MutableVariableOrProperty};
 use crate::{
-	default_derive_bundle, parse_bracketed, to_string_bracketed, ASTNode, Block,
+	derive_ASTNode, parse_bracketed, to_string_bracketed, ASTNode, Block,
 	ExpressionOrStatementPosition, ExpressionPosition, GenericTypeConstraint, ParseOptions,
 	ParseResult, TSXToken, TypeAnnotation, VisitOptions, Visitable, WithComment,
 };
@@ -322,14 +322,14 @@ impl<T: ExpressionOrStatementPosition> FunctionBased for GeneralFunctionBase<T> 
 
 #[cfg(feature = "extras")]
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum FunctionLocationModifier {
 	Server,
 	Worker,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum FunctionHeader {
 	VirginFunctionHeader {
 		is_async: bool,
@@ -499,7 +499,7 @@ impl FunctionHeader {
 
 /// This structure removes possible invalid combinations with async
 #[derive(Eq, PartialEq, Clone, Debug)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum MethodHeader {
 	Get,
 	Set,
@@ -566,7 +566,7 @@ impl MethodHeader {
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum GeneratorSpecifier {
 	Star(Span),
 	#[cfg(feature = "extras")]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -65,6 +65,12 @@ use std::{borrow::Cow, str::FromStr};
 extern crate macro_rules_attribute;
 
 attribute_alias! {
+	// Warning: known to break under the following circumstances:
+	// 1. in combination with partial_eq_ignore_types (from the PartialEqExtras derive macro)
+	// 2. in combination with get_field_by_type_target (from the crate of the same name)
+	// any variation (even just a single, straightforward, cfg_attr) will break the other macros.
+	// If adding a seemingly innocuous macro triggers a bunch of 'cannot find attribute within this scope' errors,
+	// keep this macro in mind.
 	// TODO: consult on a better name, determine if derive(serde::Serialize) implies SelfRustTokenize
 	#[apply(default_derive_bundle!)] = 
         #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -86,6 +86,7 @@ impl Quoted {
 // TODO: Can be refactored with bit to reduce memory
 #[allow(clippy::struct_excessive_bools)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Deserialize), serde(default))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ParseOptions {
 	/// Parsing of [JSX](https://facebook.github.io/jsx/) (includes some additions)
 	pub jsx: bool,
@@ -168,6 +169,7 @@ impl Default for ParseOptions {
 // TODO: Can be refactored with bit to reduce memory
 #[allow(clippy::struct_excessive_bools)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Deserialize), serde(default))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ToStringOptions {
 	/// Does not include whitespace minification
 	pub pretty: bool,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -65,6 +65,7 @@ use std::{borrow::Cow, str::FromStr};
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Quoted {
 	Single,
 	Double,
@@ -501,6 +502,7 @@ impl KeywordPositions {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum NumberSign {
 	/// Also implies non negative/missing
 	Positive,
@@ -543,6 +545,7 @@ impl std::fmt::Display for NumberSign {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum NumberRepresentation {
 	Infinity,
 	NegativeInfinity,
@@ -829,6 +832,7 @@ impl ExpressionOrStatementPosition for StatementPosition {
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ExpressionPosition(pub Option<VariableIdentifier>);
 
 impl ExpressionOrStatementPosition for ExpressionPosition {
@@ -1044,6 +1048,7 @@ pub(crate) fn expect_semi_colon(
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum VariableKeyword {
 	Const,
 	Let,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -280,16 +280,16 @@ export type WithComment<T> =
   | { PostfixComment: [T, string, Span] };
 
 // shouldn't be useful to p need
-export type Marker<T> = null;
+// export type Marker<T> = null;
 
-export interface ClassDeclaration<T> {
-	name: T,
-	type_parameters?: Array<GenericTypeConstraint>,
-	extends?: Expression,
-	implements?: Array<TypeAnnotation>,
-	members: Array<Decorated<ClassMember>>,
-	position: Span,
-}
+// export interface ClassDeclaration<T> {
+// 	name: T,
+// 	type_parameters?: Array<GenericTypeConstraint>,
+// 	extends?: Expression,
+// 	implements?: Array<TypeAnnotation>,
+// 	members: Array<Decorated<ClassMember>>,
+// 	position: Span,
+// }
 ";
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -266,32 +266,6 @@ impl ToStringOptions {
 	}
 }
 
-// TODO temp?
-// These are here because for some reason **under debug builds** these definitions are missing.
-// It has something to do with the files as these definitions only work here :?. Experimentation needed
-#[cfg_attr(
-	all(target_family = "wasm", debug_assertions),
-	wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)
-)]
-const TYPES_THAT_ARE_MISSING: &str = "
-export type WithComment<T> =
-  | { None: T }
-  | { PrefixComment: [string, T, Span] }
-  | { PostfixComment: [T, string, Span] };
-
-// shouldn't be useful to p need
-export type Marker<T> = null;
-
-export interface ClassDeclaration<T> {
-	name: T,
-	type_parameters?: Array<GenericTypeConstraint>,
-	extends?: Expression,
-	implements?: Array<TypeAnnotation>,
-	members: Array<Decorated<ClassMember>>,
-	position: Span,
-}
-";
-
 #[derive(Debug, Default, Clone, Copy)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Deserialize))]
 #[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -254,6 +254,7 @@ impl ToStringOptions {
 
 #[derive(Debug, Default, Clone, Copy)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Deserialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Comments {
 	#[default]
 	All,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -267,30 +267,30 @@ impl ToStringOptions {
 }
 
 // TODO temp?
-// // These are here because for some reason **under debug builds** these definitions are missing.
-// // It has something to do with the files as these definitions only work here :?. Experimentation needed
-// #[cfg_attr(
-// 	all(target_family = "wasm", debug_assertions),
-// 	wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)
-// )]
-// const TYPES_THAT_ARE_MISSING: &str = "
-// export type WithComment<T> =
-//   | { None: T }
-//   | { PrefixComment: [string, T, Span] }
-//   | { PostfixComment: [T, string, Span] };
+// These are here because for some reason **under debug builds** these definitions are missing.
+// It has something to do with the files as these definitions only work here :?. Experimentation needed
+#[cfg_attr(
+	all(target_family = "wasm", debug_assertions),
+	wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)
+)]
+const TYPES_THAT_ARE_MISSING: &str = "
+export type WithComment<T> =
+  | { None: T }
+  | { PrefixComment: [string, T, Span] }
+  | { PostfixComment: [T, string, Span] };
 
-// // shouldn't be useful to p need
-// export type Marker<T> = null;
+// shouldn't be useful to p need
+export type Marker<T> = null;
 
-// export interface ClassDeclaration<T> {
-// 	name: T,
-// 	type_parameters?: Array<GenericTypeConstraint>,
-// 	extends?: Expression,
-// 	implements?: Array<TypeAnnotation>,
-// 	members: Array<Decorated<ClassMember>>,
-// 	position: Span,
-// }
-// ";
+export interface ClassDeclaration<T> {
+	name: T,
+	type_parameters?: Array<GenericTypeConstraint>,
+	extends?: Expression,
+	implements?: Array<TypeAnnotation>,
+	members: Array<Decorated<ClassMember>>,
+	position: Span,
+}
+";
 
 #[derive(Debug, Default, Clone, Copy)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Deserialize))]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -71,8 +71,7 @@ attribute_alias! {
 	// any variation (even just a single, straightforward, cfg_attr) will break the other macros.
 	// If adding a seemingly innocuous macro triggers a bunch of 'cannot find attribute within this scope' errors,
 	// keep this macro in mind.
-	// TODO: consult on a better name, determine if derive(serde::Serialize) implies SelfRustTokenize
-	#[apply(default_derive_bundle!)] =
+	#[apply(derive_ASTNode!)] =
 		#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 		#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
 		#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))];
@@ -80,7 +79,7 @@ attribute_alias! {
 
 /// What surrounds a string
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
-#[apply(default_derive_bundle!)]
+#[apply(derive_ASTNode!)]
 pub enum Quoted {
 	Single,
 	Double,
@@ -266,6 +265,31 @@ impl ToStringOptions {
 		self.pretty && self.max_line_length != u8::MAX
 	}
 }
+
+// These are here because for some reason **under debug builds** these definitions are missing.
+// It has something to do with the files as these definitions only work here :?. Experimentation needed
+#[cfg_attr(
+	all(target_family = "wasm", debug_assertions),
+	wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)
+)]
+const TYPES_THAT_ARE_MISSING: &str = "
+export type WithComment<T> =
+  | { None: T }
+  | { PrefixComment: [string, T, Span] }
+  | { PostfixComment: [T, string, Span] };
+
+// shouldn't be useful to p need
+export type Marker<T> = null;
+
+export interface ClassDeclaration<T> {
+	name: T,
+	type_parameters?: Array<GenericTypeConstraint>,
+	extends?: Expression,
+	implements?: Array<TypeAnnotation>,
+	members: Array<Decorated<ClassMember>>,
+	position: Span,
+}
+";
 
 #[derive(Debug, Default, Clone, Copy)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Deserialize))]
@@ -518,7 +542,7 @@ impl KeywordPositions {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum NumberSign {
 	/// Also implies non negative/missing
 	Positive,
@@ -559,7 +583,7 @@ impl std::fmt::Display for NumberSign {
 ///
 /// <https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-literals-numeric-literals>
 #[derive(Debug, Clone)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum NumberRepresentation {
 	Infinity,
 	NegativeInfinity,
@@ -821,7 +845,7 @@ pub trait ExpressionOrStatementPosition:
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct StatementPosition(pub VariableIdentifier);
 
 impl ExpressionOrStatementPosition for StatementPosition {
@@ -843,7 +867,7 @@ impl ExpressionOrStatementPosition for StatementPosition {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct ExpressionPosition(pub Option<VariableIdentifier>);
 
 impl ExpressionOrStatementPosition for ExpressionPosition {
@@ -1057,7 +1081,7 @@ pub(crate) fn expect_semi_colon(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum VariableKeyword {
 	Const,
 	Let,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -72,8 +72,8 @@ attribute_alias! {
 	// If adding a seemingly innocuous macro triggers a bunch of 'cannot find attribute within this scope' errors,
 	// keep this macro in mind.
 	// TODO: consult on a better name, determine if derive(serde::Serialize) implies SelfRustTokenize
-	#[apply(default_derive_bundle!)] = 
-        #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
+	#[apply(default_derive_bundle!)] =
+		#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 		#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
 		#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))];
 }
@@ -518,9 +518,7 @@ impl KeywordPositions {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum NumberSign {
 	/// Also implies non negative/missing
 	Positive,
@@ -561,9 +559,7 @@ impl std::fmt::Display for NumberSign {
 ///
 /// <https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-literals-numeric-literals>
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum NumberRepresentation {
 	Infinity,
 	NegativeInfinity,
@@ -825,9 +821,7 @@ pub trait ExpressionOrStatementPosition:
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct StatementPosition(pub VariableIdentifier);
 
 impl ExpressionOrStatementPosition for StatementPosition {
@@ -849,9 +843,7 @@ impl ExpressionOrStatementPosition for StatementPosition {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct ExpressionPosition(pub Option<VariableIdentifier>);
 
 impl ExpressionOrStatementPosition for ExpressionPosition {
@@ -1065,9 +1057,7 @@ pub(crate) fn expect_semi_colon(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum VariableKeyword {
 	Const,
 	Let,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -809,6 +809,7 @@ pub trait ExpressionOrStatementPosition:
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct StatementPosition(pub VariableIdentifier);
 
 impl ExpressionOrStatementPosition for StatementPosition {

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -280,16 +280,16 @@ export type WithComment<T> =
   | { PostfixComment: [T, string, Span] };
 
 // shouldn't be useful to p need
-// export type Marker<T> = null;
+export type Marker<T> = null;
 
-// export interface ClassDeclaration<T> {
-// 	name: T,
-// 	type_parameters?: Array<GenericTypeConstraint>,
-// 	extends?: Expression,
-// 	implements?: Array<TypeAnnotation>,
-// 	members: Array<Decorated<ClassMember>>,
-// 	position: Span,
-// }
+export interface ClassDeclaration<T> {
+	name: T,
+	type_parameters?: Array<GenericTypeConstraint>,
+	extends?: Expression,
+	implements?: Array<TypeAnnotation>,
+	members: Array<Decorated<ClassMember>>,
+	position: Span,
+}
 ";
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -266,30 +266,31 @@ impl ToStringOptions {
 	}
 }
 
-// These are here because for some reason **under debug builds** these definitions are missing.
-// It has something to do with the files as these definitions only work here :?. Experimentation needed
-#[cfg_attr(
-	all(target_family = "wasm", debug_assertions),
-	wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)
-)]
-const TYPES_THAT_ARE_MISSING: &str = "
-export type WithComment<T> =
-  | { None: T }
-  | { PrefixComment: [string, T, Span] }
-  | { PostfixComment: [T, string, Span] };
+// TODO temp?
+// // These are here because for some reason **under debug builds** these definitions are missing.
+// // It has something to do with the files as these definitions only work here :?. Experimentation needed
+// #[cfg_attr(
+// 	all(target_family = "wasm", debug_assertions),
+// 	wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)
+// )]
+// const TYPES_THAT_ARE_MISSING: &str = "
+// export type WithComment<T> =
+//   | { None: T }
+//   | { PrefixComment: [string, T, Span] }
+//   | { PostfixComment: [T, string, Span] };
 
-// shouldn't be useful to p need
-export type Marker<T> = null;
+// // shouldn't be useful to p need
+// export type Marker<T> = null;
 
-export interface ClassDeclaration<T> {
-	name: T,
-	type_parameters?: Array<GenericTypeConstraint>,
-	extends?: Expression,
-	implements?: Array<TypeAnnotation>,
-	members: Array<Decorated<ClassMember>>,
-	position: Span,
-}
-";
+// export interface ClassDeclaration<T> {
+// 	name: T,
+// 	type_parameters?: Array<GenericTypeConstraint>,
+// 	extends?: Expression,
+// 	implements?: Array<TypeAnnotation>,
+// 	members: Array<Decorated<ClassMember>>,
+// 	position: Span,
+// }
+// ";
 
 #[derive(Debug, Default, Clone, Copy)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Deserialize))]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -61,11 +61,20 @@ pub(crate) use tokenizer_lib::sized_tokens::TokenStart;
 
 use std::{borrow::Cow, str::FromStr};
 
+#[macro_use]
+extern crate macro_rules_attribute;
+
+attribute_alias! {
+	// TODO: consult on a better name, determine if derive(serde::Serialize) implies SelfRustTokenize
+	#[apply(default_derive_bundle!)] = 
+        #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
+		#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+		#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))];
+}
+
 /// What surrounds a string
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle!)]
 pub enum Quoted {
 	Single,
 	Double,

--- a/parser/src/marker.rs
+++ b/parser/src/marker.rs
@@ -5,9 +5,9 @@ use std::marker::PhantomData;
 pub struct Marker<T>(pub u8, pub PhantomData<T>);
 
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES: &'static str = r#"
+const TYPES: &str = r"
 	type Marker<T> = number;
-"#;
+";
 
 pub const MARKER: &str = "EZNO_GENERATOR_SLOT";
 

--- a/parser/src/marker.rs
+++ b/parser/src/marker.rs
@@ -4,6 +4,11 @@ use std::marker::PhantomData;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Marker<T>(pub u8, pub PhantomData<T>);
 
+#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+const TYPES: &'static str = r#"
+	type Marker<T> = number;
+"#;
+
 pub const MARKER: &str = "EZNO_GENERATOR_SLOT";
 
 #[cfg(feature = "serde-serialize")]

--- a/parser/src/modules.rs
+++ b/parser/src/modules.rs
@@ -21,6 +21,7 @@ use super::{ASTNode, ParseError, Span, TSXToken, Token, TokenReader};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct Module {
 	pub items: Vec<StatementOrDeclaration>,
 	pub span: Span,

--- a/parser/src/modules.rs
+++ b/parser/src/modules.rs
@@ -2,6 +2,7 @@ use tokenizer_lib::sized_tokens::TokenStart;
 
 use crate::{
 	block::{parse_statements_and_declarations, statements_and_declarations_to_string},
+	derive_ASTNode,
 	errors::parse_lexing_error,
 	extensions::decorators::decorators_from_reader,
 	throw_unexpected_token_with_token,
@@ -20,8 +21,7 @@ use crate::{
 use super::{ASTNode, ParseError, Span, TSXToken, Token, TokenReader};
 
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(derive_ASTNode)]
 pub struct Module {
 	pub items: Vec<StatementOrDeclaration>,
 	pub span: Span,

--- a/parser/src/operators.rs
+++ b/parser/src/operators.rs
@@ -14,6 +14,7 @@ use crate::{TSXKeyword, TSXToken};
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum BinaryOperator {
 	Add, Subtract, Multiply, Divide, Modulo, Exponent,
 
@@ -37,6 +38,7 @@ pub enum BinaryOperator {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum BinaryAssignmentOperator {
     LogicalNullishAssignment,
     
@@ -50,6 +52,7 @@ pub enum BinaryAssignmentOperator {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum UnaryOperator {
     Plus, Negation,
     BitwiseNot, LogicalNot,
@@ -60,6 +63,7 @@ pub enum UnaryOperator {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum IncrementOrDecrement {
 	Increment,
 	Decrement,
@@ -68,6 +72,7 @@ pub enum IncrementOrDecrement {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum UnaryPrefixAssignmentOperator {
 	Invert,
 	IncrementOrDecrement(IncrementOrDecrement),
@@ -76,6 +81,7 @@ pub enum UnaryPrefixAssignmentOperator {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct UnaryPostfixAssignmentOperator(pub IncrementOrDecrement);
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/parser/src/operators.rs
+++ b/parser/src/operators.rs
@@ -5,14 +5,14 @@
 
 use std::convert::TryFrom;
 
-use crate::{default_derive_bundle, TSXKeyword, TSXToken};
+use crate::{derive_ASTNode, TSXKeyword, TSXToken};
 
 /// Comma operator is on [`crate::MultipleExpression`]
 /// 
 /// `InstanceOf`, In are special operators
 #[rustfmt::skip]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[apply(default_derive_bundle!)]
+#[apply(derive_ASTNode!)]
 pub enum BinaryOperator {
 	Add, Subtract, Multiply, Divide, Modulo, Exponent,
 
@@ -34,7 +34,7 @@ pub enum BinaryOperator {
 /// Straight assignment is not here because LHS can be destructuring
 #[rustfmt::skip]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[apply(default_derive_bundle!)]
+#[apply(derive_ASTNode!)]
 pub enum BinaryAssignmentOperator {
     LogicalNullishAssignment,
     
@@ -46,7 +46,7 @@ pub enum BinaryAssignmentOperator {
 
 #[rustfmt::skip]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[apply(default_derive_bundle!)]
+#[apply(derive_ASTNode!)]
 pub enum UnaryOperator {
     Plus, Negation,
     BitwiseNot, LogicalNot,
@@ -55,21 +55,21 @@ pub enum UnaryOperator {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[apply(default_derive_bundle!)]
+#[apply(derive_ASTNode!)]
 pub enum IncrementOrDecrement {
 	Increment,
 	Decrement,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[apply(default_derive_bundle!)]
+#[apply(derive_ASTNode!)]
 pub enum UnaryPrefixAssignmentOperator {
 	Invert,
 	IncrementOrDecrement(IncrementOrDecrement),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[apply(default_derive_bundle!)]
+#[apply(derive_ASTNode!)]
 pub struct UnaryPostfixAssignmentOperator(pub IncrementOrDecrement);
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/parser/src/operators.rs
+++ b/parser/src/operators.rs
@@ -5,16 +5,14 @@
 
 use std::convert::TryFrom;
 
-use crate::{TSXKeyword, TSXToken};
+use crate::{default_derive_bundle, TSXKeyword, TSXToken};
 
 /// Comma operator is on [`crate::MultipleExpression`]
 /// 
 /// `InstanceOf`, In are special operators
 #[rustfmt::skip]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle!)]
 pub enum BinaryOperator {
 	Add, Subtract, Multiply, Divide, Modulo, Exponent,
 
@@ -36,9 +34,7 @@ pub enum BinaryOperator {
 /// Straight assignment is not here because LHS can be destructuring
 #[rustfmt::skip]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle!)]
 pub enum BinaryAssignmentOperator {
     LogicalNullishAssignment,
     
@@ -50,9 +46,7 @@ pub enum BinaryAssignmentOperator {
 
 #[rustfmt::skip]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle!)]
 pub enum UnaryOperator {
     Plus, Negation,
     BitwiseNot, LogicalNot,
@@ -61,27 +55,21 @@ pub enum UnaryOperator {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle!)]
 pub enum IncrementOrDecrement {
 	Increment,
 	Decrement,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle!)]
 pub enum UnaryPrefixAssignmentOperator {
 	Invert,
 	IncrementOrDecrement(IncrementOrDecrement),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle!)]
 pub struct UnaryPostfixAssignmentOperator(pub IncrementOrDecrement);
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/parser/src/parameters.rs
+++ b/parser/src/parameters.rs
@@ -18,6 +18,7 @@ use crate::{
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct Parameter {
 	pub name: WithComment<VariableField<VariableFieldInSourceCode>>,
 	pub type_annotation: Option<TypeAnnotation>,
@@ -28,6 +29,7 @@ pub struct Parameter {
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ParameterData {
 	Optional,
 	WithDefaultValue(Box<Expression>),
@@ -36,6 +38,7 @@ pub enum ParameterData {
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct SpreadParameter {
 	pub name: VariableIdentifier,
 	pub type_annotation: Option<TypeAnnotation>,
@@ -47,6 +50,7 @@ pub struct SpreadParameter {
 #[derive(Debug, Clone, PartialEqExtras, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct FunctionParameters {
 	pub this_type: Option<(TypeAnnotation, Span)>,
 	pub super_type: Option<(TypeAnnotation, Span)>,

--- a/parser/src/parameters.rs
+++ b/parser/src/parameters.rs
@@ -1,4 +1,4 @@
-use crate::{TSXKeyword, TSXToken};
+use crate::{default_derive_bundle, TSXKeyword, TSXToken};
 use derive_partial_eq_extras::PartialEqExtras;
 use iterator_endiate::EndiateIteratorExt;
 use source_map::Span;
@@ -27,18 +27,14 @@ pub struct Parameter {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum ParameterData {
 	Optional,
 	WithDefaultValue(Box<Expression>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct SpreadParameter {
 	pub name: VariableIdentifier,
 	pub type_annotation: Option<TypeAnnotation>,

--- a/parser/src/parameters.rs
+++ b/parser/src/parameters.rs
@@ -1,4 +1,4 @@
-use crate::{default_derive_bundle, TSXKeyword, TSXToken};
+use crate::{derive_ASTNode, TSXKeyword, TSXToken};
 use derive_partial_eq_extras::PartialEqExtras;
 use iterator_endiate::EndiateIteratorExt;
 use source_map::Span;
@@ -27,14 +27,14 @@ pub struct Parameter {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum ParameterData {
 	Optional,
 	WithDefaultValue(Box<Expression>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct SpreadParameter {
 	pub name: VariableIdentifier,
 	pub type_annotation: Option<TypeAnnotation>,

--- a/parser/src/parameters.rs
+++ b/parser/src/parameters.rs
@@ -14,11 +14,9 @@ use crate::{
 	WithComment,
 };
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, Eq, PartialEq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct Parameter {
 	pub name: WithComment<VariableField<VariableFieldInSourceCode>>,
 	pub type_annotation: Option<TypeAnnotation>,
@@ -43,10 +41,8 @@ pub struct SpreadParameter {
 
 /// TODO need to something special to not enable `OptionalFunctionParameter::WithValue` in interfaces and other
 /// type structure
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEqExtras, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct FunctionParameters {
 	pub this_type: Option<(TypeAnnotation, Span)>,
 	pub super_type: Option<(TypeAnnotation, Span)>,

--- a/parser/src/property_key.rs
+++ b/parser/src/property_key.rs
@@ -34,6 +34,11 @@ pub trait PropertyKeyKind: Debug + PartialEq + Eq + Clone {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AlwaysPublic;
 
+#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+const TYPES_ALWAYS_PUBLIC: &str = r###"
+	export type AlwaysPublic = false;
+"###;
+
 impl PropertyKeyKind for AlwaysPublic {
 	type Private = ();
 
@@ -53,6 +58,10 @@ impl PropertyKeyKind for AlwaysPublic {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublicOrPrivate;
+#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+const TYPES_PUBLIC_OR_PRIVATE: &'static str = r#"
+	export type PublicOrPrivate = boolean;
+"#;
 
 impl PropertyKeyKind for PublicOrPrivate {
 	type Private = bool;
@@ -90,6 +99,15 @@ pub enum PropertyKey<T: PropertyKeyKind> {
 	/// Includes anything in the `[...]` maybe a symbol
 	Computed(Box<Expression>, Span),
 }
+
+#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+const TYPES_PROPERTY_KEY: &str = r###"
+export type PropertyKey<T> =
+  | { Ident: [string, Span, T] }
+  | { StringLiteral: [string, Quoted, Span] }
+  | { NumberLiteral: [NumberRepresentation, Span] }
+  | { Computed: [Expression, Span] };
+"###;
 
 impl<U: PropertyKeyKind> PropertyKey<U> {
 	pub fn get_position(&self) -> &Span {

--- a/parser/src/property_key.rs
+++ b/parser/src/property_key.rs
@@ -1,4 +1,5 @@
 use crate::{
+	derive_ASTNode,
 	visiting::{Chain, VisitOptions, Visitable},
 	Quoted, TSXToken,
 };
@@ -12,102 +13,90 @@ use crate::{
 	NumberRepresentation, ParseOptions, ParseResult,
 };
 
-// pub enum GeneralPropertyKey {
-// 	AlwaysPublicPropertyKey(PropertyKey<AlwaysPublic>),
-// 	PublicOrPrivatePropertyKey(PropertyKey<PublicOrPrivate>),
-// }
-
-pub trait PropertyKeyKind: Debug + PartialEq + Eq + Clone {
-	type Private: Debug + Sync + Send + Clone + Copy + PartialEq + Eq;
-
+pub trait PropertyKeyKind: Debug + PartialEq + Eq + Clone + Sized + Send + Sync + 'static {
 	fn parse_ident(
 		first: Token<TSXToken, crate::TokenStart>,
 		reader: &mut impl TokenReader<TSXToken, crate::TokenStart>,
-	) -> ParseResult<(String, Span, Self::Private)>;
+	) -> ParseResult<(String, Span, Self)>;
 
-	fn is_private(p: Self::Private) -> bool;
+	fn is_private(&self) -> bool;
 
 	/// TODO temp
-	fn new_public() -> Self::Private;
+	fn new_public() -> Self;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[apply(derive_ASTNode)]
 pub struct AlwaysPublic;
 
-#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES_ALWAYS_PUBLIC: &str = r"
-	export type AlwaysPublic = false;
-";
+// #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+// const TYPES_ALWAYS_PUBLIC: &str = r"
+// 	export type AlwaysPublic = false;
+// ";
 
 impl PropertyKeyKind for AlwaysPublic {
-	type Private = ();
-
 	fn parse_ident(
 		first: Token<TSXToken, crate::TokenStart>,
 		_reader: &mut impl TokenReader<TSXToken, crate::TokenStart>,
-	) -> ParseResult<(String, Span, Self::Private)> {
-		token_as_identifier(first, "property key").map(|(name, position)| (name, position, ()))
+	) -> ParseResult<(String, Span, Self)> {
+		token_as_identifier(first, "property key")
+			.map(|(name, position)| (name, position, Self::new_public()))
 	}
 
-	fn is_private(_p: Self::Private) -> bool {
+	fn is_private(&self) -> bool {
 		false
 	}
 
-	fn new_public() {}
+	fn new_public() -> Self {
+		AlwaysPublic
+	}
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PublicOrPrivate;
-#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES_PUBLIC_OR_PRIVATE: &str = r"
-	export type PublicOrPrivate = boolean;
-";
+#[apply(derive_ASTNode)]
+pub enum PublicOrPrivate {
+	Public,
+	Private,
+}
+
+// #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
+// const TYPES_PUBLIC_OR_PRIVATE: &str = r"
+// 	export type PublicOrPrivate = boolean;
+// ";
 
 impl PropertyKeyKind for PublicOrPrivate {
-	type Private = bool;
-
 	fn parse_ident(
 		first: Token<TSXToken, crate::TokenStart>,
 		reader: &mut impl TokenReader<TSXToken, crate::TokenStart>,
-	) -> ParseResult<(String, Span, Self::Private)> {
+	) -> ParseResult<(String, Span, Self)> {
 		if matches!(first.0, TSXToken::HashTag) {
 			token_as_identifier(reader.next().ok_or_else(parse_lexing_error)?, "property key")
-				.map(|(name, position)| (name, position, true))
+				.map(|(name, position)| (name, position, Self::Private))
 		} else {
 			token_as_identifier(first, "property key")
-				.map(|(name, position)| (name, position, false))
+				.map(|(name, position)| (name, position, Self::Public))
 		}
 	}
 
-	fn is_private(p: Self::Private) -> bool {
-		p
+	fn is_private(&self) -> bool {
+		matches!(self, Self::Private)
 	}
 
-	fn new_public() -> Self::Private {
-		true
+	fn new_public() -> Self {
+		Self::Public
 	}
 }
 
 /// A key for a member in a class or object literal
 #[derive(Debug, PartialEq, Eq, Clone)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[apply(derive_ASTNode)]
 pub enum PropertyKey<T: PropertyKeyKind> {
-	Ident(String, Span, T::Private),
+	Ident(String, Span, T),
 	StringLiteral(String, Quoted, Span),
 	NumberLiteral(NumberRepresentation, Span),
 	/// Includes anything in the `[...]` maybe a symbol
 	Computed(Box<Expression>, Span),
 }
-
-#[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES_PROPERTY_KEY: &str = r"
-export type PropertyKey<T> =
-  | { Ident: [string, Span, T] }
-  | { StringLiteral: [string, Quoted, Span] }
-  | { NumberLiteral: [NumberRepresentation, Span] }
-  | { Computed: [Expression, Span] };
-";
 
 impl<U: PropertyKeyKind> PropertyKey<U> {
 	pub fn get_position(&self) -> &Span {
@@ -121,7 +110,7 @@ impl<U: PropertyKeyKind> PropertyKey<U> {
 
 	pub fn is_private(&self) -> bool {
 		match self {
-			PropertyKey::Ident(_, _, p) => U::is_private(*p),
+			PropertyKey::Ident(_, _, p) => U::is_private(p),
 			_ => false,
 		}
 	}
@@ -138,7 +127,7 @@ impl<U: PropertyKeyKind> PartialEq<str> for PropertyKey<U> {
 	}
 }
 
-impl<U: PropertyKeyKind + 'static> ASTNode for PropertyKey<U> {
+impl<U: PropertyKeyKind> ASTNode for PropertyKey<U> {
 	fn get_position(&self) -> &Span {
 		match self {
 			PropertyKey::Ident(_, pos, _)

--- a/parser/src/property_key.rs
+++ b/parser/src/property_key.rs
@@ -35,9 +35,9 @@ pub trait PropertyKeyKind: Debug + PartialEq + Eq + Clone {
 pub struct AlwaysPublic;
 
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES_ALWAYS_PUBLIC: &str = r###"
+const TYPES_ALWAYS_PUBLIC: &str = r"
 	export type AlwaysPublic = false;
-"###;
+";
 
 impl PropertyKeyKind for AlwaysPublic {
 	type Private = ();
@@ -59,9 +59,9 @@ impl PropertyKeyKind for AlwaysPublic {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublicOrPrivate;
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES_PUBLIC_OR_PRIVATE: &'static str = r#"
+const TYPES_PUBLIC_OR_PRIVATE: &str = r"
 	export type PublicOrPrivate = boolean;
-"#;
+";
 
 impl PropertyKeyKind for PublicOrPrivate {
 	type Private = bool;
@@ -101,13 +101,13 @@ pub enum PropertyKey<T: PropertyKeyKind> {
 }
 
 #[cfg_attr(target_family = "wasm", wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section))]
-const TYPES_PROPERTY_KEY: &str = r###"
+const TYPES_PROPERTY_KEY: &str = r"
 export type PropertyKey<T> =
   | { Ident: [string, Span, T] }
   | { StringLiteral: [string, Quoted, Span] }
   | { NumberLiteral: [NumberRepresentation, Span] }
   | { Computed: [Expression, Span] };
-"###;
+";
 
 impl<U: PropertyKeyKind> PropertyKey<U> {
 	pub fn get_position(&self) -> &Span {

--- a/parser/src/statements/for_statement.rs
+++ b/parser/src/statements/for_statement.rs
@@ -14,6 +14,7 @@ use super::{
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ForLoopStatement {
 	pub condition: ForLoopCondition,
 	pub inner: BlockOrSingleStatement,
@@ -54,6 +55,7 @@ impl ASTNode for ForLoopStatement {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ForLoopStatementInitializer {
 	VariableDeclaration(VariableDeclaration),
 	VarStatement(VarVariableStatement),
@@ -63,6 +65,7 @@ pub enum ForLoopStatementInitializer {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ForLoopCondition {
 	ForOf {
 		keyword: Option<VariableKeyword>,

--- a/parser/src/statements/for_statement.rs
+++ b/parser/src/statements/for_statement.rs
@@ -1,6 +1,6 @@
 use crate::{
 	ast::MultipleExpression, block::BlockOrSingleStatement,
-	declarations::variable::VariableDeclaration, default_derive_bundle, ParseOptions, TSXKeyword,
+	declarations::variable::VariableDeclaration, derive_ASTNode, ParseOptions, TSXKeyword,
 	VariableField, VariableFieldInSourceCode, VariableKeyword, WithComment,
 };
 use tokenizer_lib::sized_tokens::TokenReaderWithTokenEnds;
@@ -53,7 +53,7 @@ impl ASTNode for ForLoopStatement {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum ForLoopStatementInitializer {
 	VariableDeclaration(VariableDeclaration),
 	VarStatement(VarVariableStatement),
@@ -61,7 +61,7 @@ pub enum ForLoopStatementInitializer {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum ForLoopCondition {
 	ForOf {
 		keyword: Option<VariableKeyword>,

--- a/parser/src/statements/for_statement.rs
+++ b/parser/src/statements/for_statement.rs
@@ -1,7 +1,7 @@
 use crate::{
 	ast::MultipleExpression, block::BlockOrSingleStatement,
-	declarations::variable::VariableDeclaration, ParseOptions, TSXKeyword, VariableField,
-	VariableFieldInSourceCode, VariableKeyword, WithComment,
+	declarations::variable::VariableDeclaration, default_derive_bundle, ParseOptions, TSXKeyword,
+	VariableField, VariableFieldInSourceCode, VariableKeyword, WithComment,
 };
 use tokenizer_lib::sized_tokens::TokenReaderWithTokenEnds;
 use visitable_derive::Visitable;
@@ -53,9 +53,7 @@ impl ASTNode for ForLoopStatement {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum ForLoopStatementInitializer {
 	VariableDeclaration(VariableDeclaration),
 	VarStatement(VarVariableStatement),
@@ -63,9 +61,7 @@ pub enum ForLoopStatementInitializer {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum ForLoopCondition {
 	ForOf {
 		keyword: Option<VariableKeyword>,

--- a/parser/src/statements/for_statement.rs
+++ b/parser/src/statements/for_statement.rs
@@ -10,11 +10,9 @@ use super::{
 	ASTNode, Expression, ParseResult, Span, TSXToken, Token, TokenReader, VarVariableStatement,
 };
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ForLoopStatement {
 	pub condition: ForLoopCondition,
 	pub inner: BlockOrSingleStatement,

--- a/parser/src/statements/if_statement.rs
+++ b/parser/src/statements/if_statement.rs
@@ -13,6 +13,7 @@ use super::{ASTNode, ParseResult, Span, TSXToken, Token, TokenReader};
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct IfStatement {
 	pub condition: MultipleExpression,
 	pub inner: BlockOrSingleStatement,
@@ -25,6 +26,7 @@ pub struct IfStatement {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ConditionalElseStatement {
 	pub condition: MultipleExpression,
 	pub inner: BlockOrSingleStatement,
@@ -35,6 +37,7 @@ pub struct ConditionalElseStatement {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct UnconditionalElseStatement {
 	pub inner: BlockOrSingleStatement,
 	pub position: Span,

--- a/parser/src/statements/if_statement.rs
+++ b/parser/src/statements/if_statement.rs
@@ -10,11 +10,9 @@ use visitable_derive::Visitable;
 use super::{ASTNode, ParseResult, Span, TSXToken, Token, TokenReader};
 
 /// A [if...else statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else)
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, Visitable, GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct IfStatement {
 	pub condition: MultipleExpression,
 	pub inner: BlockOrSingleStatement,

--- a/parser/src/statements/if_statement.rs
+++ b/parser/src/statements/if_statement.rs
@@ -1,5 +1,6 @@
 use crate::{
-	block::BlockOrSingleStatement, expressions::MultipleExpression, ParseOptions, TSXKeyword,
+	block::BlockOrSingleStatement, default_derive_bundle, expressions::MultipleExpression,
+	ParseOptions, TSXKeyword,
 };
 use get_field_by_type::GetFieldByType;
 use iterator_endiate::EndiateIteratorExt;
@@ -24,9 +25,7 @@ pub struct IfStatement {
 
 /// `... else if (...) { ... }`
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct ConditionalElseStatement {
 	pub condition: MultipleExpression,
 	pub inner: BlockOrSingleStatement,
@@ -35,9 +34,7 @@ pub struct ConditionalElseStatement {
 
 /// `... else { ... }`
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct UnconditionalElseStatement {
 	pub inner: BlockOrSingleStatement,
 	pub position: Span,

--- a/parser/src/statements/if_statement.rs
+++ b/parser/src/statements/if_statement.rs
@@ -1,6 +1,6 @@
 use crate::{
-	block::BlockOrSingleStatement, default_derive_bundle, expressions::MultipleExpression,
-	ParseOptions, TSXKeyword,
+	block::BlockOrSingleStatement, derive_ASTNode, expressions::MultipleExpression, ParseOptions,
+	TSXKeyword,
 };
 use get_field_by_type::GetFieldByType;
 use iterator_endiate::EndiateIteratorExt;
@@ -25,7 +25,7 @@ pub struct IfStatement {
 
 /// `... else if (...) { ... }`
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct ConditionalElseStatement {
 	pub condition: MultipleExpression,
 	pub inner: BlockOrSingleStatement,
@@ -34,7 +34,7 @@ pub struct ConditionalElseStatement {
 
 /// `... else { ... }`
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct UnconditionalElseStatement {
 	pub inner: BlockOrSingleStatement,
 	pub position: Span,

--- a/parser/src/statements/mod.rs
+++ b/parser/src/statements/mod.rs
@@ -6,6 +6,7 @@ mod while_statement;
 
 use crate::{
 	declarations::variable::{declarations_to_string, VariableDeclarationItem},
+	derive_ASTNode,
 	tokens::token_as_identifier,
 };
 use derive_enum_from_into::{EnumFrom, EnumTryInto};
@@ -26,13 +27,11 @@ use visitable_derive::Visitable;
 pub use while_statement::{DoWhileStatement, WhileStatement};
 
 /// A statement
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, Visitable, EnumFrom, EnumTryInto, PartialEqExtras, GetFieldByType)]
 #[get_field_by_type_target(Span)]
 #[try_into_references(&, &mut)]
 #[partial_eq_ignore_types(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Statement {
 	Expression(MultipleExpression),
 	/// { ... } statement
@@ -66,18 +65,14 @@ pub enum Statement {
 	Empty(Span),
 }
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, Visitable, PartialEqExtras, GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ReturnStatement(pub Option<MultipleExpression>, pub Span);
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, Visitable, PartialEqExtras, GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ThrowStatement(pub Box<MultipleExpression>, pub Span);
 
 impl Eq for Statement {}
@@ -315,11 +310,9 @@ impl Statement {
 	}
 }
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, PartialEq, Eq, Clone, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct VarVariableStatement {
 	pub declarations: Vec<VariableDeclarationItem<Option<Expression>>>,
 	pub position: Span,

--- a/parser/src/statements/mod.rs
+++ b/parser/src/statements/mod.rs
@@ -32,6 +32,7 @@ pub use while_statement::{DoWhileStatement, WhileStatement};
 #[partial_eq_ignore_types(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Statement {
 	Expression(MultipleExpression),
 	/// { ... } statement
@@ -69,12 +70,14 @@ pub enum Statement {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ReturnStatement(pub Option<MultipleExpression>, pub Span);
 
 #[derive(Debug, Clone, Visitable, PartialEqExtras, GetFieldByType)]
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct ThrowStatement(pub Box<MultipleExpression>, pub Span);
 
 impl Eq for Statement {}
@@ -316,6 +319,7 @@ impl Statement {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct VarVariableStatement {
 	pub declarations: Vec<VariableDeclarationItem<Option<Expression>>>,
 	pub position: Span,

--- a/parser/src/statements/switch_statement.rs
+++ b/parser/src/statements/switch_statement.rs
@@ -9,11 +9,9 @@ use crate::{
 	TSXKeyword, TSXToken,
 };
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, PartialEq, Clone, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct SwitchStatement {
 	pub case: MultipleExpression,
 	pub branches: Vec<SwitchBranch>,

--- a/parser/src/statements/switch_statement.rs
+++ b/parser/src/statements/switch_statement.rs
@@ -12,6 +12,7 @@ use crate::{
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct SwitchStatement {
 	pub case: MultipleExpression,
 	pub branches: Vec<SwitchBranch>,
@@ -21,6 +22,7 @@ pub struct SwitchStatement {
 #[derive(Debug, PartialEq, Clone, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum SwitchBranch {
 	Default(Vec<StatementOrDeclaration>),
 	Case(Expression, Vec<StatementOrDeclaration>),

--- a/parser/src/statements/switch_statement.rs
+++ b/parser/src/statements/switch_statement.rs
@@ -4,7 +4,7 @@ use tokenizer_lib::{sized_tokens::TokenEnd, Token};
 use visitable_derive::Visitable;
 
 use crate::{
-	ast::MultipleExpression, default_derive_bundle, errors::parse_lexing_error,
+	ast::MultipleExpression, derive_ASTNode, errors::parse_lexing_error,
 	throw_unexpected_token_with_token, ASTNode, Expression, ParseOptions, StatementOrDeclaration,
 	TSXKeyword, TSXToken,
 };
@@ -21,7 +21,7 @@ pub struct SwitchStatement {
 }
 
 #[derive(Debug, PartialEq, Clone, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum SwitchBranch {
 	Default(Vec<StatementOrDeclaration>),
 	Case(Expression, Vec<StatementOrDeclaration>),

--- a/parser/src/statements/switch_statement.rs
+++ b/parser/src/statements/switch_statement.rs
@@ -4,8 +4,9 @@ use tokenizer_lib::{sized_tokens::TokenEnd, Token};
 use visitable_derive::Visitable;
 
 use crate::{
-	ast::MultipleExpression, errors::parse_lexing_error, throw_unexpected_token_with_token,
-	ASTNode, Expression, ParseOptions, StatementOrDeclaration, TSXKeyword, TSXToken,
+	ast::MultipleExpression, default_derive_bundle, errors::parse_lexing_error,
+	throw_unexpected_token_with_token, ASTNode, Expression, ParseOptions, StatementOrDeclaration,
+	TSXKeyword, TSXToken,
 };
 
 #[derive(Debug, PartialEq, Clone, Visitable, get_field_by_type::GetFieldByType)]
@@ -20,9 +21,7 @@ pub struct SwitchStatement {
 }
 
 #[derive(Debug, PartialEq, Clone, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum SwitchBranch {
 	Default(Vec<StatementOrDeclaration>),
 	Case(Expression, Vec<StatementOrDeclaration>),

--- a/parser/src/statements/try_catch_statement.rs
+++ b/parser/src/statements/try_catch_statement.rs
@@ -12,6 +12,7 @@ pub type ExceptionVarField = WithComment<VariableField<VariableFieldInSourceCode
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TryCatchStatement {
 	pub try_inner: Block,
 	pub catch_inner: Option<Block>,

--- a/parser/src/statements/try_catch_statement.rs
+++ b/parser/src/statements/try_catch_statement.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ASTNode, Block, ParseError, ParseErrors, TSXKeyword, TSXToken, TypeAnnotation, VariableField,
-	VariableFieldInSourceCode, WithComment,
+	derive_ASTNode, ASTNode, Block, ParseError, ParseErrors, TSXKeyword, TSXToken, TypeAnnotation,
+	VariableField, VariableFieldInSourceCode, WithComment,
 };
 use source_map::Span;
 use tokenizer_lib::Token;
@@ -9,11 +9,9 @@ use visitable_derive::Visitable;
 #[cfg_attr(target_family = "wasm", tsify::declare)]
 pub type ExceptionVarField = WithComment<VariableField<VariableFieldInSourceCode>>;
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, PartialEq, Eq, Clone, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TryCatchStatement {
 	pub try_inner: Block,
 	pub catch_inner: Option<Block>,

--- a/parser/src/statements/try_catch_statement.rs
+++ b/parser/src/statements/try_catch_statement.rs
@@ -6,6 +6,7 @@ use source_map::Span;
 use tokenizer_lib::Token;
 use visitable_derive::Visitable;
 
+#[cfg_attr(target_family = "wasm", tsify::declare)]
 pub type ExceptionVarField = WithComment<VariableField<VariableFieldInSourceCode>>;
 
 #[derive(Debug, PartialEq, Eq, Clone, Visitable, get_field_by_type::GetFieldByType)]

--- a/parser/src/statements/while_statement.rs
+++ b/parser/src/statements/while_statement.rs
@@ -9,6 +9,7 @@ use crate::{
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct WhileStatement {
 	pub condition: MultipleExpression,
 	pub inner: BlockOrSingleStatement,
@@ -54,6 +55,7 @@ impl ASTNode for WhileStatement {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct DoWhileStatement {
 	pub condition: MultipleExpression,
 	// TODO unsure about true here

--- a/parser/src/statements/while_statement.rs
+++ b/parser/src/statements/while_statement.rs
@@ -2,14 +2,13 @@ use source_map::Span;
 use visitable_derive::Visitable;
 
 use crate::{
-	ast::MultipleExpression, block::BlockOrSingleStatement, ASTNode, TSXKeyword, TSXToken,
+	ast::MultipleExpression, block::BlockOrSingleStatement, derive_ASTNode, ASTNode, TSXKeyword,
+	TSXToken,
 };
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, PartialEq, Eq, Clone, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct WhileStatement {
 	pub condition: MultipleExpression,
 	pub inner: BlockOrSingleStatement,
@@ -50,12 +49,9 @@ impl ASTNode for WhileStatement {
 	}
 }
 
-/// TODO what about a do statement
+#[apply(derive_ASTNode)]
 #[derive(Debug, PartialEq, Eq, Clone, Visitable, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct DoWhileStatement {
 	pub condition: MultipleExpression,
 	// TODO unsure about true here

--- a/parser/src/tokens.rs
+++ b/parser/src/tokens.rs
@@ -455,7 +455,7 @@ impl TSXToken {
 	}
 }
 
-/// Some tokens can be used as names for variables, methods (eg 'get' in <Map>.get()). This function
+/// Some tokens can be used as names for variables, methods (eg 'get' in `Map.get()`). This function
 /// takes a [Token] and returns its name as a [String] and the location as a [Span]. Will throw [`ParseError`] if
 /// cannot convert token to string
 pub(crate) fn token_as_identifier(

--- a/parser/src/types/declares.rs
+++ b/parser/src/types/declares.rs
@@ -13,6 +13,7 @@ use crate::{
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct DeclareVariableDeclaration {
 	pub keyword: VariableKeyword,
 	/// TODO expressions advised against, but still parse
@@ -86,6 +87,7 @@ impl DeclareVariableDeclaration {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct DeclareFunctionDeclaration {
 	pub name: String,
 	pub type_parameters: Option<Vec<GenericTypeConstraint>>,
@@ -180,6 +182,7 @@ impl DeclareFunctionDeclaration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct DeclareClassDeclaration {
 	pub name: String,
 	pub type_parameters: Option<Vec<GenericTypeConstraint>>,

--- a/parser/src/types/declares.rs
+++ b/parser/src/types/declares.rs
@@ -1,19 +1,17 @@
 use tokenizer_lib::{sized_tokens::TokenStart, Token};
 
 use crate::{
-	declarations::VariableDeclarationItem, errors::parse_lexing_error, parse_bracketed,
-	to_string_bracketed, tokens::token_as_identifier,
+	declarations::VariableDeclarationItem, derive_ASTNode, errors::parse_lexing_error,
+	parse_bracketed, to_string_bracketed, tokens::token_as_identifier,
 	types::type_annotations::TypeAnnotationFunctionParameters, ASTNode, Decorator,
 	GenericTypeConstraint, ParseOptions, ParseResult, Span, TSXKeyword, TSXToken, TokenReader,
 	TypeAnnotation, VariableKeyword,
 };
 
 /// A `declare var/let/const` thingy.
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct DeclareVariableDeclaration {
 	pub keyword: VariableKeyword,
 	/// TODO expressions advised against, but still parse
@@ -83,11 +81,9 @@ impl DeclareVariableDeclaration {
 	}
 }
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct DeclareFunctionDeclaration {
 	pub name: String,
 	pub type_parameters: Option<Vec<GenericTypeConstraint>>,

--- a/parser/src/types/enum_declaration.rs
+++ b/parser/src/types/enum_declaration.rs
@@ -1,4 +1,4 @@
-use crate::{TSXKeyword, TSXToken};
+use crate::{default_derive_bundle, TSXKeyword, TSXToken};
 use iterator_endiate::EndiateIteratorExt;
 use source_map::Span;
 use tokenizer_lib::{sized_tokens::TokenReaderWithTokenEnds, Token};
@@ -7,9 +7,7 @@ use visitable_derive::Visitable;
 use crate::{errors::parse_lexing_error, tokens::token_as_identifier, ASTNode, Expression};
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct EnumDeclaration {
 	pub is_constant: bool,
 	pub name: String,
@@ -87,9 +85,7 @@ impl ASTNode for EnumDeclaration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum EnumMember {
 	Variant { name: String, value: Option<Expression>, position: Span },
 }

--- a/parser/src/types/enum_declaration.rs
+++ b/parser/src/types/enum_declaration.rs
@@ -9,6 +9,7 @@ use crate::{errors::parse_lexing_error, tokens::token_as_identifier, ASTNode, Ex
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct EnumDeclaration {
 	pub is_constant: bool,
 	pub name: String,
@@ -88,6 +89,7 @@ impl ASTNode for EnumDeclaration {
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum EnumMember {
 	Variant { name: String, value: Option<Expression>, position: Span },
 }

--- a/parser/src/types/enum_declaration.rs
+++ b/parser/src/types/enum_declaration.rs
@@ -1,4 +1,4 @@
-use crate::{default_derive_bundle, TSXKeyword, TSXToken};
+use crate::{derive_ASTNode, TSXKeyword, TSXToken};
 use iterator_endiate::EndiateIteratorExt;
 use source_map::Span;
 use tokenizer_lib::{sized_tokens::TokenReaderWithTokenEnds, Token};
@@ -7,7 +7,7 @@ use visitable_derive::Visitable;
 use crate::{errors::parse_lexing_error, tokens::token_as_identifier, ASTNode, Expression};
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct EnumDeclaration {
 	pub is_constant: bool,
 	pub name: String,
@@ -85,7 +85,7 @@ impl ASTNode for EnumDeclaration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Visitable)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum EnumMember {
 	Variant { name: String, value: Option<Expression>, position: Span },
 }

--- a/parser/src/types/interface.rs
+++ b/parser/src/types/interface.rs
@@ -29,6 +29,7 @@ pub struct InterfaceDeclaration {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum Optionality {
 	Default,
 	Optional,
@@ -40,6 +41,7 @@ pub enum Optionality {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum TypeRule {
 	In,
 	InKeyOf,
@@ -156,6 +158,7 @@ impl ASTNode for InterfaceDeclaration {
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum InterfaceMember {
 	Method {
 		header: MethodHeader,

--- a/parser/src/types/interface.rs
+++ b/parser/src/types/interface.rs
@@ -1,7 +1,7 @@
 use crate::{
-	errors::parse_lexing_error, extensions::decorators::Decorated, functions::MethodHeader,
-	parse_bracketed, property_key::PublicOrPrivate, throw_unexpected_token_with_token,
-	to_string_bracketed, tokens::token_as_identifier,
+	default_derive_bundle, errors::parse_lexing_error, extensions::decorators::Decorated,
+	functions::MethodHeader, parse_bracketed, property_key::PublicOrPrivate,
+	throw_unexpected_token_with_token, to_string_bracketed, tokens::token_as_identifier,
 	types::type_annotations::TypeAnnotationFunctionParameters, ASTNode, Expression,
 	GenericTypeConstraint, NumberRepresentation, ParseOptions, ParseResult, PropertyKey, Span,
 	TSXKeyword, TSXToken, TypeAnnotation, TypeDeclaration, WithComment,
@@ -28,9 +28,7 @@ pub struct InterfaceDeclaration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum Optionality {
 	Default,
 	Optional,
@@ -40,9 +38,7 @@ pub enum Optionality {
 
 // Used around type aliases for inline rule thingies
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum TypeRule {
 	In,
 	InKeyOf,

--- a/parser/src/types/interface.rs
+++ b/parser/src/types/interface.rs
@@ -15,6 +15,7 @@ use tokenizer_lib::{sized_tokens::TokenReaderWithTokenEnds, Token, TokenReader};
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct InterfaceDeclaration {
 	pub name: String,
 	#[cfg(feature = "extras")]

--- a/parser/src/types/interface.rs
+++ b/parser/src/types/interface.rs
@@ -11,11 +11,9 @@ use get_field_by_type::GetFieldByType;
 use iterator_endiate::EndiateIteratorExt;
 use tokenizer_lib::{sized_tokens::TokenReaderWithTokenEnds, Token, TokenReader};
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct InterfaceDeclaration {
 	pub name: String,
 	#[cfg(feature = "extras")]
@@ -151,11 +149,9 @@ impl ASTNode for InterfaceDeclaration {
 }
 
 /// This is also used for [`TypeAnnotation::ObjectLiteral`]
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum InterfaceMember {
 	Method {
 		header: MethodHeader,

--- a/parser/src/types/interface.rs
+++ b/parser/src/types/interface.rs
@@ -1,5 +1,5 @@
 use crate::{
-	default_derive_bundle, errors::parse_lexing_error, extensions::decorators::Decorated,
+	derive_ASTNode, errors::parse_lexing_error, extensions::decorators::Decorated,
 	functions::MethodHeader, parse_bracketed, property_key::PublicOrPrivate,
 	throw_unexpected_token_with_token, to_string_bracketed, tokens::token_as_identifier,
 	types::type_annotations::TypeAnnotationFunctionParameters, ASTNode, Expression,
@@ -28,7 +28,7 @@ pub struct InterfaceDeclaration {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum Optionality {
 	Default,
 	Optional,
@@ -38,7 +38,7 @@ pub enum Optionality {
 
 // Used around type aliases for inline rule thingies
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum TypeRule {
 	In,
 	InKeyOf,

--- a/parser/src/types/mod.rs
+++ b/parser/src/types/mod.rs
@@ -32,6 +32,7 @@ pub use interface::InterfaceDeclaration;
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum AnnotationPerforms {
 	PerformsStatements { body: crate::Block },
 	PerformsConst { identifier: String },

--- a/parser/src/types/mod.rs
+++ b/parser/src/types/mod.rs
@@ -10,7 +10,7 @@ pub mod type_declarations;
 
 pub use interface::InterfaceDeclaration;
 
-use crate::default_derive_bundle;
+use crate::derive_ASTNode;
 
 // [See](https://www.typescriptlang.org/docs/handbook/2/classes.html#member-visibility)
 // #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,7 +32,7 @@ use crate::default_derive_bundle;
 
 #[cfg(feature = "extras")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum AnnotationPerforms {
 	PerformsStatements { body: crate::Block },
 	PerformsConst { identifier: String },

--- a/parser/src/types/mod.rs
+++ b/parser/src/types/mod.rs
@@ -10,6 +10,8 @@ pub mod type_declarations;
 
 pub use interface::InterfaceDeclaration;
 
+use crate::default_derive_bundle;
+
 // [See](https://www.typescriptlang.org/docs/handbook/2/classes.html#member-visibility)
 // #[derive(Debug, Clone, PartialEq, Eq)]
 // pub enum Visibility {
@@ -30,9 +32,7 @@ pub use interface::InterfaceDeclaration;
 
 #[cfg(feature = "extras")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum AnnotationPerforms {
 	PerformsStatements { body: crate::Block },
 	PerformsConst { identifier: String },

--- a/parser/src/types/type_alias.rs
+++ b/parser/src/types/type_alias.rs
@@ -7,6 +7,7 @@ use crate::{ASTNode, TSXToken, TypeAnnotation, TypeDeclaration};
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TypeAlias {
 	pub type_name: TypeDeclaration,
 	pub type_expression: TypeAnnotation,

--- a/parser/src/types/type_alias.rs
+++ b/parser/src/types/type_alias.rs
@@ -1,13 +1,11 @@
 use source_map::Span;
 
-use crate::{ASTNode, TSXToken, TypeAnnotation, TypeDeclaration};
+use crate::{derive_ASTNode, ASTNode, TSXToken, TypeAnnotation, TypeDeclaration};
 
 /// e.g. `type NumberArray = Array<number>`
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEq, Eq, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TypeAlias {
 	pub type_name: TypeDeclaration,
 	pub type_expression: TypeAnnotation,

--- a/parser/src/types/type_annotations.rs
+++ b/parser/src/types/type_annotations.rs
@@ -26,6 +26,7 @@ use crate::{
 #[partial_eq_ignore_types(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum TypeAnnotation {
 	/// A name e.g. `IPost`
 	Name(String, Span),
@@ -91,6 +92,7 @@ impl ListItem for TypeAnnotation {}
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum AnnotationWithBinder {
 	Annotated { name: String, ty: TypeAnnotation, position: Span },
 	NoAnnotation(TypeAnnotation),
@@ -140,6 +142,7 @@ impl ASTNode for AnnotationWithBinder {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum SpreadKind {
 	NonSpread,
 	Spread,
@@ -149,6 +152,7 @@ pub enum SpreadKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum TypeCondition {
 	Extends { ty: Box<TypeAnnotation>, extends: Box<TypeAnnotation>, position: Span },
 	Is { ty: Box<TypeAnnotation>, is: Box<TypeAnnotation>, position: Span },
@@ -158,6 +162,7 @@ pub enum TypeCondition {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum CommonTypes {
 	String,
 	Number,
@@ -198,6 +203,7 @@ impl TypeCondition {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum TypeConditionResult {
 	/// TODO e.g. `infer number`
 	Infer(Box<TypeAnnotation>, Span),
@@ -837,6 +843,7 @@ pub(crate) fn generic_arguments_from_reader_sub_open_angle(
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TypeAnnotationFunctionParameters {
 	pub parameters: Vec<TypeAnnotationFunctionParameter>,
 	pub rest_parameter: Option<Box<TypeAnnotationSpreadFunctionParameter>>,
@@ -975,6 +982,7 @@ impl TypeAnnotationFunctionParameters {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TypeAnnotationFunctionParameter {
 	pub decorators: Vec<Decorator>,
 	/// Ooh nice optional
@@ -987,6 +995,7 @@ pub struct TypeAnnotationFunctionParameter {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TypeAnnotationSpreadFunctionParameter {
 	pub decorators: Vec<Decorator>,
 	pub name: String,

--- a/parser/src/types/type_annotations.rs
+++ b/parser/src/types/type_annotations.rs
@@ -82,7 +82,11 @@ pub enum TypeAnnotation {
 		resolve_false: TypeConditionResult,
 		position: Span,
 	},
-	Decorated(Decorator, Box<Self>, Span),
+	Decorated(
+		Decorator,
+		#[cfg_attr(target_family = "wasm", tsify(type = "TypeAnnotation"))] Box<Self>,
+		Span,
+	),
 	#[cfg_attr(feature = "self-rust-tokenize", self_tokenize_field(0))]
 	Marker(Marker<TypeAnnotation>, Span),
 }

--- a/parser/src/types/type_annotations.rs
+++ b/parser/src/types/type_annotations.rs
@@ -1,10 +1,11 @@
 use crate::{
+	default_derive_bundle, parse_bracketed, throw_unexpected_token_with_token, to_string_bracketed,
+	ListItem, Quoted,
+};
+use crate::{
 	errors::parse_lexing_error, expressions::TemplateLiteralPart,
 	extensions::decorators::Decorated, Decorator, Marker, ParseResult, VariableField,
 	VariableFieldInTypeAnnotation, WithComment,
-};
-use crate::{
-	parse_bracketed, throw_unexpected_token_with_token, to_string_bracketed, ListItem, Quoted,
 };
 use derive_partial_eq_extras::PartialEqExtras;
 use iterator_endiate::EndiateIteratorExt;
@@ -94,9 +95,7 @@ pub enum TypeAnnotation {
 impl ListItem for TypeAnnotation {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum AnnotationWithBinder {
 	Annotated { name: String, ty: TypeAnnotation, position: Span },
 	NoAnnotation(TypeAnnotation),
@@ -144,9 +143,7 @@ impl ASTNode for AnnotationWithBinder {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum SpreadKind {
 	NonSpread,
 	Spread,
@@ -154,9 +151,7 @@ pub enum SpreadKind {
 
 /// Condition in a [`TypeAnnotation::Conditional`]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum TypeCondition {
 	Extends { ty: Box<TypeAnnotation>, extends: Box<TypeAnnotation>, position: Span },
 	Is { ty: Box<TypeAnnotation>, is: Box<TypeAnnotation>, position: Span },
@@ -164,9 +159,7 @@ pub enum TypeCondition {
 
 /// Reduces string allocation and type lookup overhead
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum CommonTypes {
 	String,
 	Number,
@@ -205,9 +198,7 @@ impl TypeCondition {
 
 /// The result of a [`TypeAnnotation::Condition`]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum TypeConditionResult {
 	/// TODO e.g. `infer number`
 	Infer(Box<TypeAnnotation>, Span),
@@ -845,9 +836,7 @@ pub(crate) fn generic_arguments_from_reader_sub_open_angle(
 
 /// Mirrors [`crate::FunctionParameters`]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct TypeAnnotationFunctionParameters {
 	pub parameters: Vec<TypeAnnotationFunctionParameter>,
 	pub rest_parameter: Option<Box<TypeAnnotationSpreadFunctionParameter>>,
@@ -984,9 +973,7 @@ impl TypeAnnotationFunctionParameters {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct TypeAnnotationFunctionParameter {
 	pub decorators: Vec<Decorator>,
 	/// Ooh nice optional
@@ -997,9 +984,7 @@ pub struct TypeAnnotationFunctionParameter {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct TypeAnnotationSpreadFunctionParameter {
 	pub decorators: Vec<Decorator>,
 	pub name: String,

--- a/parser/src/types/type_annotations.rs
+++ b/parser/src/types/type_annotations.rs
@@ -22,12 +22,10 @@ use crate::{
 };
 
 /// A reference to a type
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEqExtras, Eq, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
 #[partial_eq_ignore_types(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum TypeAnnotation {
 	/// A name e.g. `IPost`
 	Name(String, Span),

--- a/parser/src/types/type_annotations.rs
+++ b/parser/src/types/type_annotations.rs
@@ -1,5 +1,5 @@
 use crate::{
-	default_derive_bundle, parse_bracketed, throw_unexpected_token_with_token, to_string_bracketed,
+	derive_ASTNode, parse_bracketed, throw_unexpected_token_with_token, to_string_bracketed,
 	ListItem, Quoted,
 };
 use crate::{
@@ -95,7 +95,7 @@ pub enum TypeAnnotation {
 impl ListItem for TypeAnnotation {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum AnnotationWithBinder {
 	Annotated { name: String, ty: TypeAnnotation, position: Span },
 	NoAnnotation(TypeAnnotation),
@@ -143,7 +143,7 @@ impl ASTNode for AnnotationWithBinder {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum SpreadKind {
 	NonSpread,
 	Spread,
@@ -151,7 +151,7 @@ pub enum SpreadKind {
 
 /// Condition in a [`TypeAnnotation::Conditional`]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum TypeCondition {
 	Extends { ty: Box<TypeAnnotation>, extends: Box<TypeAnnotation>, position: Span },
 	Is { ty: Box<TypeAnnotation>, is: Box<TypeAnnotation>, position: Span },
@@ -159,7 +159,7 @@ pub enum TypeCondition {
 
 /// Reduces string allocation and type lookup overhead
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum CommonTypes {
 	String,
 	Number,
@@ -198,7 +198,7 @@ impl TypeCondition {
 
 /// The result of a [`TypeAnnotation::Condition`]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum TypeConditionResult {
 	/// TODO e.g. `infer number`
 	Infer(Box<TypeAnnotation>, Span),
@@ -836,7 +836,7 @@ pub(crate) fn generic_arguments_from_reader_sub_open_angle(
 
 /// Mirrors [`crate::FunctionParameters`]
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct TypeAnnotationFunctionParameters {
 	pub parameters: Vec<TypeAnnotationFunctionParameter>,
 	pub rest_parameter: Option<Box<TypeAnnotationSpreadFunctionParameter>>,
@@ -973,7 +973,7 @@ impl TypeAnnotationFunctionParameters {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct TypeAnnotationFunctionParameter {
 	pub decorators: Vec<Decorator>,
 	/// Ooh nice optional
@@ -984,7 +984,7 @@ pub struct TypeAnnotationFunctionParameter {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct TypeAnnotationSpreadFunctionParameter {
 	pub decorators: Vec<Decorator>,
 	pub name: String,

--- a/parser/src/types/type_declarations.rs
+++ b/parser/src/types/type_declarations.rs
@@ -9,6 +9,7 @@ use tokenizer_lib::{Token, TokenReader};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct TypeDeclaration {
 	pub name: String,
 	pub type_parameters: Option<Vec<GenericTypeConstraint>>,
@@ -61,6 +62,7 @@ impl ASTNode for TypeDeclaration {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum GenericTypeConstraint {
 	Parameter { name: String, default: Option<TypeAnnotation> },
 	Extends(String, TypeAnnotation),

--- a/parser/src/types/type_declarations.rs
+++ b/parser/src/types/type_declarations.rs
@@ -1,5 +1,5 @@
 use crate::{
-	default_derive_bundle, errors::parse_lexing_error, parse_bracketed, to_string_bracketed,
+	derive_ASTNode, errors::parse_lexing_error, parse_bracketed, to_string_bracketed,
 	tokens::token_as_identifier, ASTNode, ListItem, ParseOptions, ParseResult, Span, TSXKeyword,
 	TSXToken, TypeAnnotation,
 };
@@ -8,7 +8,7 @@ use tokenizer_lib::{Token, TokenReader};
 /// Similar to type reference but no unions or intersections AND includes generic constraints.
 /// Used for declaring classes, interfaces and functions
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct TypeDeclaration {
 	pub name: String,
 	pub type_parameters: Option<Vec<GenericTypeConstraint>>,
@@ -59,7 +59,7 @@ impl ASTNode for TypeDeclaration {
 ///
 /// TODO is default and extends mut ex
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum GenericTypeConstraint {
 	Parameter { name: String, default: Option<TypeAnnotation> },
 	Extends(String, TypeAnnotation),

--- a/parser/src/types/type_declarations.rs
+++ b/parser/src/types/type_declarations.rs
@@ -1,15 +1,14 @@
 use crate::{
-	errors::parse_lexing_error, parse_bracketed, to_string_bracketed, tokens::token_as_identifier,
-	ASTNode, ListItem, ParseOptions, ParseResult, Span, TSXKeyword, TSXToken, TypeAnnotation,
+	default_derive_bundle, errors::parse_lexing_error, parse_bracketed, to_string_bracketed,
+	tokens::token_as_identifier, ASTNode, ListItem, ParseOptions, ParseResult, Span, TSXKeyword,
+	TSXToken, TypeAnnotation,
 };
 use tokenizer_lib::{Token, TokenReader};
 
 /// Similar to type reference but no unions or intersections AND includes generic constraints.
 /// Used for declaring classes, interfaces and functions
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct TypeDeclaration {
 	pub name: String,
 	pub type_parameters: Option<Vec<GenericTypeConstraint>>,
@@ -60,9 +59,7 @@ impl ASTNode for TypeDeclaration {
 ///
 /// TODO is default and extends mut ex
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum GenericTypeConstraint {
 	Parameter { name: String, default: Option<TypeAnnotation> },
 	Extends(String, TypeAnnotation),

--- a/parser/src/variable_fields.rs
+++ b/parser/src/variable_fields.rs
@@ -20,12 +20,10 @@ use get_field_by_type::GetFieldByType;
 use iterator_endiate::EndiateIteratorExt;
 use tokenizer_lib::TokenReader;
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, PartialEqExtras, Eq, Clone, GetFieldByType)]
 #[partial_eq_ignore_types(Span)]
 #[get_field_by_type_target(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum VariableIdentifier {
 	Standard(String, Span),
 	// TODO does this need Span
@@ -325,12 +323,10 @@ impl<U: VariableFieldKind> ASTNode for VariableField<U> {
 	}
 }
 
+#[apply(derive_ASTNode)]
 #[derive(Debug, Clone, PartialEqExtras, get_field_by_type::GetFieldByType)]
 #[get_field_by_type_target(Span)]
 #[partial_eq_ignore_types(Span)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ObjectDestructuringField<T: VariableFieldKind> {
 	/// `{ x }`
 	Name(
@@ -376,7 +372,7 @@ impl<U: VariableFieldKind> ASTNode for ObjectDestructuringField<U> {
 						*key.get_position()
 					};
 				Ok(Self::Map { from: key, name: variable_name, default_value, position })
-			} else if let PropertyKey::Ident(name, key_pos, ()) = key {
+			} else if let PropertyKey::Ident(name, key_pos, _) = key {
 				let default_value = U::optional_expression_from_reader(reader, state, options)?;
 				let standard = VariableIdentifier::Standard(name, key_pos);
 				let position =
@@ -633,7 +629,10 @@ mod tests {
 	fn name() {
 		assert_matches_ast!(
 			"x",
-			VariableField::Name(VariableIdentifier::Standard(Deref @ "x", Span { start: 0, end: 1, .. }))
+			VariableField::Name(VariableIdentifier::Standard(
+				Deref @ "x",
+				Span { start: 0, end: 1, .. },
+			))
 		);
 	}
 

--- a/parser/src/variable_fields.rs
+++ b/parser/src/variable_fields.rs
@@ -331,9 +331,11 @@ impl<U: VariableFieldKind> ASTNode for VariableField<U> {
 #[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ObjectDestructuringField<T: VariableFieldKind> {
 	/// `{ x }`
-	Name(VariableIdentifier,
+	Name(
+		VariableIdentifier,
 		#[cfg_attr(target_family = "wasm", tsify(type = "Expression | null"))]
-		T::OptionalExpression, Span
+		T::OptionalExpression,
+		Span,
 	),
 	/// `{ ...x }`
 	Spread(VariableIdentifier, Span),
@@ -425,9 +427,10 @@ impl<U: VariableFieldKind> ASTNode for ObjectDestructuringField<U> {
 #[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ArrayDestructuringField<T: VariableFieldKind> {
 	Spread(VariableIdentifier, Span),
-	Name(VariableField<T>, #[cfg_attr(target_family = "wasm", tsify(
-		type = "Expression?"
-	))] T::OptionalExpression),
+	Name(
+		VariableField<T>,
+		#[cfg_attr(target_family = "wasm", tsify(type = "Expression?"))] T::OptionalExpression,
+	),
 	None,
 }
 

--- a/parser/src/variable_fields.rs
+++ b/parser/src/variable_fields.rs
@@ -4,6 +4,7 @@
 use std::fmt::Debug;
 
 use crate::{
+	default_derive_bundle,
 	errors::parse_lexing_error,
 	parse_bracketed,
 	property_key::PropertyKey,
@@ -183,9 +184,7 @@ pub trait VariableFieldKind: PartialEq + Eq + Debug + Clone + 'static {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct VariableFieldInSourceCode;
 
 impl VariableFieldKind for VariableFieldInSourceCode {
@@ -224,9 +223,7 @@ impl VariableFieldKind for VariableFieldInSourceCode {
 
 /// For function type references
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub struct VariableFieldInTypeAnnotation;
 
 impl VariableFieldKind for VariableFieldInTypeAnnotation {
@@ -427,9 +424,7 @@ impl<U: VariableFieldKind> ASTNode for ObjectDestructuringField<U> {
 
 /// TODO unsure about the positions here, is potential duplication if `T::OptionalExpression` is none
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
-#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
-#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
+#[apply(default_derive_bundle)]
 pub enum ArrayDestructuringField<T: VariableFieldKind> {
 	Spread(VariableIdentifier, Span),
 	Name(

--- a/parser/src/variable_fields.rs
+++ b/parser/src/variable_fields.rs
@@ -30,9 +30,8 @@ pub enum VariableIdentifier {
 	// TODO does this need Span
 	#[cfg_attr(feature = "self-rust-tokenize", self_tokenize_field(0))]
 	Marker(
-		#[cfg_attr(target_family = "wasm", tsify(type = "VariableIdentifier"))]
-		Marker<Self>,
-		Span
+		#[cfg_attr(target_family = "wasm", tsify(type = "VariableIdentifier"))] Marker<Self>,
+		Span,
 	),
 }
 

--- a/parser/src/variable_fields.rs
+++ b/parser/src/variable_fields.rs
@@ -4,7 +4,7 @@
 use std::fmt::Debug;
 
 use crate::{
-	default_derive_bundle,
+	derive_ASTNode,
 	errors::parse_lexing_error,
 	parse_bracketed,
 	property_key::PropertyKey,
@@ -184,7 +184,7 @@ pub trait VariableFieldKind: PartialEq + Eq + Debug + Clone + 'static {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct VariableFieldInSourceCode;
 
 impl VariableFieldKind for VariableFieldInSourceCode {
@@ -223,7 +223,7 @@ impl VariableFieldKind for VariableFieldInSourceCode {
 
 /// For function type references
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub struct VariableFieldInTypeAnnotation;
 
 impl VariableFieldKind for VariableFieldInTypeAnnotation {
@@ -424,7 +424,7 @@ impl<U: VariableFieldKind> ASTNode for ObjectDestructuringField<U> {
 
 /// TODO unsure about the positions here, is potential duplication if `T::OptionalExpression` is none
 #[derive(Debug, Clone)]
-#[apply(default_derive_bundle)]
+#[apply(derive_ASTNode)]
 pub enum ArrayDestructuringField<T: VariableFieldKind> {
 	Spread(VariableIdentifier, Span),
 	Name(

--- a/parser/src/variable_fields.rs
+++ b/parser/src/variable_fields.rs
@@ -24,6 +24,7 @@ use tokenizer_lib::TokenReader;
 #[get_field_by_type_target(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum VariableIdentifier {
 	Standard(String, Span),
 	// TODO does this need Span
@@ -67,6 +68,7 @@ impl ASTNode for VariableIdentifier {
 /// A variable declaration name, used in variable declarations and function parameters.
 /// See [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)
 #[derive(Debug, Clone)]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum VariableField<T: VariableFieldKind> {
 	/// `x`
 	Name(VariableIdentifier),
@@ -326,15 +328,20 @@ impl<U: VariableFieldKind> ASTNode for VariableField<U> {
 #[partial_eq_ignore_types(Span)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ObjectDestructuringField<T: VariableFieldKind> {
 	/// `{ x }`
-	Name(VariableIdentifier, T::OptionalExpression, Span),
+	Name(VariableIdentifier,
+		#[cfg_attr(target_family = "wasm", tsify(type = "Expression | null"))]
+		T::OptionalExpression, Span
+	),
 	/// `{ ...x }`
 	Spread(VariableIdentifier, Span),
 	/// `{ x: y }`
 	Map {
 		from: PropertyKey<crate::property_key::AlwaysPublic>,
 		name: WithComment<VariableField<T>>,
+		#[cfg_attr(target_family = "wasm", tsify(type = "Expression | null"))]
 		default_value: T::OptionalExpression,
 		position: Span,
 	},
@@ -415,9 +422,12 @@ impl<U: VariableFieldKind> ASTNode for ObjectDestructuringField<U> {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub enum ArrayDestructuringField<T: VariableFieldKind> {
 	Spread(VariableIdentifier, Span),
-	Name(VariableField<T>, T::OptionalExpression),
+	Name(VariableField<T>, #[cfg_attr(target_family = "wasm", tsify(
+		type = "Expression?"
+	))] T::OptionalExpression),
 	None,
 }
 

--- a/parser/src/variable_fields.rs
+++ b/parser/src/variable_fields.rs
@@ -29,7 +29,11 @@ pub enum VariableIdentifier {
 	Standard(String, Span),
 	// TODO does this need Span
 	#[cfg_attr(feature = "self-rust-tokenize", self_tokenize_field(0))]
-	Marker(Marker<Self>, Span),
+	Marker(
+		#[cfg_attr(target_family = "wasm", tsify(type = "VariableIdentifier"))]
+		Marker<Self>,
+		Span
+	),
 }
 
 impl ASTNode for VariableIdentifier {
@@ -182,6 +186,7 @@ pub trait VariableFieldKind: PartialEq + Eq + Debug + Clone + 'static {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct VariableFieldInSourceCode;
 
 impl VariableFieldKind for VariableFieldInSourceCode {
@@ -222,6 +227,7 @@ impl VariableFieldKind for VariableFieldInSourceCode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 #[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(tsify::Tsify))]
 pub struct VariableFieldInTypeAnnotation;
 
 impl VariableFieldKind for VariableFieldInTypeAnnotation {

--- a/src/build.rs
+++ b/src/build.rs
@@ -11,14 +11,14 @@ use parser::{
 
 use crate::check::CheckingOutputWithoutDiagnostics;
 
-#[cfg_attr(target_family = "wasm", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(serde::Serialize, tsify::Tsify))]
 pub struct Output {
 	pub output_path: PathBuf,
 	pub content: String,
 	pub mappings: String,
 }
 
-#[cfg_attr(target_family = "wasm", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(serde::Serialize, tsify::Tsify))]
 pub struct BuildOutput {
 	pub outputs: Vec<Output>,
 	pub diagnostics: DiagnosticsContainer,
@@ -28,7 +28,7 @@ pub struct BuildOutput {
 	pub fs: MapFileStore<WithPathMap>,
 }
 
-#[cfg_attr(target_family = "wasm", derive(serde::Serialize))]
+#[cfg_attr(target_family = "wasm", derive(serde::Serialize, tsify::Tsify))]
 pub struct FailedBuildOutput {
 	pub diagnostics: DiagnosticsContainer,
 	/// For diagnostics

--- a/src/js-cli-and-library/package-lock.json
+++ b/src/js-cli-and-library/package-lock.json
@@ -854,18 +854,18 @@
 			}
 		},
 		"node_modules/@rollup/plugin-json": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.0.0.tgz",
-			"integrity": "sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+			"integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
 			"dev": true,
 			"dependencies": {
-				"@rollup/pluginutils": "^5.0.1"
+				"@rollup/pluginutils": "^5.1.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0"
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
 			},
 			"peerDependenciesMeta": {
 				"rollup": {
@@ -899,36 +899,24 @@
 			}
 		},
 		"node_modules/@rollup/plugin-replace": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.2.tgz",
-			"integrity": "sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
+			"integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^5.0.1",
-				"magic-string": "^0.27.0"
+				"magic-string": "^0.30.3"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0"
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
 			},
 			"peerDependenciesMeta": {
 				"rollup": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@rollup/plugin-replace/node_modules/magic-string": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-			"integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.13"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
@@ -963,9 +951,9 @@
 			}
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
 			"dev": true
 		},
 		"node_modules/@types/resolve": {
@@ -1125,9 +1113,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001583",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001583.tgz",
-			"integrity": "sha512-acWTYaha8xfhA/Du/z4sNZjHUWjkiuoAi2LM+T/aL+kemKQgPT1xBb/YKjlQ0Qo8gvbHsGNplrEJ+9G3gL7i4Q==",
+			"version": "1.0.30001585",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001585.tgz",
+			"integrity": "sha512-yr2BWR1yLXQ8fMpdS/4ZZXpseBgE7o4g41x3a6AJOqZuOi+iE/WdJYAuZ6Y95i4Ohd2Y+9MzIWRR+uGABH4s3Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -1489,9 +1477,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.656",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.656.tgz",
-			"integrity": "sha512-9AQB5eFTHyR3Gvt2t/NwR0le2jBSUNwCnMbUCejFWHD+so4tH40/dRLgoE+jxlPeWS43XJewyvCv+I8LPMl49Q==",
+			"version": "1.4.665",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.665.tgz",
+			"integrity": "sha512-UpyCWObBoD+nSZgOC2ToaIdZB0r9GhqT2WahPKiSki6ckkSuKhQNso8V2PrFcHBMleI/eqbKgVQgVC4Wni4ilw==",
 			"dev": true
 		},
 		"node_modules/entities": {
@@ -1545,9 +1533,9 @@
 			}
 		},
 		"node_modules/escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+			"integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -1585,9 +1573,9 @@
 			}
 		},
 		"node_modules/fastq": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.0.tgz",
-			"integrity": "sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -1947,9 +1935,9 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.6",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.6.tgz",
-			"integrity": "sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==",
+			"version": "0.30.7",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
+			"integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -2166,9 +2154,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.33",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
-			"integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+			"version": "8.4.35",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+			"integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2759,9 +2747,9 @@
 			}
 		},
 		"node_modules/scule": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/scule/-/scule-1.2.0.tgz",
-			"integrity": "sha512-CRCmi5zHQnSoeCik9565PONMg0kfkvYmcSqrbOJY4txFfy1wvVULV4FDaiXhUblUgahdqz3F2NwHZ8i4eBTwUw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
+			"integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
 			"dev": true
 		},
 		"node_modules/semver": {
@@ -2895,9 +2883,9 @@
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
-			"integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.4.0.tgz",
+			"integrity": "sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==",
 			"dev": true
 		},
 		"node_modules/unbuild": {

--- a/src/js-cli-and-library/package-lock.json
+++ b/src/js-cli-and-library/package-lock.json
@@ -9,10 +9,10 @@
 			"version": "0.0.19",
 			"license": "MIT",
 			"bin": {
-				"ezno": "dist/cli.cjs"
+				"ezno": "dist/cli.mjs"
 			},
 			"devDependencies": {
-				"unbuild": "^1.1.2"
+				"unbuild": "^2.0.0"
 			},
 			"funding": {
 				"type": "individual",
@@ -20,12 +20,12 @@
 			}
 		},
 		"node_modules/@ampproject/remapping": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.1.0",
+				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
 			},
 			"engines": {
@@ -33,47 +33,62 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.18.6"
+				"@babel/highlight": "^7.23.4",
+				"chalk": "^2.4.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/code-frame/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
-			"integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+			"integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.21.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
-			"integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
+			"integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.21.3",
-				"@babel/helper-compilation-targets": "^7.20.7",
-				"@babel/helper-module-transforms": "^7.21.2",
-				"@babel/helpers": "^7.21.0",
-				"@babel/parser": "^7.21.3",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.3",
-				"@babel/types": "^7.21.3",
-				"convert-source-map": "^1.7.0",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.6",
+				"@babel/helper-compilation-targets": "^7.23.6",
+				"@babel/helper-module-transforms": "^7.23.3",
+				"@babel/helpers": "^7.23.9",
+				"@babel/parser": "^7.23.9",
+				"@babel/template": "^7.23.9",
+				"@babel/traverse": "^7.23.9",
+				"@babel/types": "^7.23.9",
+				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.2",
-				"semver": "^6.3.0"
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -84,12 +99,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.21.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
-			"integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.21.3",
+				"@babel/types": "^7.23.6",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -98,31 +113,79 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+		"node_modules/@babel/helper-compilation-targets": {
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.9"
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-validator-option": "^7.23.5",
+				"browserslist": "^4.22.2",
+				"lru-cache": "^5.1.1",
+				"semver": "^6.3.1"
 			},
 			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
-			"integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+		"node_modules/@babel/helper-environment-visitor": {
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-function-name": {
+			"version": "7.23.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.20.5",
-				"@babel/helper-validator-option": "^7.18.6",
-				"browserslist": "^4.21.3",
-				"lru-cache": "^5.1.1",
-				"semver": "^6.3.0"
+				"@babel/template": "^7.22.15",
+				"@babel/types": "^7.23.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-hoist-variables": {
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.22.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-imports": {
+			"version": "7.22.15",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "^7.22.15"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-module-transforms": {
+			"version": "7.23.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+			"integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-module-imports": "^7.22.15",
+				"@babel/helper-simple-access": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-validator-identifier": "^7.22.20"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -131,144 +194,79 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-function-name": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-			"integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/template": "^7.20.7",
-				"@babel/types": "^7.21.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-imports": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.21.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
-			"integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-simple-access": "^7.20.2",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/helper-validator-identifier": "^7.19.1",
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.2",
-				"@babel/types": "^7.21.2"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-simple-access": {
-			"version": "7.20.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-			"integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+			"version": "7.22.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.20.2"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"version": "7.22.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.6"
+				"@babel/types": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.19.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-			"integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"version": "7.22.20",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
-			"integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
-			"integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
+			"integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/template": "^7.20.7",
-				"@babel/traverse": "^7.21.0",
-				"@babel/types": "^7.21.0"
+				"@babel/template": "^7.23.9",
+				"@babel/traverse": "^7.23.9",
+				"@babel/types": "^7.23.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
+				"@babel/helper-validator-identifier": "^7.22.20",
+				"chalk": "^2.4.2",
 				"js-tokens": "^4.0.0"
 			},
 			"engines": {
@@ -290,9 +288,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.21.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
-			"integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+			"integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -302,43 +300,43 @@
 			}
 		},
 		"node_modules/@babel/standalone": {
-			"version": "7.21.3",
-			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.21.3.tgz",
-			"integrity": "sha512-c8feJERTAHlBEvihQUWrnUMLg2GzrwSnE76WDyN3fRJWju10pHeRy8r3wniIq0q7zPLhHd71PQtFVsn1H+Qscw==",
+			"version": "7.23.10",
+			"resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.23.10.tgz",
+			"integrity": "sha512-xqWviI/pt1Zb/d+6ilWa5IDL2mkDzsBnlHbreqnfyP3/QB/ofQ1bNVcHj8YQX154Rf/xZKR6y0s1ydVF3nAS8g==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.20.7",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-			"integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+			"integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.20.7",
-				"@babel/types": "^7.20.7"
+				"@babel/code-frame": "^7.23.5",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.21.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
-			"integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+			"integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.21.3",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.21.0",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.21.3",
-				"@babel/types": "^7.21.3",
-				"debug": "^4.1.0",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.6",
+				"@babel/helper-environment-visitor": "^7.22.20",
+				"@babel/helper-function-name": "^7.23.0",
+				"@babel/helper-hoist-variables": "^7.22.5",
+				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/parser": "^7.23.9",
+				"@babel/types": "^7.23.9",
+				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -346,23 +344,375 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.21.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
-			"integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
+			"version": "7.23.9",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+			"integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.19.4",
-				"@babel/helper-validator-identifier": "^7.19.1",
+				"@babel/helper-string-parser": "^7.23.4",
+				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+			"integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+			"integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+			"integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+			"integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+			"integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+			"integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+			"integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+			"integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+			"integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+			"integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+			"integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+			"integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+			"integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+			"integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+			"integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+			"integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+			"integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+			"integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+			"integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+			"integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+			"integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+			"integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.12.tgz",
-			"integrity": "sha512-JOOxw49BVZx2/5tW3FqkdjSD/5gXYeVGPDcB0lvap0gLQshkh1Nyel1QazC+wNxus3xPlsYAgqU1BUmrmCvWtw==",
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+			"integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
 			"cpu": [
 				"x64"
 			],
@@ -376,22 +726,23 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.0",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
 			},
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -407,19 +758,19 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.17",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-			"integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+			"version": "0.3.22",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+			"integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/resolve-uri": "3.1.0",
-				"@jridgewell/sourcemap-codec": "1.4.14"
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -458,9 +809,9 @@
 			}
 		},
 		"node_modules/@rollup/plugin-alias": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-4.0.3.tgz",
-			"integrity": "sha512-ZuDWE1q4PQDhvm/zc5Prun8sBpLJy41DMptYrS6MhAy9s9kL/doN1613BWfEchGVfKxzliJ3BjbOPizXX38DbQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.0.tgz",
+			"integrity": "sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==",
 			"dev": true,
 			"dependencies": {
 				"slash": "^4.0.0"
@@ -469,7 +820,7 @@
 				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0"
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
 			},
 			"peerDependenciesMeta": {
 				"rollup": {
@@ -478,9 +829,9 @@
 			}
 		},
 		"node_modules/@rollup/plugin-commonjs": {
-			"version": "24.0.1",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-24.0.1.tgz",
-			"integrity": "sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==",
+			"version": "25.0.7",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz",
+			"integrity": "sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^5.0.1",
@@ -488,30 +839,18 @@
 				"estree-walker": "^2.0.2",
 				"glob": "^8.0.3",
 				"is-reference": "1.2.1",
-				"magic-string": "^0.27.0"
+				"magic-string": "^0.30.3"
 			},
 			"engines": {
 				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"rollup": "^2.68.0||^3.0.0"
+				"rollup": "^2.68.0||^3.0.0||^4.0.0"
 			},
 			"peerDependenciesMeta": {
 				"rollup": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@rollup/plugin-commonjs/node_modules/magic-string": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-			"integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.13"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@rollup/plugin-json": {
@@ -535,15 +874,15 @@
 			}
 		},
 		"node_modules/@rollup/plugin-node-resolve": {
-			"version": "15.0.1",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.0.1.tgz",
-			"integrity": "sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==",
+			"version": "15.2.3",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+			"integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
 			"dev": true,
 			"dependencies": {
 				"@rollup/pluginutils": "^5.0.1",
 				"@types/resolve": "1.20.2",
 				"deepmerge": "^4.2.2",
-				"is-builtin-module": "^3.2.0",
+				"is-builtin-module": "^3.2.1",
 				"is-module": "^1.0.0",
 				"resolve": "^1.22.1"
 			},
@@ -551,7 +890,7 @@
 				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"rollup": "^2.78.0||^3.0.0"
+				"rollup": "^2.78.0||^3.0.0||^4.0.0"
 			},
 			"peerDependenciesMeta": {
 				"rollup": {
@@ -593,9 +932,9 @@
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
-			"integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+			"integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0",
@@ -606,12 +945,21 @@
 				"node": ">=14.0.0"
 			},
 			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0||^3.0.0"
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
 			},
 			"peerDependenciesMeta": {
 				"rollup": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@trysound/sax": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+			"integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/@types/estree": {
@@ -627,9 +975,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.8.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -650,10 +998,53 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/autoprefixer": {
+			"version": "10.4.17",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
+			"integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/autoprefixer"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"browserslist": "^4.22.2",
+				"caniuse-lite": "^1.0.30001578",
+				"fraction.js": "^4.3.7",
+				"normalize-range": "^0.1.2",
+				"picocolors": "^1.0.0",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"bin": {
+				"autoprefixer": "bin/autoprefixer"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
@@ -678,9 +1069,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.5",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-			"integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+			"version": "4.22.3",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.3.tgz",
+			"integrity": "sha512-UAp55yfwNv0klWNapjs/ktHoguxuQNGnOzxYmfnXIS+8AsRDZkSDxg7R1AX3GKzn078SBI5dzwzj/Yx0Or0e3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -690,13 +1081,17 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001449",
-				"electron-to-chromium": "^1.4.284",
-				"node-releases": "^2.0.8",
-				"update-browserslist-db": "^1.0.10"
+				"caniuse-lite": "^1.0.30001580",
+				"electron-to-chromium": "^1.4.648",
+				"node-releases": "^2.0.14",
+				"update-browserslist-db": "^1.0.13"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -717,10 +1112,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/caniuse-api": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.0.0",
+				"caniuse-lite": "^1.0.0",
+				"lodash.memoize": "^4.1.2",
+				"lodash.uniq": "^4.5.0"
+			}
+		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001469",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
-			"integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
+			"version": "1.0.30001583",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001583.tgz",
+			"integrity": "sha512-acWTYaha8xfhA/Du/z4sNZjHUWjkiuoAi2LM+T/aL+kemKQgPT1xBb/YKjlQ0Qo8gvbHsGNplrEJ+9G3gL7i4Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -730,19 +1137,32 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			]
 		},
 		"node_modules/chalk": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-			"integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
 			"dev": true,
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/citty": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.5.tgz",
+			"integrity": "sha512-AS7n5NSc0OQVMV9v6wt3ByujNIrne0/cTjiC2MYqhvao57VNfiuVksTSr2p17nVOhEr2KtqiAkGwHcgMC/qUuQ==",
+			"dev": true,
+			"dependencies": {
+				"consola": "^3.2.3"
 			}
 		},
 		"node_modules/color-convert": {
@@ -760,6 +1180,21 @@
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
+		"node_modules/colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+			"dev": true
+		},
+		"node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/commondir": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -767,15 +1202,191 @@
 			"dev": true
 		},
 		"node_modules/consola": {
-			"version": "2.15.3",
-			"resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-			"integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-			"dev": true
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+			"integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+			"dev": true,
+			"engines": {
+				"node": "^14.18.0 || >=16.10.0"
+			}
 		},
 		"node_modules/convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true
+		},
+		"node_modules/css-declaration-sorter": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.1.1.tgz",
+			"integrity": "sha512-dZ3bVTEEc1vxr3Bek9vGwfB5Z6ESPULhcRvO472mfjVnj8jRcTnKO8/JTczlvxM10Myb+wBM++1MtdO76eWcaQ==",
+			"dev": true,
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.0.9"
+			}
+		},
+		"node_modules/css-select": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-tree": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+			"dev": true,
+			"dependencies": {
+				"mdn-data": "2.0.30",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cssesc": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"dev": true,
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/cssnano": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.3.tgz",
+			"integrity": "sha512-MRq4CIj8pnyZpcI2qs6wswoYoDD1t0aL28n+41c1Ukcpm56m1h6mCexIHBGjfZfnTqtGSSCP4/fB1ovxgjBOiw==",
+			"dev": true,
+			"dependencies": {
+				"cssnano-preset-default": "^6.0.3",
+				"lilconfig": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/cssnano"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/cssnano-preset-default": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.3.tgz",
+			"integrity": "sha512-4y3H370aZCkT9Ev8P4SO4bZbt+AExeKhh8wTbms/X7OLDo5E7AYUUy6YPxa/uF5Grf+AJwNcCnxKhZynJ6luBA==",
+			"dev": true,
+			"dependencies": {
+				"css-declaration-sorter": "^7.1.1",
+				"cssnano-utils": "^4.0.1",
+				"postcss-calc": "^9.0.1",
+				"postcss-colormin": "^6.0.2",
+				"postcss-convert-values": "^6.0.2",
+				"postcss-discard-comments": "^6.0.1",
+				"postcss-discard-duplicates": "^6.0.1",
+				"postcss-discard-empty": "^6.0.1",
+				"postcss-discard-overridden": "^6.0.1",
+				"postcss-merge-longhand": "^6.0.2",
+				"postcss-merge-rules": "^6.0.3",
+				"postcss-minify-font-values": "^6.0.1",
+				"postcss-minify-gradients": "^6.0.1",
+				"postcss-minify-params": "^6.0.2",
+				"postcss-minify-selectors": "^6.0.2",
+				"postcss-normalize-charset": "^6.0.1",
+				"postcss-normalize-display-values": "^6.0.1",
+				"postcss-normalize-positions": "^6.0.1",
+				"postcss-normalize-repeat-style": "^6.0.1",
+				"postcss-normalize-string": "^6.0.1",
+				"postcss-normalize-timing-functions": "^6.0.1",
+				"postcss-normalize-unicode": "^6.0.2",
+				"postcss-normalize-url": "^6.0.1",
+				"postcss-normalize-whitespace": "^6.0.1",
+				"postcss-ordered-values": "^6.0.1",
+				"postcss-reduce-initial": "^6.0.2",
+				"postcss-reduce-transforms": "^6.0.1",
+				"postcss-svgo": "^6.0.2",
+				"postcss-unique-selectors": "^6.0.2"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/cssnano-utils": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.1.tgz",
+			"integrity": "sha512-6qQuYDqsGoiXssZ3zct6dcMxiqfT6epy7x4R0TQJadd4LWO3sPR6JH6ZByOvVLoZ6EdwPGgd7+DR1EmX3tiXQQ==",
+			"dev": true,
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/csso": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+			"integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+			"dev": true,
+			"dependencies": {
+				"css-tree": "~2.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/csso/node_modules/css-tree": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+			"integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+			"dev": true,
+			"dependencies": {
+				"mdn-data": "2.0.28",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/csso/node_modules/mdn-data": {
+			"version": "2.0.28",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
 			"dev": true
 		},
 		"node_modules/debug": {
@@ -805,9 +1416,9 @@
 			}
 		},
 		"node_modules/defu": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.2.tgz",
-			"integrity": "sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
 			"dev": true
 		},
 		"node_modules/dir-glob": {
@@ -822,16 +1433,83 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			]
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"dev": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.337",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.337.tgz",
-			"integrity": "sha512-W8gdzXG86mVPoc56eM8YA+QiLxaAxJ8cmDjxZgfhLLWVvZQxyA918w5tX2JEWApZta45T1/sYcmFHTsTOUE3nw==",
+			"version": "1.4.656",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.656.tgz",
+			"integrity": "sha512-9AQB5eFTHyR3Gvt2t/NwR0le2jBSUNwCnMbUCejFWHD+so4tH40/dRLgoE+jxlPeWS43XJewyvCv+I8LPMl49Q==",
 			"dev": true
 		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/esbuild": {
-			"version": "0.17.12",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.12.tgz",
-			"integrity": "sha512-bX/zHl7Gn2CpQwcMtRogTTBf9l1nl+H6R8nUbjk+RuKqAE3+8FDulLA+pHvX7aA7Xe07Iwa+CWvy9I8Y2qqPKQ==",
+			"version": "0.19.12",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+			"integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -841,28 +1519,29 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/android-arm": "0.17.12",
-				"@esbuild/android-arm64": "0.17.12",
-				"@esbuild/android-x64": "0.17.12",
-				"@esbuild/darwin-arm64": "0.17.12",
-				"@esbuild/darwin-x64": "0.17.12",
-				"@esbuild/freebsd-arm64": "0.17.12",
-				"@esbuild/freebsd-x64": "0.17.12",
-				"@esbuild/linux-arm": "0.17.12",
-				"@esbuild/linux-arm64": "0.17.12",
-				"@esbuild/linux-ia32": "0.17.12",
-				"@esbuild/linux-loong64": "0.17.12",
-				"@esbuild/linux-mips64el": "0.17.12",
-				"@esbuild/linux-ppc64": "0.17.12",
-				"@esbuild/linux-riscv64": "0.17.12",
-				"@esbuild/linux-s390x": "0.17.12",
-				"@esbuild/linux-x64": "0.17.12",
-				"@esbuild/netbsd-x64": "0.17.12",
-				"@esbuild/openbsd-x64": "0.17.12",
-				"@esbuild/sunos-x64": "0.17.12",
-				"@esbuild/win32-arm64": "0.17.12",
-				"@esbuild/win32-ia32": "0.17.12",
-				"@esbuild/win32-x64": "0.17.12"
+				"@esbuild/aix-ppc64": "0.19.12",
+				"@esbuild/android-arm": "0.19.12",
+				"@esbuild/android-arm64": "0.19.12",
+				"@esbuild/android-x64": "0.19.12",
+				"@esbuild/darwin-arm64": "0.19.12",
+				"@esbuild/darwin-x64": "0.19.12",
+				"@esbuild/freebsd-arm64": "0.19.12",
+				"@esbuild/freebsd-x64": "0.19.12",
+				"@esbuild/linux-arm": "0.19.12",
+				"@esbuild/linux-arm64": "0.19.12",
+				"@esbuild/linux-ia32": "0.19.12",
+				"@esbuild/linux-loong64": "0.19.12",
+				"@esbuild/linux-mips64el": "0.19.12",
+				"@esbuild/linux-ppc64": "0.19.12",
+				"@esbuild/linux-riscv64": "0.19.12",
+				"@esbuild/linux-s390x": "0.19.12",
+				"@esbuild/linux-x64": "0.19.12",
+				"@esbuild/netbsd-x64": "0.19.12",
+				"@esbuild/openbsd-x64": "0.19.12",
+				"@esbuild/sunos-x64": "0.19.12",
+				"@esbuild/win32-arm64": "0.19.12",
+				"@esbuild/win32-ia32": "0.19.12",
+				"@esbuild/win32-x64": "0.19.12"
 			}
 		},
 		"node_modules/escalade": {
@@ -890,9 +1569,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.12",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+			"integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -906,9 +1585,9 @@
 			}
 		},
 		"node_modules/fastq": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.0.tgz",
+			"integrity": "sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==",
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -926,10 +1605,23 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/fraction.js": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+			"integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"type": "patreon",
+				"url": "https://github.com/sponsors/rawify"
+			}
+		},
 		"node_modules/fs-extra": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-			"integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
 			"dev": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
@@ -946,11 +1638,28 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
@@ -1002,14 +1711,14 @@
 			}
 		},
 		"node_modules/globby": {
-			"version": "13.1.3",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
-			"integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+			"version": "13.2.2",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+			"integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
 			"dev": true,
 			"dependencies": {
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.11",
-				"ignore": "^5.2.0",
+				"fast-glob": "^3.3.0",
+				"ignore": "^5.2.4",
 				"merge2": "^1.4.1",
 				"slash": "^4.0.0"
 			},
@@ -1026,18 +1735,6 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true
 		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
 		"node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1047,16 +1744,28 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/hasown": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+			"integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+			"dev": true,
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/hookable": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.1.tgz",
-			"integrity": "sha512-ac50aYjbtRMMZEtTG0qnVaBDA+1lqL9fHzDnxMQlVuO6LZWcBB7NXjIu9H9iImClewNdrit4RiEzi9QpRTgKrg==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+			"integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
 			"dev": true
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -1094,12 +1803,12 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-			"integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
 			"dev": true,
 			"dependencies": {
-				"has": "^1.0.3"
+				"hasown": "^2.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1151,9 +1860,9 @@
 			}
 		},
 		"node_modules/jiti": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
-			"integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+			"integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
 			"dev": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
@@ -1190,9 +1899,9 @@
 			}
 		},
 		"node_modules/jsonc-parser": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
+			"integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
 			"dev": true
 		},
 		"node_modules/jsonfile": {
@@ -1207,6 +1916,27 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"node_modules/lilconfig": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
+			"integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true
+		},
+		"node_modules/lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+			"dev": true
+		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1217,16 +1947,22 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
-			"integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+			"version": "0.30.6",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.6.tgz",
+			"integrity": "sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==",
 			"dev": true,
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.13"
+				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+			"dev": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -1263,26 +1999,31 @@
 			}
 		},
 		"node_modules/mkdist": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/mkdist/-/mkdist-1.1.2.tgz",
-			"integrity": "sha512-s9whPlQsr84iY3XoufsDrVlzGiDdTnMwf2+7QU6ekJPgTIgGwn7EsU8lcefWqLH6no+/4UqjDBwyIkGKfZyH9g==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/mkdist/-/mkdist-1.4.0.tgz",
+			"integrity": "sha512-LzzdzWDx6cWWPd8saIoO+kT5jnbijfeDaE6jZfmCYEi3YL2aJSyF23/tCFee/mDuh/ek1UQeSYdLeSa6oesdiw==",
 			"dev": true,
 			"dependencies": {
-				"defu": "^6.1.2",
-				"esbuild": "^0.17.11",
-				"fs-extra": "^11.1.0",
-				"globby": "^13.1.3",
-				"jiti": "^1.17.2",
-				"mlly": "^1.1.1",
+				"autoprefixer": "^10.4.14",
+				"citty": "^0.1.5",
+				"cssnano": "^6.0.1",
+				"defu": "^6.1.3",
+				"esbuild": "^0.19.7",
+				"fs-extra": "^11.1.1",
+				"globby": "^13.2.2",
+				"jiti": "^1.21.0",
+				"mlly": "^1.4.2",
 				"mri": "^1.2.0",
-				"pathe": "^1.1.0"
+				"pathe": "^1.1.1",
+				"postcss": "^8.4.26",
+				"postcss-nested": "^6.0.1"
 			},
 			"bin": {
 				"mkdist": "dist/cli.cjs"
 			},
 			"peerDependencies": {
-				"sass": "^1.58.3",
-				"typescript": ">=4.9.5"
+				"sass": "^1.69.5",
+				"typescript": ">=5.3.2"
 			},
 			"peerDependenciesMeta": {
 				"sass": {
@@ -1294,15 +2035,15 @@
 			}
 		},
 		"node_modules/mlly": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
-			"integrity": "sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/mlly/-/mlly-1.5.0.tgz",
+			"integrity": "sha512-NPVQvAY1xr1QoVeG0cy8yUYC7FQcOx6evl/RjT1wL5FvzPnzOysoqB/jmx/DhssT2dYa8nxECLAaFI/+gVLhDQ==",
 			"dev": true,
 			"dependencies": {
-				"acorn": "^8.8.2",
-				"pathe": "^1.1.0",
-				"pkg-types": "^1.0.2",
-				"ufo": "^1.1.1"
+				"acorn": "^8.11.3",
+				"pathe": "^1.1.2",
+				"pkg-types": "^1.0.3",
+				"ufo": "^1.3.2"
 			}
 		},
 		"node_modules/mri": {
@@ -1320,11 +2061,50 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
+		"node_modules/nanoid": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
 		"node_modules/node-releases": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-			"integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true
+		},
+		"node_modules/normalize-range": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+			"integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
@@ -1351,9 +2131,9 @@
 			}
 		},
 		"node_modules/pathe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.0.tgz",
-			"integrity": "sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+			"integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
 			"dev": true
 		},
 		"node_modules/picocolors": {
@@ -1375,20 +2155,493 @@
 			}
 		},
 		"node_modules/pkg-types": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.2.tgz",
-			"integrity": "sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.0.3.tgz",
+			"integrity": "sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==",
 			"dev": true,
 			"dependencies": {
 				"jsonc-parser": "^3.2.0",
-				"mlly": "^1.1.1",
+				"mlly": "^1.2.0",
 				"pathe": "^1.1.0"
 			}
 		},
+		"node_modules/postcss": {
+			"version": "8.4.33",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+			"integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"nanoid": "^3.3.7",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.0.2"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/postcss-calc": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-9.0.1.tgz",
+			"integrity": "sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==",
+			"dev": true,
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.11",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.2"
+			}
+		},
+		"node_modules/postcss-colormin": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.2.tgz",
+			"integrity": "sha512-TXKOxs9LWcdYo5cgmcSHPkyrLAh86hX1ijmyy6J8SbOhyv6ua053M3ZAM/0j44UsnQNIWdl8gb5L7xX2htKeLw==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.22.2",
+				"caniuse-api": "^3.0.0",
+				"colord": "^2.9.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-convert-values": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.2.tgz",
+			"integrity": "sha512-aeBmaTnGQ+NUSVQT8aY0sKyAD/BaLJenEKZ03YK0JnDE1w1Rr8XShoxdal2V2H26xTJKr3v5haByOhJuyT4UYw==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.22.2",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-discard-comments": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.1.tgz",
+			"integrity": "sha512-f1KYNPtqYLUeZGCHQPKzzFtsHaRuECe6jLakf/RjSRqvF5XHLZnM2+fXLhb8Qh/HBFHs3M4cSLb1k3B899RYIg==",
+			"dev": true,
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-discard-duplicates": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.1.tgz",
+			"integrity": "sha512-1hvUs76HLYR8zkScbwyJ8oJEugfPV+WchpnA+26fpJ7Smzs51CzGBHC32RS03psuX/2l0l0UKh2StzNxOrKCYg==",
+			"dev": true,
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-discard-empty": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.1.tgz",
+			"integrity": "sha512-yitcmKwmVWtNsrrRqGJ7/C0YRy53i0mjexBDQ9zYxDwTWVBgbU4+C9jIZLmQlTDT9zhml+u0OMFJh8+31krmOg==",
+			"dev": true,
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-discard-overridden": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.1.tgz",
+			"integrity": "sha512-qs0ehZMMZpSESbRkw1+inkf51kak6OOzNRaoLd/U7Fatp0aN2HQ1rxGOrJvYcRAN9VpX8kUF13R2ofn8OlvFVA==",
+			"dev": true,
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-merge-longhand": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.2.tgz",
+			"integrity": "sha512-+yfVB7gEM8SrCo9w2lCApKIEzrTKl5yS1F4yGhV3kSim6JzbfLGJyhR1B6X+6vOT0U33Mgx7iv4X9MVWuaSAfw==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0",
+				"stylehacks": "^6.0.2"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-merge-rules": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.3.tgz",
+			"integrity": "sha512-yfkDqSHGohy8sGYIJwBmIGDv4K4/WrJPX355XrxQb/CSsT4Kc/RxDi6akqn5s9bap85AWgv21ArcUWwWdGNSHA==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.22.2",
+				"caniuse-api": "^3.0.0",
+				"cssnano-utils": "^4.0.1",
+				"postcss-selector-parser": "^6.0.15"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-minify-font-values": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.1.tgz",
+			"integrity": "sha512-tIwmF1zUPoN6xOtA/2FgVk1ZKrLcCvE0dpZLtzyyte0j9zUeB8RTbCqrHZGjJlxOvNWKMYtunLrrl7HPOiR46w==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-minify-gradients": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.1.tgz",
+			"integrity": "sha512-M1RJWVjd6IOLPl1hYiOd5HQHgpp6cvJVLrieQYS9y07Yo8itAr6jaekzJphaJFR0tcg4kRewCk3kna9uHBxn/w==",
+			"dev": true,
+			"dependencies": {
+				"colord": "^2.9.1",
+				"cssnano-utils": "^4.0.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-minify-params": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.2.tgz",
+			"integrity": "sha512-zwQtbrPEBDj+ApELZ6QylLf2/c5zmASoOuA4DzolyVGdV38iR2I5QRMsZcHkcdkZzxpN8RS4cN7LPskOkTwTZw==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.22.2",
+				"cssnano-utils": "^4.0.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-minify-selectors": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.2.tgz",
+			"integrity": "sha512-0b+m+w7OAvZejPQdN2GjsXLv5o0jqYHX3aoV0e7RBKPCsB7TYG5KKWBFhGnB/iP3213Ts8c5H4wLPLMm7z28Sg==",
+			"dev": true,
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.15"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-nested": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+			"integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+			"dev": true,
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.11"
+			},
+			"engines": {
+				"node": ">=12.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2.14"
+			}
+		},
+		"node_modules/postcss-normalize-charset": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.1.tgz",
+			"integrity": "sha512-aW5LbMNRZ+oDV57PF9K+WI1Z8MPnF+A8qbajg/T8PP126YrGX1f9IQx21GI2OlGz7XFJi/fNi0GTbY948XJtXg==",
+			"dev": true,
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-display-values": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.1.tgz",
+			"integrity": "sha512-mc3vxp2bEuCb4LgCcmG1y6lKJu1Co8T+rKHrcbShJwUmKJiEl761qb/QQCfFwlrvSeET3jksolCR/RZuMURudw==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-positions": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.1.tgz",
+			"integrity": "sha512-HRsq8u/0unKNvm0cvwxcOUEcakFXqZ41fv3FOdPn916XFUrympjr+03oaLkuZENz3HE9RrQE9yU0Xv43ThWjQg==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-repeat-style": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.1.tgz",
+			"integrity": "sha512-Gbb2nmCy6tTiA7Sh2MBs3fj9W8swonk6lw+dFFeQT68B0Pzwp1kvisJQkdV6rbbMSd9brMlS8I8ts52tAGWmGQ==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-string": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.1.tgz",
+			"integrity": "sha512-5Fhx/+xzALJD9EI26Aq23hXwmv97Zfy2VFrt5PLT8lAhnBIZvmaT5pQk+NuJ/GWj/QWaKSKbnoKDGLbV6qnhXg==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-timing-functions": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.1.tgz",
+			"integrity": "sha512-4zcczzHqmCU7L5dqTB9rzeqPWRMc0K2HoR+Bfl+FSMbqGBUcP5LRfgcH4BdRtLuzVQK1/FHdFoGT3F7rkEnY+g==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-unicode": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.2.tgz",
+			"integrity": "sha512-Ff2VdAYCTGyMUwpevTZPZ4w0+mPjbZzLLyoLh/RMpqUqeQKZ+xMm31hkxBavDcGKcxm6ACzGk0nBfZ8LZkStKA==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.22.2",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-url": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.1.tgz",
+			"integrity": "sha512-jEXL15tXSvbjm0yzUV7FBiEXwhIa9H88JOXDGQzmcWoB4mSjZIsmtto066s2iW9FYuIrIF4k04HA2BKAOpbsaQ==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-normalize-whitespace": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.1.tgz",
+			"integrity": "sha512-76i3NpWf6bB8UHlVuLRxG4zW2YykF9CTEcq/9LGAiz2qBuX5cBStadkk0jSkg9a9TCIXbMQz7yzrygKoCW9JuA==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-ordered-values": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.1.tgz",
+			"integrity": "sha512-XXbb1O/MW9HdEhnBxitZpPFbIvDgbo9NK4c/5bOfiKpnIGZDoL2xd7/e6jW5DYLsWxBbs+1nZEnVgnjnlFViaA==",
+			"dev": true,
+			"dependencies": {
+				"cssnano-utils": "^4.0.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-reduce-initial": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.2.tgz",
+			"integrity": "sha512-YGKalhNlCLcjcLvjU5nF8FyeCTkCO5UtvJEt0hrPZVCTtRLSOH4z00T1UntQPj4dUmIYZgMj8qK77JbSX95hSw==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.22.2",
+				"caniuse-api": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-reduce-transforms": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.1.tgz",
+			"integrity": "sha512-fUbV81OkUe75JM+VYO1gr/IoA2b/dRiH6HvMwhrIBSUrxq3jNZQZitSnugcTLDi1KkQh1eR/zi+iyxviUNBkcQ==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-selector-parser": {
+			"version": "6.0.15",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
+			"integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
+			"dev": true,
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-svgo": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.2.tgz",
+			"integrity": "sha512-IH5R9SjkTkh0kfFOQDImyy1+mTCb+E830+9SV1O+AaDcoHTvfsvt6WwJeo7KwcHbFnevZVCsXhDmjFiGVuwqFQ==",
+			"dev": true,
+			"dependencies": {
+				"postcss-value-parser": "^4.2.0",
+				"svgo": "^3.2.0"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >= 18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-unique-selectors": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.2.tgz",
+			"integrity": "sha512-8IZGQ94nechdG7Y9Sh9FlIY2b4uS8/k8kdKRX040XHsS3B6d1HrJAkXrBSsSu4SuARruSsUjW3nlSw8BHkaAYQ==",
+			"dev": true,
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.15"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true
+		},
 		"node_modules/pretty-bytes": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.0.tgz",
-			"integrity": "sha512-Rk753HI8f4uivXi4ZCIYdhmG1V+WKzvRMg/X+M42a6t7D07RcmopXJMDNk6N++7Bl75URRGsb40ruvg7Hcp2wQ==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+			"integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
 			"dev": true,
 			"engines": {
 				"node": "^14.13.1 || >=16.0.0"
@@ -1418,12 +2671,12 @@
 			]
 		},
 		"node_modules/resolve": {
-			"version": "1.22.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-			"integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+			"version": "1.22.8",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
 			"dev": true,
 			"dependencies": {
-				"is-core-module": "^2.9.0",
+				"is-core-module": "^2.13.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
@@ -1445,9 +2698,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.20.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.0.tgz",
-			"integrity": "sha512-YsIfrk80NqUDrxrjWPXUa7PWvAfegZEXHuPsEZg58fGCdjL1I9C1i/NaG+L+27kxxwkrG/QEDEQc8s/ynXWWGQ==",
+			"version": "3.29.4",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+			"integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -1461,37 +2714,25 @@
 			}
 		},
 		"node_modules/rollup-plugin-dts": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-5.3.0.tgz",
-			"integrity": "sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.0.tgz",
+			"integrity": "sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==",
 			"dev": true,
 			"dependencies": {
-				"magic-string": "^0.30.0"
+				"magic-string": "^0.30.4"
 			},
 			"engines": {
-				"node": ">=v14"
+				"node": ">=16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/Swatinem"
 			},
 			"optionalDependencies": {
-				"@babel/code-frame": "^7.18.6"
+				"@babel/code-frame": "^7.22.13"
 			},
 			"peerDependencies": {
-				"rollup": "^3.0.0",
-				"typescript": "^4.1 || ^5.0"
-			}
-		},
-		"node_modules/rollup-plugin-dts/node_modules/magic-string": {
-			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-			"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.13"
-			},
-			"engines": {
-				"node": ">=12"
+				"rollup": "^3.29.4 || ^4",
+				"typescript": "^4.5 || ^5.0"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -1518,15 +2759,15 @@
 			}
 		},
 		"node_modules/scule": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/scule/-/scule-1.0.0.tgz",
-			"integrity": "sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/scule/-/scule-1.2.0.tgz",
+			"integrity": "sha512-CRCmi5zHQnSoeCik9565PONMg0kfkvYmcSqrbOJY4txFfy1wvVULV4FDaiXhUblUgahdqz3F2NwHZ8i4eBTwUw==",
 			"dev": true
 		},
 		"node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
@@ -1542,6 +2783,31 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stylehacks": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.2.tgz",
+			"integrity": "sha512-00zvJGnCu64EpMjX8b5iCZ3us2Ptyw8+toEkb92VdmkEaRaSGBNKAoK6aWZckhXxmQP8zWiTaFaiMGIU8Ve8sg==",
+			"dev": true,
+			"dependencies": {
+				"browserslist": "^4.22.2",
+				"postcss-selector-parser": "^6.0.15"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
 			}
 		},
 		"node_modules/supports-color": {
@@ -1568,6 +2834,31 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/svgo": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
+			"integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
+			"dev": true,
+			"dependencies": {
+				"@trysound/sax": "0.2.0",
+				"commander": "^7.2.0",
+				"css-select": "^5.1.0",
+				"css-tree": "^2.3.1",
+				"css-what": "^6.1.0",
+				"csso": "^5.0.5",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"svgo": "bin/svgo"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/svgo"
+			}
+		},
 		"node_modules/to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -1590,85 +2881,99 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/ufo": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.1.1.tgz",
-			"integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.3.2.tgz",
+			"integrity": "sha512-o+ORpgGwaYQXgqGDwd+hkS4PuZ3QnmqMMxRuajK/a38L6fTpcE5GPIfrf+L/KemFzfUpeUQc1rRS1iDBozvnFA==",
 			"dev": true
 		},
 		"node_modules/unbuild": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unbuild/-/unbuild-1.1.2.tgz",
-			"integrity": "sha512-EK5LeABThyn5KbX0eo5c7xKRQhnHVxKN8/e5Y+YQEf4ZobJB6OZ766756wbVqzIY/G/MvAfLbc6EwFPdSNnlpA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unbuild/-/unbuild-2.0.0.tgz",
+			"integrity": "sha512-JWCUYx3Oxdzvw2J9kTAp+DKE8df/BnH/JTSj6JyA4SH40ECdFu7FoJJcrm8G92B7TjofQ6GZGjJs50TRxoH6Wg==",
 			"dev": true,
 			"dependencies": {
-				"@rollup/plugin-alias": "^4.0.3",
-				"@rollup/plugin-commonjs": "^24.0.1",
+				"@rollup/plugin-alias": "^5.0.0",
+				"@rollup/plugin-commonjs": "^25.0.4",
 				"@rollup/plugin-json": "^6.0.0",
-				"@rollup/plugin-node-resolve": "^15.0.1",
+				"@rollup/plugin-node-resolve": "^15.2.1",
 				"@rollup/plugin-replace": "^5.0.2",
-				"@rollup/pluginutils": "^5.0.2",
-				"chalk": "^5.2.0",
-				"consola": "^2.15.3",
+				"@rollup/pluginutils": "^5.0.3",
+				"chalk": "^5.3.0",
+				"citty": "^0.1.2",
+				"consola": "^3.2.3",
 				"defu": "^6.1.2",
-				"esbuild": "^0.17.8",
-				"globby": "^13.1.3",
-				"hookable": "^5.4.2",
-				"jiti": "^1.17.1",
-				"magic-string": "^0.29.0",
-				"mkdist": "^1.1.1",
-				"mlly": "^1.1.1",
-				"mri": "^1.2.0",
-				"pathe": "^1.1.0",
-				"pkg-types": "^1.0.2",
-				"pretty-bytes": "^6.1.0",
-				"rollup": "^3.15.0",
-				"rollup-plugin-dts": "^5.2.0",
+				"esbuild": "^0.19.2",
+				"globby": "^13.2.2",
+				"hookable": "^5.5.3",
+				"jiti": "^1.19.3",
+				"magic-string": "^0.30.3",
+				"mkdist": "^1.3.0",
+				"mlly": "^1.4.0",
+				"pathe": "^1.1.1",
+				"pkg-types": "^1.0.3",
+				"pretty-bytes": "^6.1.1",
+				"rollup": "^3.28.1",
+				"rollup-plugin-dts": "^6.0.0",
 				"scule": "^1.0.0",
-				"typescript": "^4.9.5",
-				"untyped": "^1.2.2"
+				"untyped": "^1.4.0"
 			},
 			"bin": {
 				"unbuild": "dist/cli.mjs"
+			},
+			"peerDependencies": {
+				"typescript": "^5.1.6"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/universalify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/untyped": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/untyped/-/untyped-1.2.2.tgz",
-			"integrity": "sha512-EANYd5L6AdpgfldlgMcmvOOnj092nWhy0ybhc7uhEH12ipytDYz89EOegBQKj8qWL3u1wgYnmFjADhsuCJs5Aw==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/untyped/-/untyped-1.4.2.tgz",
+			"integrity": "sha512-nC5q0DnPEPVURPhfPQLahhSTnemVtPzdx7ofiRxXpOB2SYnb3MfdU3DVGyJdS8Lx+tBWeAePO8BfU/3EgksM7Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/core": "^7.20.12",
-				"@babel/standalone": "^7.20.12",
-				"@babel/types": "^7.20.7",
-				"scule": "^1.0.0"
+				"@babel/core": "^7.23.7",
+				"@babel/standalone": "^7.23.8",
+				"@babel/types": "^7.23.6",
+				"defu": "^6.1.4",
+				"jiti": "^1.21.0",
+				"mri": "^1.2.0",
+				"scule": "^1.2.0"
+			},
+			"bin": {
+				"untyped": "dist/cli.mjs"
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-			"integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+			"integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1678,6 +2983,10 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
@@ -1685,11 +2994,17 @@
 				"picocolors": "^1.0.0"
 			},
 			"bin": {
-				"browserslist-lint": "cli.js"
+				"update-browserslist-db": "cli.js"
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",

--- a/src/js-cli-and-library/package.json
+++ b/src/js-cli-and-library/package.json
@@ -20,10 +20,11 @@
 	},
 	"scripts": {
 		"clean": "rmdir dist && rmdir build",
-		"build": "npm run bind && npm run build-js",
-		"build-release": "npm run bind-release && npm run build-js",
-		"bind": "wasm-pack build --dev --out-dir src/js-cli-and-library/build --target web --no-pack",
-		"bind-release": "wasm-pack build --release --out-dir src/js-cli-and-library/build --target web --no-pack",
+		"build": "wasm-pack build --dev --out-dir src/js-cli-and-library/build --target web --no-pack && npm run build-js",
+		"build-release": "wasm-pack build --release --out-dir src/js-cli-and-library/build --target web --no-pack && npm run build-js",
+		"--": "'debug' can be replaced with 'release' for those builds",
+		"build-manual-bind": "cargo build --lib --target wasm32-unknown-unknown --profile debug && wasm-bindgen --out-dir build --target web ../../target/wasm32-unknown-unknown/debug/ezno_lib.wasm && npm run build-js",
+		"--": "Manually assembles the output",
 		"build-js": "unbuild && cp ./build/ezno_lib_bg.wasm dist/shared && cp src/cli_node.cjs dist/cli.cjs",
 		"test": "npm run build && npm run run-tests",
 		"run-tests": "node test.mjs && deno run -A test.mjs"

--- a/src/js-cli-and-library/package.json
+++ b/src/js-cli-and-library/package.json
@@ -65,6 +65,7 @@
 				"input": "./src/cli"
 			}
 		],
+		"declaration": true,
 		"rollup": {
 			"commonjs": true,
 			"esbuild": {
@@ -73,6 +74,6 @@
 		}
 	},
 	"devDependencies": {
-		"unbuild": "^1.1.2"
+		"unbuild": "^2.0.0"
 	}
 }

--- a/src/js-cli-and-library/package.json
+++ b/src/js-cli-and-library/package.json
@@ -20,7 +20,7 @@
 	},
 	"scripts": {
 		"clean": "rmdir dist && rmdir build",
-		"build": "cargo build --lib --target wasm32-unknown-unknown && npm run bind && npm run build-js",
+		"build": "npm run bind && npm run build-js",
 		"build-release": "npm run bind-release && npm run build-js",
 		"bind": "wasm-pack build --dev --out-dir src/js-cli-and-library/build --target web --no-pack",
 		"bind-release": "wasm-pack build --release --out-dir src/js-cli-and-library/build --target web --no-pack",

--- a/src/js-cli-and-library/package.json
+++ b/src/js-cli-and-library/package.json
@@ -21,9 +21,9 @@
 	"scripts": {
 		"clean": "rmdir dist && rmdir build",
 		"build": "cargo build --lib --target wasm32-unknown-unknown && npm run bind && npm run build-js",
-		"build-release": "cargo build --lib --release --target wasm32-unknown-unknown && npm run bind-release && npm run build-js",
-		"bind": "wasm-bindgen --out-dir build --target web ../../target/wasm32-unknown-unknown/debug/ezno_lib.wasm",
-		"bind-release": "wasm-bindgen --out-dir build --target web ../../target/wasm32-unknown-unknown/release/ezno_lib.wasm",
+		"build-release": "npm run bind-release && npm run build-js",
+		"bind": "wasm-pack build --dev --out-dir build --target web --no-pack",
+		"bind-release": "wasm-pack build --release --out-dir build --target web --no-pack",
 		"build-js": "unbuild && cp ./build/ezno_lib_bg.wasm dist/shared && cp src/cli_node.cjs dist/cli.cjs",
 		"test": "npm run build && npm run run-tests",
 		"run-tests": "node test.mjs && deno run -A test.mjs"

--- a/src/wasm_bindings.rs
+++ b/src/wasm_bindings.rs
@@ -13,7 +13,13 @@ pub struct CheckOptions {
 	pub lsp_mode: bool,
 }
 
-#[wasm_bindgen(js_name = experimental_build)]
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES_EXPERIMENTAL_BUILD: &str = r###"
+export function experimental_build(
+	entry_path: string, fs_resolve_js: (path: string) => string | undefined, minify: boolean
+): {Ok: BuildOutput} | {Err: FailedBuildOutput}
+"###;
+#[wasm_bindgen(js_name = experimental_build, skip_typescript)]
 pub fn experimental_build_wasm(
 	entry_path: String,
 	fs_resolver_js: &js_sys::Function,
@@ -39,15 +45,11 @@ pub fn experimental_build_wasm(
 }
 
 #[wasm_bindgen(typescript_custom_section)]
-const TYPES: &str = r###"
+const TYPES_WASM_CHECK_OUTPUT: &str = r###"
 interface WASMCheckOutput {
 	readonly diagnostics: DiagnosticsContainer
 }
-
-export function parse_expression(input: string): {Ok: Expression} | {Err: [string, Span]}
-export function parse_module(input: string): {Ok: Module} | {Err: [string, Span]}
 "###;
-
 #[wasm_bindgen]
 pub struct WASMCheckOutput(checker::CheckOutput<checker::synthesis::EznoParser>);
 
@@ -64,7 +66,11 @@ impl WASMCheckOutput {
 	}
 }
 
-#[wasm_bindgen(js_name = check)]
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES_CHECK: &str = r#"
+export function check(entry_path: string, fs_resolver_js: (path: string) => string | undefined): WASMCheckOutput
+"#;
+#[wasm_bindgen(js_name = check, skip_typescript)]
 pub fn check_wasm(entry_path: String, fs_resolver_js: &js_sys::Function) -> WASMCheckOutput {
 	std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
@@ -77,7 +83,11 @@ pub fn check_wasm(entry_path: String, fs_resolver_js: &js_sys::Function) -> WASM
 	WASMCheckOutput(crate::check::check(vec![entry_path.into()], &fs_resolver, None, None))
 }
 
-#[wasm_bindgen(js_name = check_with_options)]
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES_CHECK_WITH_OPTIONS: &str = r#"
+export function check_with_options(entry_path: string, fs_resolver_js: (path: string) => string | undefined, options: TypeCheckOptions): WASMCheckOutput
+"#;
+#[wasm_bindgen(js_name = check_with_options, skip_typescript)]
 pub fn check_wasm_with_options(
 	entry_path: String,
 	fs_resolver_js: &js_sys::Function,
@@ -95,8 +105,16 @@ pub fn check_wasm_with_options(
 	};
 	WASMCheckOutput(crate::check::check(vec![entry_path.into()], &fs_resolver, None, Some(options)))
 }
-
-#[wasm_bindgen(js_name = run_cli)]
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES_RUN_CLI: &str = r#"
+export function run_cli(
+	cli_arguments: string[],
+	read_from_file: (path: string) => string | undefined,
+	write_to_file: (path: string, content: string) => void,
+	cli_input_resolver: (prompt: string) => string | undefined
+): void
+"#;
+#[wasm_bindgen(js_name = run_cli, skip_typescript)]
 pub fn run_cli_wasm(
 	cli_arguments: Box<[JsValue]>,
 	read_from_file: &js_sys::Function,
@@ -135,6 +153,10 @@ pub fn run_cli_wasm(
 	crate::run_cli(&arguments, &read_from_file, write_to_file, cli_input_resolver);
 }
 
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES_PARSE_EXPRESSION: &str = r#"
+export function parse_expression(input: string): {Ok: Expression} | {Err: [string, Span]}
+"#;
 #[wasm_bindgen(js_name = parse_expression, skip_typescript)]
 pub fn parse_expression_to_json(input: String) -> JsValue {
 	use parser::{ASTNode, Expression};
@@ -149,6 +171,10 @@ pub fn parse_expression_to_json(input: String) -> JsValue {
 	}
 }
 
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES_PARSE_MODULE: &str = r#"
+export function parse_module(input: string): {Ok: Module} | {Err: [string, Span]}
+"#;
 #[wasm_bindgen(js_name = parse_module, skip_typescript)]
 pub fn parse_module_to_json(input: String) -> JsValue {
 	use parser::{ASTNode, Module};
@@ -162,8 +188,15 @@ pub fn parse_module_to_json(input: String) -> JsValue {
 		}
 	}
 }
-
-#[wasm_bindgen(js_name = parse_module_and_into_string)]
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES_PARSE_MODULE_AND_INTO_STRING: &str = r#"
+export function parse_module_and_into_string(
+	input: string,
+	parse_options: ParseOptions,
+	to_string_options: ToStringOptions
+): {Ok: string} | {Err: [string, Span]}
+"#;
+#[wasm_bindgen(js_name = parse_module_and_into_string, skip_typescript)]
 pub fn parse_module_and_into_string(
 	input: String,
 	parse_options: JsValue,
@@ -186,8 +219,11 @@ pub fn parse_module_and_into_string(
 		}
 	}
 }
-
-#[wasm_bindgen]
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES_JUST_IMPORTS: &str = r#"
+export function just_imports(input: string): {Ok: string} | {Err: [string, Span]}
+"#;
+#[wasm_bindgen(skip_typescript)]
 pub fn just_imports(input: String) -> JsValue {
 	use parser::{ASTNode, Module};
 

--- a/src/wasm_bindings.rs
+++ b/src/wasm_bindings.rs
@@ -155,7 +155,7 @@ pub fn run_cli_wasm(
 
 #[wasm_bindgen(typescript_custom_section)]
 const TYPES_PARSE_EXPRESSION: &str = r#"
-export function parse_expression(input: string): {Ok: Expression} | {Err: [string, Span]}
+export function parse_expression(input: string): Expression | [string, Span]
 "#;
 #[wasm_bindgen(js_name = parse_expression, skip_typescript)]
 pub fn parse_expression_to_json(input: String) -> JsValue {
@@ -173,7 +173,7 @@ pub fn parse_expression_to_json(input: String) -> JsValue {
 
 #[wasm_bindgen(typescript_custom_section)]
 const TYPES_PARSE_MODULE: &str = r#"
-export function parse_module(input: string): {Ok: Module} | {Err: [string, Span]}
+export function parse_module(input: string): Module | [string, Span]
 "#;
 #[wasm_bindgen(js_name = parse_module, skip_typescript)]
 pub fn parse_module_to_json(input: String) -> JsValue {
@@ -194,7 +194,7 @@ export function parse_module_and_into_string(
 	input: string,
 	parse_options: ParseOptions,
 	to_string_options: ToStringOptions
-): {Ok: string} | {Err: [string, Span]}
+): string | [string, Span]
 "#;
 #[wasm_bindgen(js_name = parse_module_and_into_string, skip_typescript)]
 pub fn parse_module_and_into_string(
@@ -221,7 +221,7 @@ pub fn parse_module_and_into_string(
 }
 #[wasm_bindgen(typescript_custom_section)]
 const TYPES_JUST_IMPORTS: &str = r#"
-export function just_imports(input: string): {Ok: string} | {Err: [string, Span]}
+export function just_imports(input: string): string | [string, Span]
 "#;
 #[wasm_bindgen(skip_typescript)]
 pub fn just_imports(input: String) -> JsValue {

--- a/src/wasm_bindings.rs
+++ b/src/wasm_bindings.rs
@@ -38,12 +38,22 @@ pub fn experimental_build_wasm(
 	serde_wasm_bindgen::to_value(&result).unwrap()
 }
 
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES: &str = r###"
+interface WASMCheckOutput {
+	readonly diagnostics: DiagnosticsContainer
+}
+
+export function parse_expression(input: string): {Ok: Expression} | {Err: [string, Span]}
+export function parse_module(input: string): {Ok: Module} | {Err: [string, Span]}
+"###;
+
 #[wasm_bindgen]
 pub struct WASMCheckOutput(checker::CheckOutput<checker::synthesis::EznoParser>);
 
 #[wasm_bindgen]
 impl WASMCheckOutput {
-	#[wasm_bindgen(js_name = diagnostics, getter)]
+	#[wasm_bindgen(js_name = diagnostics, getter, skip_typescript)]
 	pub fn get_diagnostics(&self) -> JsValue {
 		serde_wasm_bindgen::to_value(&self.0.diagnostics).unwrap()
 	}
@@ -125,7 +135,7 @@ pub fn run_cli_wasm(
 	crate::run_cli(&arguments, &read_from_file, write_to_file, cli_input_resolver);
 }
 
-#[wasm_bindgen(js_name = parse_expression)]
+#[wasm_bindgen(js_name = parse_expression, skip_typescript)]
 pub fn parse_expression_to_json(input: String) -> JsValue {
 	use parser::{ASTNode, Expression};
 
@@ -139,7 +149,7 @@ pub fn parse_expression_to_json(input: String) -> JsValue {
 	}
 }
 
-#[wasm_bindgen(js_name = parse_module)]
+#[wasm_bindgen(js_name = parse_module, skip_typescript)]
 pub fn parse_module_to_json(input: String) -> JsValue {
 	use parser::{ASTNode, Module};
 


### PR DESCRIPTION
NB: macro-free for the moment (self-rust-tokenize was _not_ happy).

Problematic types so far:

- [x]  WithComment. Presumably because of the manual serde derives, tsify isn't picking up on it.
- [x]  PropertyKey - uses associated types, will need overriding, or an Omit typedef.
- [x]  ArrayDestructuringField - associated types, fortunately just the one variant.
- [x]  ObjectDestructuringField - associated types, ditto.
- [x]  Marker - custom typescript section not taking effect
- [x] ClassDeclaration - custom typescript section not taking effect.
- [x] PublicOrPrivate
- [x] Private
- [x] AlwaysPublic

In general, everything that uses an associated type needs a bit of adjustment.