### PR TITLE
List possible variables, types, properties and imports when cannot find reference

### DIFF
--- a/checker/specification/specification.md
+++ b/checker/specification/specification.md
@@ -49,7 +49,7 @@ a satisfies number
 const a = c
 ```
 
-- Could not find variable 'c' in scope
+- Could not find variable 'c' in scope. Did you mean a?
 
 #### Assigning before declaration
 
@@ -117,7 +117,7 @@ const a = my_obj.a
 const b = my_obj.b
 ```
 
-- No property 'b' on { a: 3 }
+- No property 'b' on { a: 3 }. Did you mean a?
 
 #### Reading property (via accessor)
 
@@ -273,7 +273,7 @@ delete x.b;
 const b = x.b;
 ```
 
-- No property 'b' on { a: 2 }
+- No property 'b' on { a: 2 }. Did you mean a?
 
 #### `Object.keys`, `Object.values`, `Object.entries`
 
@@ -611,7 +611,7 @@ function createObject2<T, U>(a: T, b: U): { a: U, b: U } {
 const x: (a: string) => number = a => a.to;
 ```
 
-- No property 'to' on string
+- No property 'to' on string. 
 
 #### Expected argument from parameter declaration
 
@@ -623,7 +623,7 @@ function map(a: (a: number) => number) {}
 map(a => a.t)
 ```
 
-- No property 't' on number
+- No property 't' on number. 
 
 #### Assignment to parameter
 
@@ -1856,7 +1856,7 @@ y.not_a_key
 ```
 
 - Expected 3, found 7
-- No property 'not_a_key' on { ezno: 7 }
+- No property 'not_a_key' on { ezno: 7 }. 
 
 #### Shorthand object literal
 
@@ -2300,7 +2300,7 @@ type X = number;
 const a: Y = 2;
 ```
 
-- Cannot find type Y
+- Cannot find type Y. Did you mean T, U or X?
 
 #### Type shadowing
 
@@ -2531,7 +2531,7 @@ function get(obj: {a: 2} | { b: 3 }) {
 
 > `Cannot read property "a" from { b: 3 }`
 
-- No property 'a' on { a: 2 } | { b: 3 }
+- No property 'a' on { a: 2 } | { b: 3 }. 
 
 #### Optional interface member
 
@@ -2811,7 +2811,7 @@ myRecord.hello;
 ```
 
 - Expected string, found number
-- No property 'hello' on { [\"hi\"]: number }
+- No property 'hello' on { [\"hi\"]: number }. 
 
 #### Assignment
 
@@ -2840,8 +2840,8 @@ obj2.fine satisfies boolean;
 obj2[2];
 ```
 
-- No property 'bye' on { ["hi" | "hello"]: boolean }
-- No property '2' on { [string]: boolean }
+- No property 'bye' on { ["hi" | "hello"]: boolean }. 
+- No property '2' on { [string]: boolean }. 
 
 ### Forward inference
 
@@ -3119,7 +3119,7 @@ console.log(a.prop);
 export const a = 2;
 ```
 
-- Cannot find file
+- Cannot find ./two. 
 
 #### Import where export does not exist
 
@@ -3190,7 +3190,7 @@ export const x = 2;
 const y = "122LH"
 ```
 
-- Could not find variable 'y' in scope
+- Could not find variable 'y' in scope. Did you mean x?
 
 #### Import side effect
 
@@ -3260,7 +3260,7 @@ const z: number = getString(2);
 
 - Cannot return number because the function is expected to return string
 - Type 5 is not assignable to type string
-- Could not find variable 'h' in scope
+- Could not find variable 'h' in scope. Did you mean x, y or z?
 - Type (error) string is not assignable to type number
 
 #### Unconditional throw
@@ -3353,5 +3353,5 @@ function x() {
 x().nothing
 ```
 
-- Could not find variable 'y' in scope
-- No property 'a' on { prop: 2 }
+- Could not find variable 'y' in scope. Did you mean x?
+- No property 'a' on { prop: 2 }. 

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -536,7 +536,7 @@ impl<'a> Environment<'a> {
 									false,
 								),
 							    site: position,
-							    possibles: get_property_key_names_on_a_single_type(rhs, &mut checking_data.types, self).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
+							    possibles: get_property_key_names_on_a_single_type(rhs, &mut checking_data.types, self).iter().map(AsRef::as_ref).collect::<Vec<&str>>()
 							},
 						);
 
@@ -884,7 +884,7 @@ impl<'a> Environment<'a> {
 					false,
 				),
 			    site,
-			    possibles: get_property_key_names_on_a_single_type(on, &mut checking_data.types, self).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
+			    possibles: get_property_key_names_on_a_single_type(on, &mut checking_data.types, self).iter().map(AsRef::as_ref).collect::<Vec<&str>>()
 			});
 			Err(())
 		}

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -24,7 +24,10 @@ use crate::{
 	subtyping::{type_is_subtype, type_is_subtype_object, State, SubTypeResult, SubTypingOptions},
 	types::{
 		printing,
-		properties::{PropertyKey, PropertyKind, PropertyValue, Publicity, get_property_key_names_on_a_single_type},
+		properties::{
+			get_property_key_names_on_a_single_type, PropertyKey, PropertyKind, PropertyValue,
+			Publicity,
+		},
 		PolyNature, Type, TypeStore,
 	},
 	CheckingData, Instance, RootContext, TypeCheckOptions, TypeId,
@@ -535,8 +538,15 @@ impl<'a> Environment<'a> {
 									&checking_data.types,
 									false,
 								),
-							    site: position,
-							    possibles: get_property_key_names_on_a_single_type(rhs, &mut checking_data.types, self).iter().map(AsRef::as_ref).collect::<Vec<&str>>()
+								site: position,
+								possibles: get_property_key_names_on_a_single_type(
+									rhs,
+									&mut checking_data.types,
+									self,
+								)
+								.iter()
+								.map(AsRef::as_ref)
+								.collect::<Vec<&str>>(),
 							},
 						);
 
