### PR TITLE
implement setters support as described in #39

### DIFF
--- a/checker/specification/specification.md
+++ b/checker/specification/specification.md
@@ -2894,3 +2894,37 @@ register(document.title)
 ```
 
 - Argument of type string is not assignable to parameter of type Literal\<string\>
+
+### Setters
+
+#### Setters invocation invalid assignment
+
+```ts
+let a = 2;
+const obj = {
+   set value(v) {
+       a = v;
+   }
+}
+
+let b: 80 = (obj.value = "some value");
+let c: 80 = a;
+```
+
+- Type "some value" is not assignable to type 80
+- Type "some value" is not assignable to type 80
+
+#### Setters
+
+```ts
+let a = 2;
+const obj = {
+   set value(v) {
+       a = v;
+   }
+}
+
+let b: 80 = (obj.value = 80);
+let c: 80 = a;
+```
+

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -863,7 +863,9 @@ impl<'a> Environment<'a> {
 			Ok(match kind {
 				PropertyKind::Getter => Instance::GValue(result),
 				// TODO instance.property...?
-				PropertyKind::Generic | PropertyKind::Direct => Instance::RValue(result),
+				PropertyKind::Generic | PropertyKind::Direct | PropertyKind::Setter => {
+					Instance::RValue(result)
+				}
 			})
 		} else {
 			checking_data.diagnostics_container.add_error(TypeCheckError::PropertyDoesNotExist {


### PR DESCRIPTION
This PR implements setters support as described in #39. 

Note: In `run_setter_on_object`, we do an expect on the optional `setter_position` field, as the FunctionType.call method requires a SpanWithSource. I looked into refactoring to change the `setter_position` from an Option but it looked like it'd have wide consequences. @kaleidawave - would love your thoughts on this one.