### PR TITLE
Add "duplicate import name" and "missing default export" diagnostics

### DIFF
--- a/checker/specification/specification.md
+++ b/checker/specification/specification.md
@@ -4106,14 +4106,15 @@ export const a = 2;
 #### Import where export does not exist
 
 ```ts
-import { a } from "./export";
+import b, { a } from "./export";
 
 console.log(a.prop);
 
 // in export.ts
-export const b = 2;
+export const c = 2;
 ```
 
+- Cannot find default export from module './export'
 - a not exported from ./export
 
 #### Import from invalid file

--- a/checker/specification/specification.md
+++ b/checker/specification/specification.md
@@ -4117,6 +4117,24 @@ export const c = 2;
 - Cannot find default export from module './export'
 - a not exported from ./export
 
+#### Import conflicts with existing name
+
+```ts
+import { x } from "./export1";
+import x, { z } from "./export2";
+
+// in export1.ts
+export const x = 1;
+
+// in export2.ts
+const y = 2;
+
+export default y;
+export const z = 2;
+```
+
+- Cannot import using conflicting name
+
 #### Import from invalid file
 
 ```ts

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -387,6 +387,10 @@ pub(crate) enum TypeCheckError<'a> {
 	},
 	#[allow(dead_code)]
 	NotTopLevelImport(SpanWithSource),
+	DuplicateImportName {
+		import_position: SpanWithSource,
+		existing_position: SpanWithSource,
+	},
 	#[allow(dead_code)]
 	DoubleDefaultExport(SpanWithSource),
 	CannotOpenFile {
@@ -673,6 +677,12 @@ impl From<TypeCheckError<'_>> for Diagnostic {
 				reason: "Import must be in the top of the scope".to_owned(),
 				position,
 				kind,
+			},
+			TypeCheckError::DuplicateImportName { import_position: position, existing_position, ..} => Diagnostic::PositionWithAdditionalLabels {
+				reason: "Cannot import using conflicting name".to_string(),
+				position,
+				kind,
+				labels: vec![("Existing import with same name".to_string(), existing_position)],
 			},
 			TypeCheckError::DoubleDefaultExport(_) => todo!(),
 			TypeCheckError::CannotOpenFile { file, import_position, possibles, partial_import_path } => if let Some(import_position) = import_position {

--- a/checker/src/diagnostics.rs
+++ b/checker/src/diagnostics.rs
@@ -393,6 +393,10 @@ pub(crate) enum TypeCheckError<'a> {
 	},
 	#[allow(dead_code)]
 	DoubleDefaultExport(SpanWithSource),
+	NoDefaultExport {
+		position: SpanWithSource,
+		partial_import_path: &'a str,
+	},
 	CannotOpenFile {
 		file: CouldNotOpenFile,
 		import_position: Option<SpanWithSource>,
@@ -685,6 +689,11 @@ impl From<TypeCheckError<'_>> for Diagnostic {
 				labels: vec![("Existing import with same name".to_string(), existing_position)],
 			},
 			TypeCheckError::DoubleDefaultExport(_) => todo!(),
+			TypeCheckError::NoDefaultExport { partial_import_path, position, ..} => Diagnostic::Position {
+				reason: format!("Cannot find default export from module '{partial_import_path}'"),
+				position,
+				kind
+			},
 			TypeCheckError::CannotOpenFile { file, import_position, possibles, partial_import_path } => if let Some(import_position) = import_position {
 				Diagnostic::PositionWithAdditionalLabels {
 					reason: format!("Cannot find {partial_import_path}"),

--- a/checker/src/features/modules.rs
+++ b/checker/src/features/modules.rs
@@ -157,7 +157,20 @@ pub fn import_items<
 				environment.info.variable_current_value.insert(id, *item);
 				let existing = environment.variables.insert(default_name.to_owned(), v);
 				if let Some(_existing) = existing {
-					todo!("diagnostic")
+					checking_data.diagnostics_container.add_error(
+						crate::diagnostics::TypeCheckError::DuplicateImportName {
+							import_position: position.with_source(current_source),
+							existing_position: match _existing {
+								VariableOrImport::Variable { declared_at, .. } => declared_at,
+								VariableOrImport::MutableImport { import_specified_at, .. } => {
+									import_specified_at
+								}
+								VariableOrImport::ConstantImport {
+									import_specified_at, ..
+								} => import_specified_at,
+							},
+						},
+					);
 				}
 			} else {
 				todo!("emit 'no default export' diagnostic")
@@ -244,7 +257,26 @@ pub fn import_items<
 						crate::utilities::notify!("{:?}", part.r#as.to_owned());
 						let existing = environment.variables.insert(part.r#as.to_owned(), v);
 						if let Some(_existing) = existing {
-							todo!("diagnostic")
+							checking_data.diagnostics_container.add_error(
+								crate::diagnostics::TypeCheckError::DuplicateImportName {
+									import_position: part
+										.position
+										.with_source(environment.get_source()),
+									existing_position: match _existing {
+										VariableOrImport::Variable { declared_at, .. } => {
+											declared_at
+										}
+										VariableOrImport::MutableImport {
+											import_specified_at,
+											..
+										} => import_specified_at,
+										VariableOrImport::ConstantImport {
+											import_specified_at,
+											..
+										} => import_specified_at,
+									},
+								},
+							);
 						}
 						if also_export {
 							if let Scope::Module { ref mut exported, .. } =

--- a/checker/src/features/modules.rs
+++ b/checker/src/features/modules.rs
@@ -156,16 +156,14 @@ pub fn import_items<
 				};
 				environment.info.variable_current_value.insert(id, *item);
 				let existing = environment.variables.insert(default_name.to_owned(), v);
-				if let Some(_existing) = existing {
+				if let Some(existing) = existing {
 					checking_data.diagnostics_container.add_error(
 						crate::diagnostics::TypeCheckError::DuplicateImportName {
 							import_position: position.with_source(current_source),
-							existing_position: match _existing {
+							existing_position: match existing {
 								VariableOrImport::Variable { declared_at, .. } => declared_at,
-								VariableOrImport::MutableImport { import_specified_at, .. } => {
-									import_specified_at
-								}
-								VariableOrImport::ConstantImport {
+								VariableOrImport::MutableImport { import_specified_at, .. }
+								| VariableOrImport::ConstantImport {
 									import_specified_at, ..
 								} => import_specified_at,
 							},
@@ -261,21 +259,21 @@ pub fn import_items<
 						};
 						crate::utilities::notify!("{:?}", part.r#as.to_owned());
 						let existing = environment.variables.insert(part.r#as.to_owned(), v);
-						if let Some(_existing) = existing {
+						if let Some(existing) = existing {
 							checking_data.diagnostics_container.add_error(
 								crate::diagnostics::TypeCheckError::DuplicateImportName {
 									import_position: part
 										.position
 										.with_source(environment.get_source()),
-									existing_position: match _existing {
+									existing_position: match existing {
 										VariableOrImport::Variable { declared_at, .. } => {
 											declared_at
 										}
 										VariableOrImport::MutableImport {
 											import_specified_at,
 											..
-										} => import_specified_at,
-										VariableOrImport::ConstantImport {
+										}
+										| VariableOrImport::ConstantImport {
 											import_specified_at,
 											..
 										} => import_specified_at,

--- a/checker/src/features/modules.rs
+++ b/checker/src/features/modules.rs
@@ -173,7 +173,12 @@ pub fn import_items<
 					);
 				}
 			} else {
-				todo!("emit 'no default export' diagnostic")
+				checking_data.diagnostics_container.add_error(
+					crate::diagnostics::TypeCheckError::NoDefaultExport {
+						position: position.with_source(current_source),
+						partial_import_path,
+					},
+				);
 			}
 		} else {
 			environment.register_variable_handle_error(


### PR DESCRIPTION
addressing #182

### Changes

- Add `TypeCheckError::DuplicateImportName` for reporting diagnostics on importing using an already imported name
- Add `TypeCheckError::NoDefaultExport` for reporting diagnostics on missing, but expected default exports


### Examples

```ts
// test1.ts
import x from "./test2";
import y, { z } from "./test3";
```

```sh
$ cargo run check ../dump/test1.ts
error:
  ┌─ ../dump/test1.ts:1:8
  │
1 │ import x from "./test2";
  │        ^ Cannot find default export from module './test2'
```

---

```ts
// test1.ts
import { x } from "./test2";
import x, { z } from "./test3";
```

```sh
$ cargo run check ../dump/test1.ts
error:
  ┌─ ../dump/test1.ts:2:8
  │
1 │ import { x } from "./test2";
  │          - Existing import with same name
2 │ import x, { z } from "./test3";
  │        ^ Cannot import using conflicting name
```

---

```ts
// test1.ts
import { x as z } from "./test2";
import y, { z } from "./test3";
```

```sh
$ cargo run check ../dump/test1.ts
error:
  ┌─ ../dump/test1.ts:2:13
  │
1 │ import { x as z } from "./test2";
  │          ------ Existing import with same name
2 │ import y, { z } from "./test3";
  │             ^ Cannot import using conflicting name
```

### Appendix

<details>
<summary>test2.ts</summary>

```ts
const x: string = "x";

export { x };
```

</details>
<details>
<summary>test3.ts</summary>

```ts
const y: string = "y";

export default y;
export const z: string = "z";
```

</details>