@@ -883,8 +893,15 @@ impl<'a> Environment<'a> {
 					&checking_data.types,
 					false,
 				),
-			    site,
-			    possibles: get_property_key_names_on_a_single_type(on, &mut checking_data.types, self).iter().map(AsRef::as_ref).collect::<Vec<&str>>()
+				site,
+				possibles: get_property_key_names_on_a_single_type(
+					on,
+					&mut checking_data.types,
+					self,
+				)
+				.iter()
+				.map(AsRef::as_ref)
+				.collect::<Vec<&str>>(),
 			});
 			Err(())
 		}

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -24,7 +24,7 @@ use crate::{
 	subtyping::{type_is_subtype, type_is_subtype_object, State, SubTypeResult, SubTypingOptions},
 	types::{
 		printing,
-		properties::{PropertyKey, PropertyKind, PropertyValue, Publicity},
+		properties::{PropertyKey, PropertyKind, PropertyValue, Publicity, get_property_key_names_on_a_single_type},
 		PolyNature, Type, TypeStore,
 	},
 	CheckingData, Instance, RootContext, TypeCheckOptions, TypeId,
@@ -535,7 +535,8 @@ impl<'a> Environment<'a> {
 									&checking_data.types,
 									false,
 								),
-								site: position,
+							    site: position,
+							    possibles: get_property_key_names_on_a_single_type(rhs, &mut checking_data.types, self).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
 							},
 						);
 
@@ -882,7 +883,8 @@ impl<'a> Environment<'a> {
 					&checking_data.types,
 					false,
 				),
-				site,
+			    site,
+			    possibles: get_property_key_names_on_a_single_type(on, &mut checking_data.types, self).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
 			});
 			Err(())
 		}

