### PR TITLE
Report TDZ writes to free variables

### DIFF
--- a/checker/specification/specification.md
+++ b/checker/specification/specification.md
@@ -1614,6 +1614,20 @@ let x: number = 5;
 
 > Not shown in the example but thanks to [#69](https://github.com/kaleidawave/ezno/pull/69) for adding the position of the error
 
+#### TDZ from free variable write (across function)
+
+```ts
+function setX() {
+	x = 1
+}
+
+setX();
+
+let x: number = 5;
+```
+
+- Variable 'x' used before declaration
+
 #### TDZ errors through nested getter
 
 ```ts

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -123,33 +123,34 @@ pub(crate) fn apply_events(
 					// TODO maybe needs to be returned back up, rather than set here?
 					top_environment.possibly_mutated_variables.insert(*variable);
 				} else {
-					if get_value_of_variable(
-						top_environment,
-						*variable,
-						Some(type_arguments),
-						types,
-					)
-					.is_none()
-					{
-						diagnostics.errors.push(
-							crate::types::calling::FunctionCallingError::VariableUsedInTDZ {
-								error: VariableUsedInTDZ {
-									variable_name: top_environment
-										.get_variable_name(*variable)
-										.to_owned(),
-									position: *position,
-								},
-								call_site: input.call_site,
-							},
-						);
-					}
-
 					let new_value = substitute(*value, type_arguments, top_environment, types);
 
 					// There is probably a way to speed this up. For example `Environment` could have a range?
 					// This also doesn't work around conditionals
 					let in_above_environment =
 						top_environment.variables.values().any(|var| var.get_id() == *variable);
+
+					if in_above_environment {
+						let current_value = get_value_of_variable(
+							top_environment,
+							*variable,
+							Some(type_arguments),
+							types,
+						);
+						if current_value.is_none() {
+							diagnostics.errors.push(
+								crate::types::calling::FunctionCallingError::VariableUsedInTDZ {
+									error: VariableUsedInTDZ {
+										variable_name: top_environment
+											.get_variable_name(*variable)
+											.to_owned(),
+										position: *position,
+									},
+									call_site: input.call_site,
+								},
+							);
+						}
+					}
 
 					// TODO temp assigns to many contexts, which is bad.
 					// Closures should have an indicator of what they close over #56

--- a/checker/src/events/application.rs
+++ b/checker/src/events/application.rs
@@ -123,6 +123,27 @@ pub(crate) fn apply_events(
 					// TODO maybe needs to be returned back up, rather than set here?
 					top_environment.possibly_mutated_variables.insert(*variable);
 				} else {
+					if get_value_of_variable(
+						top_environment,
+						*variable,
+						Some(type_arguments),
+						types,
+					)
+					.is_none()
+					{
+						diagnostics.errors.push(
+							crate::types::calling::FunctionCallingError::VariableUsedInTDZ {
+								error: VariableUsedInTDZ {
+									variable_name: top_environment
+										.get_variable_name(*variable)
+										.to_owned(),
+									position: *position,
+								},
+								call_site: input.call_site,
+							},
+						);
+					}
+
 					let new_value = substitute(*value, type_arguments, top_environment, types);
 
 					// There is probably a way to speed this up. For example `Environment` could have a range?


### PR DESCRIPTION
## Summary
- Report `VariableUsedInTDZ` when applying a `SetsVariable` event to a free variable whose current value is unavailable.
- Keep applying the write after recording the diagnostic, matching the existing read-side behavior that avoids cascading failures.
- Add the requested specification example next to the existing free-variable TDZ read case.

Fixes #239

## Validation
- `rustfmt +stable-x86_64-pc-windows-gnu --edition 2024 --check checker/src/events/application.rs`
- `cargo +stable-x86_64-pc-windows-gnu check --workspace`
- `cargo +stable-x86_64-pc-windows-gnu check --bin ezno`
- `cargo +stable-x86_64-pc-windows-gnu test -p ezno-checker`
- `cargo +stable-x86_64-pc-windows-gnu run -p ezno-checker --example run_checker ../tdz-write.ts --simple-diagnostics`
- `cargo +stable-x86_64-pc-windows-gnu run -p ezno-checker --example runner -- --interactive --rpc` for both TDZ-write and declared-before-write cases

Notes:
- I couldn't run the exact full `spectra test specification/specification.md ...` command locally because the `spectra` release asset referenced by CI was not available in `kaleidawave/experiments@assets`; the runner protocol used by spectra was validated directly for this case.
- `cargo clippy -p ezno-checker -- -A warnings` currently fails under Rust 1.96 on existing lints outside this change, such as `parser/src/lexer.rs` and a few checker files.
