### PR TITLE
Fix RegExp UTF-16 Matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,12 +474,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
- "ahash",
  "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -858,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1541daf4e4ed43a0922b7969bdc2170178bcacc5dabf7e39bc508a9fa3953a7a"
+checksum = "78ef7fa9ed0256d64a688a3747d0fef7a88851c18a5e1d57f115f38ec2e09366"
 dependencies = [
  "hashbrown",
  "memchr",
@@ -1178,12 +1179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,23 +1475,3 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]

--- a/checker/Cargo.toml
+++ b/checker/Cargo.toml
@@ -39,7 +39,7 @@ path-absolutize = { version = "3.0", features = ["use_unix_paths_on_wasm"] }
 either = "1.6"
 levenshtein = "1"
 ordered-float = "4.2"
-regress = { version = "0.10", features = [] }
+regress = { version = "0.10", features = ["utf16"] }
 
 serde = { version = "1.0", features = ["derive"], optional = true }
 simple-json-parser = "0.0.2"

--- a/checker/src/features/regexp.rs
+++ b/checker/src/features/regexp.rs
@@ -121,12 +121,16 @@ impl RegExp {
 			&mut environment.info,
 		);
 
-		match self.re.find(pattern) {
+		let pattern_utf16: Box<[u16]> = pattern.encode_utf16().collect();
+		let matches = self.re.find_from_utf16(&pattern_utf16, 0);
+
+		match matches.into_iter().next() {
 			Some(match_) => {
 				{
 					let index = types.new_constant_type(Constant::Number(
 						(match_.start() as f64).try_into().unwrap(),
 					));
+
 					object.append(
 						Publicity::Public,
 						PropertyKey::String("index".into()),
@@ -139,9 +143,9 @@ impl RegExp {
 				for (idx, group) in match_.groups().enumerate() {
 					let key = PropertyKey::from_usize(idx);
 					let value = match group {
-						Some(range) => {
-							types.new_constant_type(Constant::String(pattern[range].to_string()))
-						}
+						Some(range) => types.new_constant_type(Constant::String(
+							String::from_utf16(&pattern_utf16[range]).unwrap(),
+						)),
 						None => todo!(),
 					};
 
@@ -167,7 +171,7 @@ impl RegExp {
 							let key = PropertyKey::String(name.to_string().into());
 							let value = match group {
 								Some(range) => types.new_constant_type(Constant::String(
-									pattern[range].to_string(),
+									String::from_utf16(&pattern_utf16[range]).unwrap(),
 								)),
 								None => todo!(),
 							};


### PR DESCRIPTION
The crate used to evaluate regexp, [regress](https://github.com/ridiculousfish/regress), fixed the [utf-16 matching problems](https://github.com/kaleidawave/ezno/issues/184#issuecomment-2274383051) in their [0.10.3 release](https://github.com/ridiculousfish/regress/releases/tag/v0.10.3).

The `RegExp::exec` function now correctly matches using utf-16 instead of utf-8.

### Before (`main`):
![snapshot_2025-01-31_10-36-01](https://github.com/user-attachments/assets/b65ca61f-bfac-415f-8690-dd212eff3a1d)

### After (`regexp-utf16`):
![snapshot_2025-01-31_10-38-35](https://github.com/user-attachments/assets/18eb7654-67b8-45da-9e46-24d22aa84f24)

### Expected:
![snapshot_2025-01-31_10-45-05](https://github.com/user-attachments/assets/1df7ccea-f21a-4212-98a5-138cadd67d8f)