--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -903,8 +903,7 @@ impl<'a> Environment<'a> {
 				checking_data.diagnostics_container.add_error(
 					TypeCheckError::CouldNotFindVariable {
 						variable: name,
-						// TODO
-						possibles: Default::default(),
+						possibles: self.get_all_variable_names(),
 						position,
 					},
 				);

--- a/checker/src/context/mod.rs
+++ b/checker/src/context/mod.rs
@@ -460,7 +460,7 @@ impl<T: ContextType> Context<T> {
 		self.parents_iter().find_map(|env| get_on_ctx!(env.named_types.get(name))).copied()
 	}
 
-        pub fn get_all_variable_names(&self) -> Vec<&str> {
+    pub fn get_all_variable_names(&self) -> Vec<&str> {
 	    self.parents_iter()
 		.map(|env| get_on_ctx!(env.variables.keys()).collect::<Vec<&String>>())
 		.flatten()
@@ -468,7 +468,7 @@ impl<T: ContextType> Context<T> {
 		.collect::<Vec<&str>>()
 	}
 
-        pub fn get_all_named_types(&self) -> Vec<&str> {
+    pub fn get_all_named_types(&self) -> Vec<&str> {
 	    self.parents_iter()
 		.map(|env| get_on_ctx!(env.named_types.keys()).collect::<Vec<&String>>())
 		.flatten()
@@ -745,7 +745,7 @@ impl<T: ContextType> Context<T> {
 
 	pub fn get_type_by_name_handle_errors<U, A: crate::ASTImplementation>(
 		&self,
-		name: &str,
+	    name: &str,
 		pos: SpanWithSource,
 		checking_data: &mut CheckingData<U, A>,
 	) -> TypeId {
@@ -754,7 +754,8 @@ impl<T: ContextType> Context<T> {
 		} else {
 			checking_data
 				.diagnostics_container
-				.add_error(TypeCheckError::CouldNotFindType(name, pos));
+			.add_error(TypeCheckError::CouldNotFindType(name,
+								    self.get_all_named_types(), pos));
 
 			TypeId::ERROR_TYPE
 		}

--- a/checker/src/context/mod.rs
+++ b/checker/src/context/mod.rs
@@ -474,17 +474,7 @@ impl<T: ContextType> Context<T> {
 		.flatten()
 		.map(|x| x.as_str())
 		.collect::<Vec<&str>>()
-    }
-
-    pub fn get_all_imports(&self) -> Vec<&str> {
-	    self.parents_iter()
-	    .map(|env| get_on_ctx!(env.variables.iter()))
-	    .flatten()
-	    .filter(|(_,variable)| matches!(variable, VariableOrImport::ConstantImport{..} | VariableOrImport::MutableImport{..}))
-	    .map(|(name, _)| name.as_str())
-	    .collect::<Vec<&str>>()
-    }
-
+	}
 
 	pub(crate) fn get_variable_name(&self, id: VariableId) -> &str {
 		match self.parents_iter().find_map(|env| get_on_ctx!(env.variable_names.get(&id))) {

--- a/checker/src/context/mod.rs
+++ b/checker/src/context/mod.rs
@@ -460,6 +460,22 @@ impl<T: ContextType> Context<T> {
 		self.parents_iter().find_map(|env| get_on_ctx!(env.named_types.get(name))).copied()
 	}
 
+        pub fn get_all_variable_names(&self) -> Vec<&str> {
+	    self.parents_iter()
+		.map(|env| get_on_ctx!(env.variables.keys()).collect::<Vec<&String>>())
+		.flatten()
+		.map(|x| x.as_str())
+		.collect::<Vec<&str>>()
+	}
+
+        pub fn get_all_named_types(&self) -> Vec<&str> {
+	    self.parents_iter()
+		.map(|env| get_on_ctx!(env.named_types.keys()).collect::<Vec<&String>>())
+		.flatten()
+		.map(|x| x.as_str())
+		.collect::<Vec<&str>>()
+	}
+
 	pub(crate) fn get_variable_name(&self, id: VariableId) -> &str {
 		match self.parents_iter().find_map(|env| get_on_ctx!(env.variable_names.get(&id))) {
 			Some(s) => s.as_str(),
@@ -698,6 +714,7 @@ impl<T: ContextType> Context<T> {
 			}
 		})
 	}
+        
 
 	pub fn new_explicit_type_parameter(
 		&mut self,

--- a/checker/src/context/mod.rs
+++ b/checker/src/context/mod.rs
@@ -460,22 +460,22 @@ impl<T: ContextType> Context<T> {
 		self.parents_iter().find_map(|env| get_on_ctx!(env.named_types.get(name))).copied()
 	}
 
-    #[allow(clippy::map_flatten)]
-    pub fn get_all_variable_names(&self) -> Vec<&str> {
-	    self.parents_iter()
-		.map(|env| get_on_ctx!(env.variables.keys()).collect::<Vec<&String>>())
-		.flatten()
-		.map(AsRef::as_ref)
-		.collect::<Vec<&str>>()
-    }
+	#[allow(clippy::map_flatten)]
+	pub fn get_all_variable_names(&self) -> Vec<&str> {
+		self.parents_iter()
+			.map(|env| get_on_ctx!(env.variables.keys()).collect::<Vec<&String>>())
+			.flatten()
+			.map(AsRef::as_ref)
+			.collect::<Vec<&str>>()
+	}
 
-    #[allow(clippy::map_flatten)]
-    pub fn get_all_named_types(&self) -> Vec<&str> {
-	    self.parents_iter()
-		.map(|env| get_on_ctx!(env.named_types.keys()).collect::<Vec<&String>>())
-		.flatten()
-		.map(AsRef::as_ref)
-		.collect::<Vec<&str>>()
+	#[allow(clippy::map_flatten)]
+	pub fn get_all_named_types(&self) -> Vec<&str> {
+		self.parents_iter()
+			.map(|env| get_on_ctx!(env.named_types.keys()).collect::<Vec<&String>>())
+			.flatten()
+			.map(AsRef::as_ref)
+			.collect::<Vec<&str>>()
 	}
 
 	pub(crate) fn get_variable_name(&self, id: VariableId) -> &str {
@@ -716,7 +716,6 @@ impl<T: ContextType> Context<T> {
 			}
 		})
 	}
-        
 
 	pub fn new_explicit_type_parameter(
 		&mut self,
@@ -747,17 +746,18 @@ impl<T: ContextType> Context<T> {
 
 	pub fn get_type_by_name_handle_errors<U, A: crate::ASTImplementation>(
 		&self,
-	    name: &str,
+		name: &str,
 		pos: SpanWithSource,
 		checking_data: &mut CheckingData<U, A>,
 	) -> TypeId {
 		if let Some(val) = self.get_type_from_name(name) {
 			val
 		} else {
-			checking_data
-				.diagnostics_container
-			.add_error(TypeCheckError::CouldNotFindType(name,
-								    self.get_all_named_types(), pos));
+			checking_data.diagnostics_container.add_error(TypeCheckError::CouldNotFindType(
+				name,
+				self.get_all_named_types(),
+				pos,
+			));
 
 			TypeId::ERROR_TYPE
 		}

--- a/checker/src/context/mod.rs
+++ b/checker/src/context/mod.rs
@@ -460,19 +460,21 @@ impl<T: ContextType> Context<T> {
 		self.parents_iter().find_map(|env| get_on_ctx!(env.named_types.get(name))).copied()
 	}
 
+    #[allow(clippy::map_flatten)]
     pub fn get_all_variable_names(&self) -> Vec<&str> {
 	    self.parents_iter()
 		.map(|env| get_on_ctx!(env.variables.keys()).collect::<Vec<&String>>())
 		.flatten()
-		.map(|x| x.as_str())
+		.map(AsRef::as_ref)
 		.collect::<Vec<&str>>()
-	}
+    }
 
+    #[allow(clippy::map_flatten)]
     pub fn get_all_named_types(&self) -> Vec<&str> {
 	    self.parents_iter()
 		.map(|env| get_on_ctx!(env.named_types.keys()).collect::<Vec<&String>>())
 		.flatten()
-		.map(|x| x.as_str())
+		.map(AsRef::as_ref)
 		.collect::<Vec<&str>>()
 	}
 

--- a/checker/src/context/mod.rs
+++ b/checker/src/context/mod.rs
@@ -474,7 +474,17 @@ impl<T: ContextType> Context<T> {
 		.flatten()
 		.map(|x| x.as_str())
 		.collect::<Vec<&str>>()
-	}
+    }
+
+    pub fn get_all_imports(&self) -> Vec<&str> {
+	    self.parents_iter()
+	    .map(|env| get_on_ctx!(env.variables.iter()))
+	    .flatten()
+	    .filter(|(_,variable)| matches!(variable, VariableOrImport::ConstantImport{..} | VariableOrImport::MutableImport{..}))
+	    .map(|(name, _)| name.as_str())
+	    .collect::<Vec<&str>>()
+    }
+
 
 	pub(crate) fn get_variable_name(&self, id: VariableId) -> &str {
 		match self.parents_iter().find_map(|env| get_on_ctx!(env.variable_names.get(&id))) {

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -429,7 +429,11 @@ pub(crate) enum TypeCheckError<'a> {
 }
 
 pub fn get_possibles_message<'a, 'b>(possibles: Vec<&'a str>, reference: &'b str) -> String {
-    match get_closest(possibles.into_iter(), reference).unwrap_or(vec![]).as_slice() {
+    
+    let mut binding = get_closest(possibles.into_iter(), reference).unwrap_or(vec![]);
+    let candidates: &mut [&str] = binding.as_mut_slice();
+    candidates.sort();
+    match candidates {
         [] => return format!(""),
 	[a] => return format!("Did you mean {a}?"),
         [a,b] => return format!("Did you mean {a} or {b}?"),

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -9,6 +9,7 @@ use crate::{
 		calling::FunctionCallingError, printing::print_type_with_type_arguments, GenericChain,
 		GenericChainLink,
 	},
+    get_closest
 };
 use source_map::{SourceId, SpanWithSource};
 use std::{
@@ -423,6 +424,15 @@ pub(crate) enum TypeCheckError<'a> {
 		base: TypeStringRepresentation,
 		overload: TypeStringRepresentation,
 	},
+}
+
+pub fn get_possibles_message<'a, 'b>(possibles: Vec<&'a str>, reference: &'b str) -> String {
+    match get_closest(possibles.into_iter(), reference).unwrap_or(vec![]).as_slice() {
+        [] => return format!(""),
+        [a,b] => return format!("Did you mean {a} or {b}?"),
+        [a,b,c] => return format!("Did you mean {a},{b} or {c}?"),
+        [a @ .., b] => return format!("Did you mean {items} or {b}?", items = a.join(", "))
+    };
 }
 
 impl From<TypeCheckError<'_>> for Diagnostic {

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -429,6 +429,7 @@ pub(crate) enum TypeCheckError<'a> {
 }
 
 pub fn get_possibles_message<'a, 'b>(possibles: Vec<&'a str>, reference: &'b str) -> String {
+    println!("{:?}{:?}",possibles, reference);
     match get_closest(possibles.into_iter(), reference).unwrap_or(vec![]).as_slice() {
         [] => return format!(""),
 	[a] => return format!("Did you mean {a}?"),

--- a/checker/src/features/modules.rs
+++ b/checker/src/features/modules.rs
@@ -130,7 +130,9 @@ pub fn import_items<
 		checking_data.diagnostics_container.add_error(
 			crate::diagnostics::TypeCheckError::CannotOpenFile {
 				file: err.clone(),
-				import_position: Some(import_position.with_source(environment.get_source())),
+			    import_position: Some(import_position.with_source(environment.get_source())),
+			    possibles: checking_data.modules.files.get_paths().keys().filter(|path| path.to_str().is_some()).map(|path| path.to_str().unwrap()).collect(),
+			    partial_import_path
 			},
 		);
 	}

--- a/checker/src/features/modules.rs
+++ b/checker/src/features/modules.rs
@@ -130,10 +130,15 @@ pub fn import_items<
 		checking_data.diagnostics_container.add_error(
 			crate::diagnostics::TypeCheckError::CannotOpenFile {
 				file: err.clone(),
-			    import_position: Some(import_position.with_source(environment.get_source())),
-			    possibles: checking_data.modules.files.get_paths().keys()
-				.filter_map(|path| path.to_str()).collect(),
-			    partial_import_path
+				import_position: Some(import_position.with_source(environment.get_source())),
+				possibles: checking_data
+					.modules
+					.files
+					.get_paths()
+					.keys()
+					.filter_map(|path| path.to_str())
+					.collect(),
+				partial_import_path,
 			},
 		);
 	}

--- a/checker/src/features/modules.rs
+++ b/checker/src/features/modules.rs
@@ -131,7 +131,8 @@ pub fn import_items<
 			crate::diagnostics::TypeCheckError::CannotOpenFile {
 				file: err.clone(),
 			    import_position: Some(import_position.with_source(environment.get_source())),
-			    possibles: checking_data.modules.files.get_paths().keys().filter(|path| path.to_str().is_some()).map(|path| path.to_str().unwrap()).collect(),
+			    possibles: checking_data.modules.files.get_paths().keys()
+				.filter_map(|path| path.to_str()).collect(),
 			    partial_import_path
 			},
 		);

--- a/checker/src/features/variables.rs
+++ b/checker/src/features/variables.rs
@@ -8,7 +8,7 @@ use crate::subtyping::{type_is_subtype_object, SubTypeResult};
 use crate::{
 	types::{
 		printing::print_type,
-		properties::{get_property_unbound, PropertyKey, Publicity},
+		properties::{get_property_unbound, get_property_key_names_on_a_single_type, PropertyKey, Publicity},
 		TypeId,
 	},
 	CheckingData, VariableId,
@@ -167,7 +167,8 @@ pub fn get_new_register_argument_under<T: crate::ReadFromFS, A: crate::ASTImplem
 					&checking_data.types,
 					false,
 				),
-				site: position,
+			    site: position,
+			    possibles: get_property_key_names_on_a_single_type(space, &mut checking_data.types, environment).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
 			});
 			TypeId::ERROR_TYPE
 		}

--- a/checker/src/features/variables.rs
+++ b/checker/src/features/variables.rs
@@ -8,7 +8,9 @@ use crate::subtyping::{type_is_subtype_object, SubTypeResult};
 use crate::{
 	types::{
 		printing::print_type,
-		properties::{get_property_unbound, get_property_key_names_on_a_single_type, PropertyKey, Publicity},
+		properties::{
+			get_property_key_names_on_a_single_type, get_property_unbound, PropertyKey, Publicity,
+		},
 		TypeId,
 	},
 	CheckingData, VariableId,
@@ -167,8 +169,15 @@ pub fn get_new_register_argument_under<T: crate::ReadFromFS, A: crate::ASTImplem
 					&checking_data.types,
 					false,
 				),
-			    site: position,
-			    possibles: get_property_key_names_on_a_single_type(space, &mut checking_data.types, environment).iter().map(AsRef::as_ref).collect::<Vec<&str>>()
+				site: position,
+				possibles: get_property_key_names_on_a_single_type(
+					space,
+					&mut checking_data.types,
+					environment,
+				)
+				.iter()
+				.map(AsRef::as_ref)
+				.collect::<Vec<&str>>(),
 			});
 			TypeId::ERROR_TYPE
 		}

--- a/checker/src/features/variables.rs
+++ b/checker/src/features/variables.rs
@@ -168,7 +168,7 @@ pub fn get_new_register_argument_under<T: crate::ReadFromFS, A: crate::ASTImplem
 					false,
 				),
 			    site: position,
-			    possibles: get_property_key_names_on_a_single_type(space, &mut checking_data.types, environment).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
+			    possibles: get_property_key_names_on_a_single_type(space, &mut checking_data.types, environment).iter().map(AsRef::as_ref).collect::<Vec<&str>>()
 			});
 			TypeId::ERROR_TYPE
 		}

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -528,7 +528,8 @@ pub fn check_project<T: crate::ReadFromFS, A: crate::ASTImplementation>(
 			checking_data.diagnostics_container.add_error(TypeCheckError::CannotOpenFile {
 				file: CouldNotOpenFile(point.clone()),
 			    import_position: None,
-			    possibles: checking_data.modules.files.get_paths().keys().filter(|path| path.to_str().is_some()).map(|path| path.to_str().unwrap()).collect(),
+			    possibles: checking_data.modules.files.get_paths().keys()
+				.filter_map(|path| path.to_str()).collect(),
 			    partial_import_path: point.to_str().unwrap_or("")
 			});
 			continue;
@@ -814,8 +815,8 @@ pub fn get_closest<'a, 'b>(items: impl Iterator<Item=&'a str>, closest_one: &'b 
     const MIN_DISTANCE: usize = 2;
     let candidates = items.filter(|item| levenshtein(closest_one, item) <= MIN_DISTANCE).collect::<Vec<&str>>();
     match candidates.len() {
-	0 => return None,
-	1.. => return Some(candidates)
+	0 => None,
+	1.. => Some(candidates)
     }
 
 }

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -69,6 +69,8 @@ pub use source_map::{self, SourceId, Span};
 
 use crate::subtyping::State;
 
+use levenshtein::levenshtein;
+
 pub trait ASTImplementation: Sized {
 	type ParseOptions;
 	/// Custom allocator etc
@@ -803,4 +805,15 @@ impl<K, V> std::iter::Extend<(K, V)> for Map<K, V> {
 	fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
 		self.0.extend(iter);
 	}
+}
+
+pub fn get_closest<'a, 'b>(items: impl Iterator<Item=&'a str>, closest_one: &'b str) -> Option<Vec<&'a str>>
+{
+    const MIN_DISTANCE: usize = 2;
+    let candidates = items.filter(|item| levenshtein(closest_one, item) <= MIN_DISTANCE).collect::<Vec<&str>>();
+    match candidates.len() {
+	0 => return None,
+	1.. => return Some(candidates)
+    }
+
 }

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -527,7 +527,9 @@ pub fn check_project<T: crate::ReadFromFS, A: crate::ASTImplementation>(
 		} else {
 			checking_data.diagnostics_container.add_error(TypeCheckError::CannotOpenFile {
 				file: CouldNotOpenFile(point.clone()),
-				import_position: None,
+			    import_position: None,
+			    possibles: checking_data.modules.files.get_paths().keys().filter(|path| path.to_str().is_some()).map(|path| path.to_str().unwrap()).collect(),
+			    partial_import_path: point.to_str().unwrap_or("")
 			});
 			continue;
 		}

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -527,10 +527,15 @@ pub fn check_project<T: crate::ReadFromFS, A: crate::ASTImplementation>(
 		} else {
 			checking_data.diagnostics_container.add_error(TypeCheckError::CannotOpenFile {
 				file: CouldNotOpenFile(point.clone()),
-			    import_position: None,
-			    possibles: checking_data.modules.files.get_paths().keys()
-				.filter_map(|path| path.to_str()).collect(),
-			    partial_import_path: point.to_str().unwrap_or("")
+				import_position: None,
+				possibles: checking_data
+					.modules
+					.files
+					.get_paths()
+					.keys()
+					.filter_map(|path| path.to_str())
+					.collect(),
+				partial_import_path: point.to_str().unwrap_or(""),
 			});
 			continue;
 		}
@@ -810,13 +815,15 @@ impl<K, V> std::iter::Extend<(K, V)> for Map<K, V> {
 	}
 }
 
