### PR TITLE
add `bacon.toml` for easier new dev experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,37 @@ cargo run -p ezno-parser --example parse path/to/file.ts
 cargo run -p ezno-parser --example lex path/to/file.ts
 ```
 
+### Bacon (script runner)
+
+The [Bacon script runner](https://dystroy.org/bacon/) is configured for this repo. This can watch your files and re-run things like checks or tests on file change.
+The configuration is managed in the [`bacon.toml`](./bacon.toml) file. The configuration has dedicated jobs for the checker specification tests mentioned above. 
+
+#### Installing Bacon
+
+To install bacon, simply run `cargo install --locked bacon`, and you're ready to go.
+
+#### Using Bacon
+
+To use bacon, you can start it by running `bacon check`. This will spin up a job that listens to the source and runs checks on file changes!
+There are also hotkeys you can use to switch jobs, or manually trigger a re-run of a job (for jobs where watch functionality is disabled).
+We have some custom jobs defined as well:
+
+| Job Name      | Description      | Hotkey    |
+| ------------- | ------------- | ------------- |
+| test-spec-no-watch | this job runs `cargo test -p ezno-checker-specification` and does *not* watch for file changes | 1 |
+| test-staging-no-watch | this job runs `cargo test -p ezno-checker-specification -F staging` and does *not* watch for file changes | 2 |
+| test-all-no-watch | this job runs `cargo test -p ezno-checker-specification -F all` and does *not* watch for file changes | 3 |
+| test-spec | this job runs `cargo test -p ezno-checker-specification` and watches for file changes | 4 |
+| test-staging | this job runs `cargo test -p ezno-checker-specification -F staging` and watches for file changes | 5 |
+| test-all | this job runs `cargo test -p ezno-checker-specification -F all` and watches for file changes | 6 |
+
+At any point, you can press `?` to see a list of all available hotkeys.
+
+#### Adding new jobs to our Bacon config
+
+New jobs can easily be added to our `bacon.toml` config if we find there are repetitive actions we're doing frequently. 
+[The Bacon documentation](https://dystroy.org/bacon/config/#jobs) does a good job of explaining how to do so.
+
 ### Useful commands
 
 - Check source is valid with `cargo check --workspace`

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,118 @@
+# This is a configuration file for the bacon tool
+#
+# Bacon repository: https://github.com/Canop/bacon
+# Complete help on configuration: https://dystroy.org/bacon/config/
+# You can also check bacon's own bacon.toml file
+#  as an example: https://github.com/Canop/bacon/blob/main/bacon.toml
+
+default_job = "check"
+
+[jobs.check]
+command = ["cargo", "check", "--color", "always"]
+need_stdout = false
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets", "--color", "always"]
+need_stdout = false
+
+# Run clippy on the default target
+[jobs.clippy]
+command = ["cargo", "clippy", "--color", "always"]
+need_stdout = false
+
+# Run clippy on all targets
+# To disable some lints, you may change the job this way:
+#    [jobs.clippy-all]
+#    command = [
+#        "cargo", "clippy",
+#        "--all-targets",
+#        "--color", "always",
+#    	 "--",
+#    	 "-A", "clippy::bool_to_int_with_if",
+#    	 "-A", "clippy::collapsible_if",
+#    	 "-A", "clippy::derive_partial_eq_without_eq",
+#    ]
+# need_stdout = false
+[jobs.clippy-all]
+command = ["cargo", "clippy", "--all-targets", "--color", "always"]
+need_stdout = false
+
+# You can run your application and have the result displayed in bacon,
+# *if* it makes sense for this crate.
+# Don't forget the `--color always` part or the errors won't be
+# properly parsed.
+# If your program never stops (eg a server), you may set `background`
+# to false to have the cargo run output immediately displayed instead
+# of waiting for program's end.
+[jobs.run]
+command = [
+    "cargo",
+    "run",
+    "--color",
+    "always",
+    # put launch parameters for your program behind a `--` separator
+]
+need_stdout = true
+allow_warnings = true
+background = true
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal global prefs.toml file instead.
+[keybindings]
+# alt-m = "job:my-job"
+c = "job:clippy-all"   # comment this to have 'c' run clippy on only the default target
+1 = "job:test-spec"
+2 = "job:test-staging"
+3 = "job:test-all"
+
+
+[jobs.test-spec]
+command = [
+    "cargo",
+    "test",
+    "-p",
+    "ezno-checker-specification",
+    "--color",
+    "always",
+    "--",
+    "--color",
+    "always",
+]
+need_stdout = true
+watch = ["checker", "parser"]
+
+[jobs.test-staging]
+command = [
+    "cargo",
+    "test",
+    "-p",
+    "ezno-checker-specification",
+    "-F",
+    "staging",
+    "--color",
+    "always",
+    "--",
+    "--color",
+    "always",
+]
+need_stdout = true
+watch = ["checker", "parser"]
+
+[jobs.test-all]
+command = [
+    "cargo",
+    "test",
+    "-p",
+    "ezno-checker-specification",
+    "-F",
+    "all",
+    "--color",
+    "always",
+    "--",
+    "--color",
+    "always",
+]
+need_stdout = true
+watch = ["checker", "parser"]

--- a/bacon.toml
+++ b/bacon.toml
@@ -62,11 +62,13 @@ background = true
 # should go in your personal global prefs.toml file instead.
 [keybindings]
 # alt-m = "job:my-job"
-c = "job:clippy-all"   # comment this to have 'c' run clippy on only the default target
-1 = "job:test-spec"
-2 = "job:test-staging"
-3 = "job:test-all"
-
+c = "job:clippy-all"            # comment this to have 'c' run clippy on only the default target
+1 = "job:test-spec-no-watch"
+2 = "job:test-staging-no-watch"
+3 = "job:test-all-no-watch"
+4 = "job:test-spec"
+5 = "job:test-staging"
+6 = "job:test-all"
 
 [jobs.test-spec]
 command = [
@@ -116,3 +118,52 @@ command = [
 ]
 need_stdout = true
 watch = ["checker", "parser"]
+
+[jobs.test-spec-no-watch]
+command = [
+    "cargo",
+    "test",
+    "-p",
+    "ezno-checker-specification",
+    "--color",
+    "always",
+    "--",
+    "--color",
+    "always",
+]
+need_stdout = true
+default_watch = false
+
+[jobs.test-staging-no-watch]
+command = [
+    "cargo",
+    "test",
+    "-p",
+    "ezno-checker-specification",
+    "-F",
+    "staging",
+    "--color",
+    "always",
+    "--",
+    "--color",
+    "always",
+]
+need_stdout = true
+default_watch = false
+
+[jobs.test-all-no-watch]
+command = [
+    "cargo",
+    "test",
+    "-p",
+    "ezno-checker-specification",
+    "-F",
+    "all",
+    "--color",
+    "always",
+    "--",
+    "--color",
+    "always",
+]
+need_stdout = true
+default_watch = false


### PR DESCRIPTION
Proposal to use [Bacon](https://github.com/Canop/bacon) to make the standard operations of running the specification tests a little simpler during development.

How to use:

1. install `bacon` with `cargo install --locked bacon`
2. press `1` to run only the `specification.md` tests once.
3. press `2` to run only the `staging.md` tests once.
4. press `3` to run all tests once.
5. press `4` to run only the `specification.md` tests and watch for changes.
6. press `5` to run only the `staging.md` tests and watch for changes.
7. press `6` to run all tests and watch for changes.

Bacon will watch for changes in the source sets and re-run the tests on change. This can help optimize the feedback cycle and accelerate development.