-pub fn get_closest<'a, 'b>(items: impl Iterator<Item=&'a str>, closest_one: &'b str) -> Option<Vec<&'a str>>
-{
-    const MIN_DISTANCE: usize = 2;
-    let candidates = items.filter(|item| levenshtein(closest_one, item) <= MIN_DISTANCE).collect::<Vec<&str>>();
-    match candidates.len() {
-	0 => None,
-	1.. => Some(candidates)
-    }
-
+pub fn get_closest<'a, 'b>(
+	items: impl Iterator<Item = &'a str>,
+	closest_one: &'b str,
+) -> Option<Vec<&'a str>> {
+	const MIN_DISTANCE: usize = 2;
+	let candidates =
+		items.filter(|item| levenshtein(closest_one, item) <= MIN_DISTANCE).collect::<Vec<&str>>();
+	match candidates.len() {
+		0 => None,
+		1.. => Some(candidates),
+	}
 }

--- a/checker/src/synthesis/type_annotations.rs
+++ b/checker/src/synthesis/type_annotations.rs
@@ -99,7 +99,8 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 					}
 				} else {
 					checking_data.diagnostics_container.add_error(TypeCheckError::CannotFindType(
-						name,
+					    name,
+					    environment.get_all_named_types(),
 						pos.with_source(environment.get_source()),
 					));
 					TypeId::ERROR_TYPE
@@ -165,7 +166,8 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 
 			let Some(inner_type_id) = environment.get_type_from_name(name) else {
 				checking_data.diagnostics_container.add_error(TypeCheckError::CouldNotFindType(
-					name,
+				    name,
+				    environment.get_all_named_types(),
 					position.with_source(environment.get_source()),
 				));
 				return TypeId::ERROR_TYPE;

--- a/checker/src/synthesis/type_annotations.rs
+++ b/checker/src/synthesis/type_annotations.rs
@@ -99,8 +99,8 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 					}
 				} else {
 					checking_data.diagnostics_container.add_error(TypeCheckError::CannotFindType(
-					    name,
-					    environment.get_all_named_types(),
+						name,
+						environment.get_all_named_types(),
 						pos.with_source(environment.get_source()),
 					));
 					TypeId::ERROR_TYPE
@@ -166,8 +166,8 @@ pub(super) fn synthesise_type_annotation<T: crate::ReadFromFS>(
 
 			let Some(inner_type_id) = environment.get_type_from_name(name) else {
 				checking_data.diagnostics_container.add_error(TypeCheckError::CouldNotFindType(
-				    name,
-				    environment.get_all_named_types(),
+					name,
+					environment.get_all_named_types(),
 					position.with_source(environment.get_source()),
 				));
 				return TypeId::ERROR_TYPE;

--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -346,7 +346,8 @@ fn assign_initial_to_fields<T: crate::ReadFromFS>(
 												false,
 											),
 										    site: position,
-										    possibles: get_property_key_names_on_a_single_type(value, &mut checking_data.types, environment).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
+										    possibles: get_property_key_names_on_a_single_type(value, &mut checking_data.types, environment)
+											.iter().map(AsRef::as_ref).collect::<Vec<&str>>()
 										},
 									);
 
@@ -420,7 +421,8 @@ fn assign_initial_to_fields<T: crate::ReadFromFS>(
 												false,
 											),
 										    site: position.with_source(environment.get_source()),
-										    possibles: get_property_key_names_on_a_single_type(value, &mut checking_data.types, environment).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
+										    possibles: get_property_key_names_on_a_single_type(value, &mut checking_data.types, environment).iter()
+											.map(AsRef::as_ref).collect::<Vec<&str>>()
 										},
 									);
 

--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -13,7 +13,7 @@ use crate::{
 	synthesis::parser_property_key_to_checker_property_key,
 	types::{
 		printing,
-		properties::{PropertyKey, Publicity},
+		properties::{PropertyKey, Publicity, get_property_key_names_on_a_single_type},
 	},
 	CheckingData, Environment, TypeId,
 };
@@ -345,7 +345,8 @@ fn assign_initial_to_fields<T: crate::ReadFromFS>(
 												&checking_data.types,
 												false,
 											),
-											site: position,
+										    site: position,
+										    possibles: get_property_key_names_on_a_single_type(value, &mut checking_data.types, environment).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
 										},
 									);
 
@@ -418,7 +419,8 @@ fn assign_initial_to_fields<T: crate::ReadFromFS>(
 												&checking_data.types,
 												false,
 											),
-											site: position.with_source(environment.get_source()),
+										    site: position.with_source(environment.get_source()),
+										    possibles: get_property_key_names_on_a_single_type(value, &mut checking_data.types, environment).iter().map(|prop| prop.as_str()).collect::<Vec<&str>>()
 										},
 									);
 

--- a/checker/src/synthesis/variables.rs
+++ b/checker/src/synthesis/variables.rs
@@ -13,7 +13,7 @@ use crate::{
 	synthesis::parser_property_key_to_checker_property_key,
 	types::{
 		printing,
-		properties::{PropertyKey, Publicity, get_property_key_names_on_a_single_type},
+		properties::{get_property_key_names_on_a_single_type, PropertyKey, Publicity},
 	},
 	CheckingData, Environment, TypeId,
 };
@@ -345,9 +345,15 @@ fn assign_initial_to_fields<T: crate::ReadFromFS>(
 												&checking_data.types,
 												false,
 											),
-										    site: position,
-										    possibles: get_property_key_names_on_a_single_type(value, &mut checking_data.types, environment)
-											.iter().map(AsRef::as_ref).collect::<Vec<&str>>()
+											site: position,
+											possibles: get_property_key_names_on_a_single_type(
+												value,
+												&mut checking_data.types,
+												environment,
+											)
+											.iter()
+											.map(AsRef::as_ref)
+											.collect::<Vec<&str>>(),
 										},
 									);
 
@@ -420,9 +426,15 @@ fn assign_initial_to_fields<T: crate::ReadFromFS>(
 												&checking_data.types,
 												false,
 											),
-										    site: position.with_source(environment.get_source()),
-										    possibles: get_property_key_names_on_a_single_type(value, &mut checking_data.types, environment).iter()
-											.map(AsRef::as_ref).collect::<Vec<&str>>()
+											site: position.with_source(environment.get_source()),
+											possibles: get_property_key_names_on_a_single_type(
+												value,
+												&mut checking_data.types,
+												environment,
+											)
+											.iter()
+											.map(AsRef::as_ref)
+											.collect::<Vec<&str>>(),
 										},
 									);
 

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -1581,11 +1581,35 @@ pub fn get_property_as_string(property: &PropertyKey, types: &mut TypeStore, env
     }
 }
 
+pub fn special_type(base: TypeId, types: &mut TypeStore,) -> bool {
+    
+    match types.get_type_by_id(base) {
+	Type::SpecialObject(_)
+		| Type::Constructor(_)
+		| Type::RootPolyType(_)
+		| Type::Or(..)
+		| Type::PartiallyAppliedGenerics(_)
+		| Type::Constant(_)
+		| Type::AliasTo { .. }
+		| Type::FunctionReference(_)
+	     | Type::And(_, _) => return true,
+	
+	_ => return false
+	
+        
+    }
+
+}
+
 pub fn get_property_key_names_on_a_single_type<'a>(
 	base: TypeId,
 	types: &mut TypeStore,
     environment: &mut Environment
 ) -> Vec<String> {
+
+    if special_type(base, types){
+	return vec![];
+    }
     
     get_properties_on_single_type(base, types, environment).into_iter().map(|property| {
 	get_property_as_string(&property.1, types, environment)

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -5,7 +5,7 @@ use crate::{
 		information::InformationChain, CallCheckingBehavior, Logical, PossibleLogical,
 		SetPropertyError,
 	},
-    diagnostics::TypeStringRepresentation,
+	diagnostics::TypeStringRepresentation,
 	events::Event,
 	features::{
 		functions::{FunctionBehavior, ThisValue},
@@ -15,8 +15,8 @@ use crate::{
 	types::{
 		calling::{self, FunctionCallingError},
 		generics::generic_type_arguments::GenericArguments,
-		get_constraint, get_larger_type, substitute, FunctionType, GenericChain, GenericChainLink, printing,
-		ObjectNature, PartiallyAppliedGenerics, PolyNature, SynthesisedArgument,
+		get_constraint, get_larger_type, printing, substitute, FunctionType, GenericChain,
+		GenericChainLink, ObjectNature, PartiallyAppliedGenerics, PolyNature, SynthesisedArgument,
 	},
 	Constant, Environment, LocalInformation, TypeId,
 };
@@ -839,11 +839,21 @@ pub(crate) fn set_property<E: CallCheckingBehavior>(
 		);
 	}
 
-	if let Ok(fact) = current_property { match fact {
-		Logical::Pure(og) => { let result =
-		run_setter_on_object( og, behavior, environment, on,
-		publicity, under, new, types, setter_position, ); if
-		let Err(result) = result {
+	if let Ok(fact) = current_property {
+		match fact {
+			Logical::Pure(og) => {
+				let result = run_setter_on_object(
+					og,
+					behavior,
+					environment,
+					on,
+					publicity,
+					under,
+					new,
+					types,
+					setter_position,
+				);
+				if let Err(result) = result {
 					// TODO temp
 					for error in result {
 						match error {
@@ -1567,51 +1577,43 @@ pub fn get_properties_on_single_type(
 	}
 }
 
-
-pub fn get_property_as_string(property: &PropertyKey, types: &mut TypeStore, environment: &mut Environment) -> String {
-
-    match property {
-	PropertyKey::String(s) => s.to_string(),
-	PropertyKey::Type(t) => printing::print_type(
-	    *t,
-	    types,
-	    environment,
-	    false,
-	),
-    }
+pub fn get_property_as_string(
+	property: &PropertyKey,
+	types: &mut TypeStore,
+	environment: &mut Environment,
+) -> String {
+	match property {
+		PropertyKey::String(s) => s.to_string(),
+		PropertyKey::Type(t) => printing::print_type(*t, types, environment, false),
+	}
 }
 
 pub fn special_type(base: TypeId, types: &mut TypeStore) -> bool {
-    
-    matches!(types.get_type_by_id(base), 
-	Type::SpecialObject(_)
-		| Type::Constructor(_)
-		| Type::RootPolyType(_)
-		| Type::Or(..)
-		| Type::PartiallyAppliedGenerics(_)
-		| Type::Constant(_)
-		| Type::AliasTo { .. }
-		| Type::FunctionReference(_)
-	     | Type::And(_, _))
-	
-	
-        
-    
-
+	matches!(
+		types.get_type_by_id(base),
+		Type::SpecialObject(_)
+			| Type::Constructor(_)
+			| Type::RootPolyType(_)
+			| Type::Or(..)
+			| Type::PartiallyAppliedGenerics(_)
+			| Type::Constant(_)
+			| Type::AliasTo { .. }
+			| Type::FunctionReference(_)
+			| Type::And(_, _)
+	)
 }
 
 pub fn get_property_key_names_on_a_single_type(
 	base: TypeId,
 	types: &mut TypeStore,
-    environment: &mut Environment
+	environment: &mut Environment,
 ) -> Vec<String> {
+	if special_type(base, types) {
+		return vec![];
+	}
 
-    if special_type(base, types){
-	return vec![];
-    }
-    
-    get_properties_on_single_type(base, types, environment).into_iter().map(|property| {
-	get_property_as_string(&property.1, types, environment)
-    }
-    ).collect()
+	get_properties_on_single_type(base, types, environment)
+		.into_iter()
+		.map(|property| get_property_as_string(&property.1, types, environment))
+		.collect()
 }

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -1584,11 +1584,10 @@ pub fn get_property_as_string(property: &PropertyKey, types: &mut TypeStore, env
 pub fn get_property_key_names_on_a_single_type<'a>(
 	base: TypeId,
 	types: &mut TypeStore,
-    info: &impl InformationChain,
     environment: &mut Environment
 ) -> Vec<String> {
     
-    get_properties_on_single_type(base, types, info).into_iter().map(|property| {
+    get_properties_on_single_type(base, types, environment).into_iter().map(|property| {
 	get_property_as_string(&property.1, types, environment)
     }
     ).collect()

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -5,7 +5,7 @@ use crate::{
 		information::InformationChain, CallCheckingBehavior, Logical, PossibleLogical,
 		SetPropertyError,
 	},
-	diagnostics::TypeStringRepresentation,
+    diagnostics::TypeStringRepresentation,
 	events::Event,
 	features::{
 		functions::{FunctionBehavior, ThisValue},
@@ -15,7 +15,7 @@ use crate::{
 	types::{
 		calling::{self, FunctionCallingError},
 		generics::generic_type_arguments::GenericArguments,
-		get_constraint, get_larger_type, substitute, FunctionType, GenericChain, GenericChainLink,
+		get_constraint, get_larger_type, substitute, FunctionType, GenericChain, GenericChainLink, printing,
 		ObjectNature, PartiallyAppliedGenerics, PolyNature, SynthesisedArgument,
 	},
 	Constant, Environment, LocalInformation, TypeId,
@@ -839,21 +839,11 @@ pub(crate) fn set_property<E: CallCheckingBehavior>(
 		);
 	}
 
-	if let Ok(fact) = current_property {
-		match fact {
-			Logical::Pure(og) => {
-				let result = run_setter_on_object(
-					og,
-					behavior,
-					environment,
-					on,
-					publicity,
-					under,
-					new,
-					types,
-					setter_position,
-				);
-				if let Err(result) = result {
+	if let Ok(fact) = current_property { match fact {
+		Logical::Pure(og) => { let result =
+		run_setter_on_object( og, behavior, environment, on,
+		publicity, under, new, types, setter_position, ); if
+		let Err(result) = result {
 					// TODO temp
 					for error in result {
 						match error {
@@ -1575,4 +1565,31 @@ pub fn get_properties_on_single_type(
 		| Type::FunctionReference(_)
 		| Type::And(_, _)) => panic!("Cannot get all properties on {t:?}"),
 	}
+}
+
+
+pub fn get_property_as_string(property: &PropertyKey, types: &mut TypeStore, environment: &mut Environment) -> String {
+
+    match property {
+	PropertyKey::String(s) => return s.to_string(),
+	PropertyKey::Type(t) => return printing::print_type(
+	    *t,
+	    types,
+	    environment,
+	    false,
+	),
+    }
+}
+
+pub fn get_property_key_names_on_a_single_type<'a>(
+	base: TypeId,
+	types: &mut TypeStore,
+    info: &impl InformationChain,
+    environment: &mut Environment
+) -> Vec<String> {
+    
+    get_properties_on_single_type(base, types, info).into_iter().map(|property| {
+	get_property_as_string(&property.1, types, environment)
+    }
+    ).collect()
 }

--- a/checker/src/types/properties.rs
+++ b/checker/src/types/properties.rs
@@ -1571,8 +1571,8 @@ pub fn get_properties_on_single_type(
 pub fn get_property_as_string(property: &PropertyKey, types: &mut TypeStore, environment: &mut Environment) -> String {
 
     match property {
-	PropertyKey::String(s) => return s.to_string(),
-	PropertyKey::Type(t) => return printing::print_type(
+	PropertyKey::String(s) => s.to_string(),
+	PropertyKey::Type(t) => printing::print_type(
 	    *t,
 	    types,
 	    environment,
@@ -1581,9 +1581,9 @@ pub fn get_property_as_string(property: &PropertyKey, types: &mut TypeStore, env
     }
 }
 
-pub fn special_type(base: TypeId, types: &mut TypeStore,) -> bool {
+pub fn special_type(base: TypeId, types: &mut TypeStore) -> bool {
     
-    match types.get_type_by_id(base) {
+    matches!(types.get_type_by_id(base), 
 	Type::SpecialObject(_)
 		| Type::Constructor(_)
 		| Type::RootPolyType(_)
@@ -1592,16 +1592,15 @@ pub fn special_type(base: TypeId, types: &mut TypeStore,) -> bool {
 		| Type::Constant(_)
 		| Type::AliasTo { .. }
 		| Type::FunctionReference(_)
-	     | Type::And(_, _) => return true,
+	     | Type::And(_, _))
 	
-	_ => return false
 	
         
-    }
+    
 
 }
 
-pub fn get_property_key_names_on_a_single_type<'a>(
+pub fn get_property_key_names_on_a_single_type(
 	base: TypeId,
 	types: &mut TypeStore,
     environment: &mut Environment

--- a/checker/tests/partial_source.rs
+++ b/checker/tests/partial_source.rs
@@ -31,5 +31,8 @@ fn type_mappings() {
 
 	let diagnostics: Vec<_> = result.diagnostics.into_iter().collect();
 	assert_eq!(diagnostics.len(), 1);
-	assert_eq!(diagnostics.first().unwrap().reason(), "Could not find variable 'b' in scope. Did you mean x, y or z?");
+	assert_eq!(
+		diagnostics.first().unwrap().reason(),
+		"Could not find variable 'b' in scope. Did you mean x, y or z?"
+	);
 }

--- a/checker/tests/partial_source.rs
+++ b/checker/tests/partial_source.rs
@@ -31,5 +31,5 @@ fn type_mappings() {
 
 	let diagnostics: Vec<_> = result.diagnostics.into_iter().collect();
 	assert_eq!(diagnostics.len(), 1);
-	assert_eq!(diagnostics.first().unwrap().reason(), "Could not find variable 'b' in scope");
+	assert_eq!(diagnostics.first().unwrap().reason(), "Could not find variable 'b' in scope. Did you mean x, y or z");
 }

--- a/checker/tests/partial_source.rs
+++ b/checker/tests/partial_source.rs
@@ -31,5 +31,5 @@ fn type_mappings() {
 
 	let diagnostics: Vec<_> = result.diagnostics.into_iter().collect();
 	assert_eq!(diagnostics.len(), 1);
-	assert_eq!(diagnostics.first().unwrap().reason(), "Could not find variable 'b' in scope. Did you mean x, y or z");
+	assert_eq!(diagnostics.first().unwrap().reason(), "Could not find variable 'b' in scope. Did you mean x, y or z?");
 }


### PR DESCRIPTION
For #166. A get_closest function was added using the levenshtein crate. This function is used to create a list of possible variables, types, properties and imports when a cannot find reference error is raised.  The specification tests have been updated to reflect the new error message. I would like to note that in the code, there are currently two functions that can be used to raise a cannot find reference error for properties: PropertyDoesNotExist and ExcessProperty. My pull request only makes changes to the PropertyDoesNotExist. ExcessProperty would need lifetime annotations for a "possibles" variables, which would have required a bigger revision of the TypeCheckWarning enum. 